### PR TITLE
Login page: sign in with username and password

### DIFF
--- a/api/cmd/uichiyomiserver/setup.go
+++ b/api/cmd/uichiyomiserver/setup.go
@@ -67,6 +67,7 @@ func setupApp(cfg *cfg) (*core.App, error) {
 		Logger:          logger,
 		SessionsService: services.Sessions,
 		SetupService:    services.Setup,
+		AuthService:     services.Auth,
 		AsuraApp:        apps.Asura,
 		Registry:        registry,
 	})

--- a/api/pkg/core/auth/domain.go
+++ b/api/pkg/core/auth/domain.go
@@ -11,8 +11,13 @@ import (
 )
 
 type AuthService interface {
-	LoginWithPwd(context.Context, LoginWithPwdOpts) (*sessions.IssuedSession, error)
+	LoginWithPwd(context.Context, LoginWithPwdOpts) (*LoginResult, error)
 	CreateUserWithPwd(context.Context, CreateUserWithPwdOpts) (*users.User, error)
+}
+
+type LoginResult struct {
+	Session *sessions.IssuedSession
+	User    *users.User
 }
 
 type CreateUserWithPwdOpts struct {

--- a/api/pkg/core/auth/gateway/http/controller.go
+++ b/api/pkg/core/auth/gateway/http/controller.go
@@ -101,7 +101,7 @@ func (c *Controller) loginWithPwd(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	session, err := c.deps.AuthService.LoginWithPwd(ctx, auth.LoginWithPwdOpts{
+	res, err := c.deps.AuthService.LoginWithPwd(ctx, auth.LoginWithPwdOpts{
 		Username: req.Username.String(),
 		Password: req.Password.String(),
 	})
@@ -118,7 +118,11 @@ func (c *Controller) loginWithPwd(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	c.deps.Cookies.Set(w, session.Token, session.ExpiresAt, c.deps.Now())
+	c.deps.Cookies.Set(w, res.Session.Token, res.Session.ExpiresAt, c.deps.Now())
 
-	w.WriteHeader(http.StatusOK)
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, LoginWithPwdResponse{
+		ID:       res.User.ID.String(),
+		Username: res.User.Name,
+		IsAdmin:  res.User.IsAdmin,
+	})
 }

--- a/api/pkg/core/auth/gateway/http/controller_test.go
+++ b/api/pkg/core/auth/gateway/http/controller_test.go
@@ -34,7 +34,7 @@ const (
 
 type stubAuthService struct {
 	err     error
-	session *sessions.IssuedSession
+	result  *auth.LoginResult
 	gotOpts auth.LoginWithPwdOpts
 	calls   int
 }
@@ -42,7 +42,7 @@ type stubAuthService struct {
 func (s *stubAuthService) LoginWithPwd(
 	_ context.Context,
 	opts auth.LoginWithPwdOpts,
-) (*sessions.IssuedSession, error) {
+) (*auth.LoginResult, error) {
 	s.calls++
 	s.gotOpts = opts
 
@@ -50,7 +50,7 @@ func (s *stubAuthService) LoginWithPwd(
 		return nil, s.err
 	}
 
-	return s.session, nil
+	return s.result, nil
 }
 
 func (s *stubAuthService) CreateUserWithPwd(context.Context, auth.CreateUserWithPwdOpts) (*users.User, error) {
@@ -68,8 +68,12 @@ func issuedSession() *sessions.IssuedSession {
 	}
 }
 
+func loggedInUser() *users.User {
+	return &users.User{ID: uuid.New(), Name: username, IsAdmin: true}
+}
+
 func loggedInStub() *stubAuthService {
-	return &stubAuthService{session: issuedSession()}
+	return &stubAuthService{result: &auth.LoginResult{Session: issuedSession(), User: loggedInUser()}}
 }
 
 func testLogger() (*slog.Logger, *bytes.Buffer) {
@@ -345,6 +349,30 @@ func TestLoginSetsSessionCookie(t *testing.T) {
 
 	if logs.Len() != 0 {
 		t.Errorf("aucun log attendu sur le chemin nominal: %s", logs.String())
+	}
+}
+
+func TestLoginReturnsTheAuthenticatedUser(t *testing.T) {
+	t.Parallel()
+
+	svc := loggedInStub()
+	r, _ := newTestRouter(t, svc)
+
+	rec := postLogin(t, r, loginBody(username, password))
+
+	var got authhttp.LoginWithPwdResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("json.Unmarshal(%s): %v", rec.Body.String(), err)
+	}
+
+	want := authhttp.LoginWithPwdResponse{
+		ID:       svc.result.User.ID.String(),
+		Username: username,
+		IsAdmin:  true,
+	}
+
+	if got != want {
+		t.Errorf("body = %+v, want %+v", got, want)
 	}
 }
 

--- a/api/pkg/core/auth/gateway/http/dto.go
+++ b/api/pkg/core/auth/gateway/http/dto.go
@@ -8,3 +8,9 @@ type LoginWithPwdRequest struct {
 	Username httputils.TrimmedString `json:"username" validate:"required"`
 	Password httputils.TrimmedString `json:"password" validate:"required"`
 }
+
+type LoginWithPwdResponse struct {
+	ID       string `json:"id"`
+	Username string `json:"username"`
+	IsAdmin  bool   `json:"isAdmin"`
+}

--- a/api/pkg/core/auth/service.go
+++ b/api/pkg/core/auth/service.go
@@ -92,7 +92,7 @@ func (s *Service) CreateUserWithPwd(ctx context.Context, opts CreateUserWithPwdO
 	return user, nil
 }
 
-func (s *Service) LoginWithPwd(ctx context.Context, opts LoginWithPwdOpts) (*sessions.IssuedSession, error) {
+func (s *Service) LoginWithPwd(ctx context.Context, opts LoginWithPwdOpts) (*LoginResult, error) {
 	user, err := s.deps.UsersRepository.GetByUsername(ctx, opts.Username)
 	if err != nil {
 		if errors.Is(err, domain.ErrNotFound) {
@@ -133,7 +133,7 @@ func (s *Service) LoginWithPwd(ctx context.Context, opts LoginWithPwdOpts) (*ses
 		return nil, fmt.Errorf("s.deps.SessionService.Create: %w", err)
 	}
 
-	return session, nil
+	return &LoginResult{Session: session, User: user}, nil
 }
 
 func (s *Service) equalizeLoginTiming(password string) {

--- a/api/pkg/core/auth/service_test.go
+++ b/api/pkg/core/auth/service_test.go
@@ -457,8 +457,12 @@ func TestLoginWithPwdIssuesPasswordSession(t *testing.T) {
 		t.Fatalf("LoginWithPwd: %v", err)
 	}
 
-	if got == nil || got.Token != "letoken" {
+	if got == nil || got.Session == nil || got.Session.Token != "letoken" {
 		t.Fatalf("LoginWithPwd() = %+v", got)
+	}
+
+	if got.User == nil || got.User.ID != f.ur.user.ID {
+		t.Errorf("LoginWithPwd() user = %+v, want %v", got.User, f.ur.user.ID)
 	}
 
 	if f.ur.gotName != userName {

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -116,7 +116,7 @@ func (fakeSetupService) DoSetup(context.Context, setup.DoSetupOpts) (*sessions.I
 
 type fakeAuthService struct{}
 
-func (fakeAuthService) LoginWithPwd(context.Context, auth.LoginWithPwdOpts) (*sessions.IssuedSession, error) {
+func (fakeAuthService) LoginWithPwd(context.Context, auth.LoginWithPwdOpts) (*auth.LoginResult, error) {
 	return nil, errors.New(notImplemented)
 }
 

--- a/api/pkg/core/setup/dosetup_test.go
+++ b/api/pkg/core/setup/dosetup_test.go
@@ -62,7 +62,7 @@ func (f *fakeAuthService) CreateUserWithPwd(
 	return f.user, nil
 }
 
-func (f *fakeAuthService) LoginWithPwd(context.Context, auth.LoginWithPwdOpts) (*sessions.IssuedSession, error) {
+func (f *fakeAuthService) LoginWithPwd(context.Context, auth.LoginWithPwdOpts) (*auth.LoginResult, error) {
 	panic("LoginWithPwd ne doit pas être appelée par DoSetup")
 }
 

--- a/web/app/composables/health.api.ts
+++ b/web/app/composables/health.api.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { apiFetch } from '~/utils/api'
+import { initApi } from '~/utils/api'
 
 export type ServerStatus = 'ok' | 'starting' | 'failed'
 
@@ -25,7 +25,7 @@ function isServerStatusResponse(value: unknown): value is ServerStatusResponse {
 
 async function getServerStatus(): Promise<ServerStatusResponse> {
   try {
-    const res = await apiFetch.raw<ServerStatusResponse>('/readyz', {
+    const res = await initApi().raw<ServerStatusResponse>('/readyz', {
       ignoreResponseError: true,
       timeout: READYZ_TIMEOUT_MS,
     })

--- a/web/app/composables/setup.api.ts
+++ b/web/app/composables/setup.api.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import type { ApiResponse } from '~/utils/api'
-import { ApiError, apiFetch } from '~/utils/api'
+import { ApiError, initApi } from '~/utils/api'
 
 export type DoSetupBody = {
   username: string
@@ -26,7 +26,7 @@ function isSetupStatusResponse(value: unknown): value is SetupStatusResponse {
 }
 
 export function createSetupApi(): SetupApi {
-  const api = apiFetch.create({ baseURL: '/api/setup' })
+  const api = initApi('/setup')
 
   async function getSetupStatus(): Promise<SetupState> {
     try {

--- a/web/app/features/auth/components/Card.vue
+++ b/web/app/features/auth/components/Card.vue
@@ -7,7 +7,6 @@ interface Props {
   error?: string
   onSubmit: () => void
   submitText: string
-  notice?: string
 }
 
 defineProps<Props>()
@@ -28,19 +27,10 @@ const { mobile } = useDisplay()
         {{ subtitle }}
       </span>
     </div>
-
-    <VAlert
-      v-if="notice"
-      type="info"
-      class="rounded-lg"
-      variant="tonal"
-      data-test="auth-form-notice"
-    >
-      {{ notice }}
-    </VAlert>
     <VAlert
       v-if="error"
-      class="rounded-lg"
+      class="rounded-lg border-thin-error text-body-medium"
+      density="compact"
       type="error"
       variant="tonal"
       data-test="auth-form-error"

--- a/web/app/features/auth/composables/auth.api.test.ts
+++ b/web/app/features/auth/composables/auth.api.test.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createAuthApi } from './auth.api'
+
+const call = vi.fn()
+
+vi.mock('~/utils/api', async importOriginal => ({
+  ...(await importOriginal<typeof import('~/utils/api')>()),
+  initApi: () => call,
+}))
+
+describe('createAuthApi().loginWithPwd', () => {
+  beforeEach(() => {
+    call.mockReset()
+  })
+
+  const user = { id: 'e2d1', username: 'alice', isAdmin: true }
+
+  it('returns the user carried by a successful login', async () => {
+    call.mockResolvedValue(user)
+
+    await expect(createAuthApi().loginWithPwd({ username: 'a', password: 'b' })).resolves.toEqual({
+      status: 'ok',
+      user,
+    })
+  })
+
+  it('returns invalid-credentials on a 401', async () => {
+    call.mockRejectedValue({ statusCode: 401, data: {} })
+
+    await expect(createAuthApi().loginWithPwd({ username: 'a', password: 'b' })).resolves.toEqual({
+      status: 'invalid-credentials',
+    })
+  })
+
+  it('returns unknown-error on a 500', async () => {
+    call.mockRejectedValue({ statusCode: 500, data: {} })
+
+    await expect(createAuthApi().loginWithPwd({ username: 'a', password: 'b' })).resolves.toEqual({
+      status: 'unknown-error',
+    })
+  })
+})

--- a/web/app/features/auth/composables/auth.api.ts
+++ b/web/app/features/auth/composables/auth.api.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { User } from '~/features/users/composables/users.api'
+import { ApiError, initApi } from '~/utils/api'
+
+export interface AuthApi {
+  loginWithPwd: (request: LoginWithPwdRequest) => Promise<LoginWithPwdResult>
+}
+
+export type LoginWithPwdStatus = 'ok' | 'invalid-credentials' | 'unknown-error'
+
+export type LoginWithPwdResult
+  = | { status: 'ok', user: User }
+    | { status: Exclude<LoginWithPwdStatus, 'ok'> }
+
+export interface LoginWithPwdRequest {
+  username: string
+  password: string
+}
+
+export function createAuthApi(): AuthApi {
+  const api = initApi('/auth')
+
+  async function loginWithPwd(body: LoginWithPwdRequest): Promise<LoginWithPwdResult> {
+    try {
+      const user = await api<User>('/login', { method: 'POST', body })
+
+      return { status: 'ok', user }
+    } catch (error) {
+      const apiError = ApiError.fromFetchError(error)
+      if (apiError.status === 401) {
+        return { status: 'invalid-credentials' }
+      }
+
+      console.error(loginWithPwd.name, apiError)
+
+      return { status: 'unknown-error' }
+    }
+  }
+
+  return { loginWithPwd }
+}

--- a/web/app/features/auth/composables/auth.composable.ts
+++ b/web/app/features/auth/composables/auth.composable.ts
@@ -1,27 +1,41 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import type { LoginWithPwdRequest, LoginWithPwdStatus } from './auth.api'
 import type { AuthCheck } from '~/features/auth/store/auth.store'
 import type { User } from '~/features/users/composables/users.api'
+import { createAuthApi } from './auth.api'
 
 export interface AuthComposable {
   user: Ref<User | undefined>
 
   isAuthenticated: Ref<boolean>
   isAdmin: Ref<boolean>
-
   loading: Ref<boolean>
 
   fetchMe: () => Promise<AuthCheck>
   invalidate: () => void
+
+  login: (request: LoginWithPwdRequest) => Promise<LoginWithPwdStatus>
 }
 
 export function useAuth(): AuthComposable {
   const store = useAuthStore()
+  const authApi = createAuthApi()
 
   const user = computed(() => store.user)
   const isAuthenticated = computed(() => !!user.value)
   const isAdmin = computed(() => !!user.value?.isAdmin)
   const loading = computed(() => store.status === 'loading')
+
+  async function login(request: LoginWithPwdRequest): Promise<LoginWithPwdStatus> {
+    const res = await authApi.loginWithPwd(request)
+
+    if (res.status === 'ok') {
+      store.setUser(res.user)
+    }
+
+    return res.status
+  }
 
   return {
     user,
@@ -29,6 +43,8 @@ export function useAuth(): AuthComposable {
     isAdmin,
 
     loading,
+
+    login,
 
     fetchMe: store.fetchMe,
     invalidate: store.invalidate,

--- a/web/app/features/auth/store/auth.store.ts
+++ b/web/app/features/auth/store/auth.store.ts
@@ -12,6 +12,7 @@ export interface AuthStore {
   status: Ref<AuthStatus>
 
   fetchMe: () => Promise<AuthCheck>
+  setUser: (user: User) => void
   invalidate: () => void
 }
 
@@ -26,6 +27,11 @@ export const useAuthStore = defineStore('auth', (): AuthStore => {
   function invalidate(): void {
     user.value = undefined
     status.value = 'idle'
+  }
+
+  function setUser(next: User): void {
+    user.value = next
+    status.value = 'ready'
   }
 
   async function load(): Promise<AuthCheck> {
@@ -75,6 +81,7 @@ export const useAuthStore = defineStore('auth', (): AuthStore => {
     status,
 
     fetchMe,
+    setUser,
     invalidate,
   }
 })

--- a/web/app/features/users/composables/users.api.ts
+++ b/web/app/features/users/composables/users.api.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import type { ApiResponse } from '~/utils/api'
-import { ApiError, apiFetch } from '~/utils/api'
+import { ApiError, initApi } from '~/utils/api'
 
 export interface UsersApi {
   getCurrentUser: () => Promise<ApiResponse<User>>
@@ -14,7 +14,7 @@ export interface User {
 }
 
 export function createUsersApi(): UsersApi {
-  const api = apiFetch.create({ baseURL: '/api/users' })
+  const api = initApi('/users')
 
   async function getCurrentUser(): Promise<ApiResponse<User>> {
     try {

--- a/web/app/pages/login.vue
+++ b/web/app/pages/login.vue
@@ -1,13 +1,71 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script setup lang="ts">
+import type { LoginWithPwdRequest } from '~/features/auth/composables/auth.api'
+import { object, string } from 'yup'
 import { NOT_AUTHENTICATED_ROUTE_GROUP } from '~/constants/auth'
+import { useForm } from '~/utils/forms/use-form'
+import { safeRedirect } from '~/utils/redirect'
 
 definePageMeta({
   layout: 'auth',
   authGroups: [NOT_AUTHENTICATED_ROUTE_GROUP],
 })
+
+const route = useRoute()
+const { t } = useI18n()
+const { login } = useAuth()
+
+const loading = ref<boolean>(false)
+const error = ref<string>()
+
+async function onSubmit(values: LoginWithPwdRequest): Promise<void> {
+  error.value = undefined
+  loading.value = true
+
+  const res = await login(values)
+  if (res === 'ok') {
+    await navigateTo(safeRedirect(route.query.redirect))
+
+    return
+  }
+
+  error.value = t(`login.error.${res}`)
+
+  loading.value = false
+}
+
+const { field, handleSubmit } = useForm({
+  schema: object({
+    username: string().required().label(t('login.username')),
+    password: string().required().label(t('login.password')),
+  }),
+  initialValues: {
+    username: '',
+    password: '',
+  },
+  onSubmit,
+})
 </script>
 
 <template>
-  <h1>LOGIN</h1>
+  <AuthCard
+    :title="$t('login.title')"
+    :subtitle="$t('login.subtitle')"
+    :error
+    :loading="loading"
+    :on-submit="handleSubmit"
+    :submit-text="$t('login.submit')"
+  >
+    <VTextField
+      v-bind="field('username').props"
+      type="text"
+      autocomplete="username"
+      data-test="login-username"
+    />
+
+    <AtomInputPassword
+      v-bind="field('password').props"
+      data-test="login-password"
+    />
+  </AuthCard>
 </template>

--- a/web/app/pages/status.vue
+++ b/web/app/pages/status.vue
@@ -10,7 +10,6 @@ const POLL_INTERVAL_MS = 5 * 1000
 
 const { getServerStatus } = createHealthApi()
 const route = useRoute('status')
-const router = useRouter()
 
 const serverStatus = ref<ServerStatusResponse>()
 let stopped = false
@@ -41,10 +40,6 @@ const loaderValue = computed(() => {
   return (started.length / components.length) * 100
 })
 
-function isKnownRoute(path: string): boolean {
-  return router.resolve(path).matched.length > 0
-}
-
 async function statusCheckLoop(): Promise<void> {
   while (true) {
     if (stopped) {
@@ -60,7 +55,7 @@ async function statusCheckLoop(): Promise<void> {
     serverStatus.value = status
 
     if (status.status === 'ok') {
-      await navigateTo(safeRedirect(route.query.redirect, isKnownRoute))
+      await navigateTo(safeRedirect(route.query.redirect))
       if (!isStatusPath(route.fullPath)) {
         return
       }

--- a/web/app/utils/api/api-fetch.ts
+++ b/web/app/utils/api/api-fetch.ts
@@ -1,3 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-export const apiFetch = $fetch.create({ baseURL: '/api' })
+export function initApi(endpoint: string = ''): ReturnType<typeof $fetch.create> {
+  return $fetch.create({ baseURL: `/api${endpoint}` })
+}

--- a/web/app/utils/redirect.test.ts
+++ b/web/app/utils/redirect.test.ts
@@ -1,78 +1,117 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
 
-import { describe, expect, it } from 'vitest'
+import type { RouteLocationRaw } from 'vue-router'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
 import { createMemoryHistory, createRouter } from 'vue-router'
 import { safeRedirect } from './redirect'
 import { STATUS_PATH } from './routes'
 
-const isEverythingKnown = (): boolean => true
+const { resolve } = vi.hoisted(() => ({
+  resolve: { fn: (_: RouteLocationRaw) => ({ matched: [{}] }) },
+}))
+
+function unsubscribe(): void {}
+
+function noop(): () => void {
+  return unsubscribe
+}
+
+async function ready(): Promise<void> {}
+
+function resolveRoute(to: RouteLocationRaw): { matched: object[] } {
+  return resolve.fn(to)
+}
+
+const routerStub = {
+  resolve: resolveRoute,
+  beforeEach: noop,
+  beforeResolve: noop,
+  afterEach: noop,
+  onError: noop,
+  isReady: ready,
+}
+
+function useRouterStub(): typeof routerStub {
+  return routerStub
+}
+
+mockNuxtImport('useRouter', () => useRouterStub)
+
 const stub = defineComponent({ render: () => h('div') })
 
 describe('safeRedirect', () => {
+  beforeEach(() => {
+    resolve.fn = () => ({ matched: [{}] })
+  })
+
   it('accepte un chemin interne résolu par le router', () => {
-    expect(safeRedirect('/library', isEverythingKnown)).toBe('/library')
+    expect(safeRedirect('/library')).toBe('/library')
   })
 
   it('conserve la query string du chemin cible', () => {
-    expect(safeRedirect('/library?page=2', isEverythingKnown)).toBe('/library?page=2')
+    expect(safeRedirect('/library?page=2')).toBe('/library?page=2')
   })
 
   it('retombe sur / quand le paramètre est absent', () => {
-    expect(safeRedirect(undefined, isEverythingKnown)).toBe('/')
+    expect(safeRedirect(undefined)).toBe('/')
   })
 
   it('retombe sur / quand la clé est répétée et vue-router rend un tableau', () => {
-    expect(safeRedirect(['/a', '/b'], isEverythingKnown)).toBe('/')
+    expect(safeRedirect(['/a', '/b'])).toBe('/')
   })
 
   it('rejette une URL absolue', () => {
-    expect(safeRedirect('https://evil.com', isEverythingKnown)).toBe('/')
+    expect(safeRedirect('https://evil.com')).toBe('/')
   })
 
   it('rejette une URL protocol-relative', () => {
-    expect(safeRedirect('//evil.com', isEverythingKnown)).toBe('/')
+    expect(safeRedirect('//evil.com')).toBe('/')
   })
 
   it('rejette un antislash, que certains navigateurs normalisent en /', () => {
-    expect(safeRedirect(String.raw`/\evil.com`, isEverythingKnown)).toBe('/')
+    expect(safeRedirect(String.raw`/\evil.com`)).toBe('/')
   })
 
   it('rejette un chemin relatif sans / initial', () => {
-    expect(safeRedirect('library', isEverythingKnown)).toBe('/')
+    expect(safeRedirect('library')).toBe('/')
   })
 
   it('rejette un chemin qui ne résout aucune route', () => {
-    expect(safeRedirect('/nope', () => false)).toBe('/')
+    resolve.fn = () => ({ matched: [] })
+
+    expect(safeRedirect('/nope')).toBe('/')
   })
 
   it('rejette /status, qui se renverrait sur lui-même', () => {
-    expect(safeRedirect(STATUS_PATH, isEverythingKnown)).toBe('/')
+    expect(safeRedirect(STATUS_PATH)).toBe('/')
   })
 
   it("rejette /status même porteur d'une query string", () => {
-    expect(safeRedirect('/status?redirect=%2Flibrary', isEverythingKnown)).toBe('/')
+    expect(safeRedirect('/status?redirect=%2Flibrary')).toBe('/')
   })
 
   it("rejette /status même porteur d'un fragment", () => {
-    expect(safeRedirect('/status#bas', isEverythingKnown)).toBe('/')
+    expect(safeRedirect('/status#bas')).toBe('/')
   })
 
   it('accepte un chemin seulement préfixé par /status', () => {
-    expect(safeRedirect('/statustique', isEverythingKnown)).toBe('/statustique')
+    expect(safeRedirect('/statustique')).toBe('/statustique')
   })
 
   it('rejette /status avec un slash final', () => {
-    expect(safeRedirect('/status/', isEverythingKnown)).toBe('/')
+    expect(safeRedirect('/status/')).toBe('/')
   })
 
   it('rejette /status quelle que soit la casse', () => {
-    expect(safeRedirect('/Status', isEverythingKnown)).toBe('/')
+    expect(safeRedirect('/Status')).toBe('/')
   })
 
   it("rejette /status porteur à la fois d'une query et d'un fragment", () => {
-    expect(safeRedirect('/status?redirect=%2Fa#bas', isEverythingKnown)).toBe('/')
-    expect(safeRedirect('/status#bas?redirect=%2Fa', isEverythingKnown)).toBe('/')
+    expect(safeRedirect('/status?redirect=%2Fa#bas')).toBe('/')
+    expect(safeRedirect('/status#bas?redirect=%2Fa')).toBe('/')
   })
 })
 
@@ -86,27 +125,29 @@ const router = createRouter({
   ],
 })
 
-const isKnownRoute = (path: string): boolean => router.resolve(path).matched.length > 0
-
 describe('safeRedirect adossé au router', () => {
+  beforeEach(() => {
+    resolve.fn = to => router.resolve(to)
+  })
+
   it('accepte une route à paramètre', () => {
-    expect(safeRedirect('/source/one-piece', isKnownRoute)).toBe('/source/one-piece')
+    expect(safeRedirect('/source/one-piece')).toBe('/source/one-piece')
   })
 
   it('accepte une route à paramètres imbriqués', () => {
-    expect(safeRedirect('/source/one-piece/chapter/42', isKnownRoute))
+    expect(safeRedirect('/source/one-piece/chapter/42'))
       .toBe('/source/one-piece/chapter/42')
   })
 
   it("accepte une route à paramètre porteuse d'une query string", () => {
-    expect(safeRedirect('/source/one-piece?page=2', isKnownRoute)).toBe('/source/one-piece?page=2')
+    expect(safeRedirect('/source/one-piece?page=2')).toBe('/source/one-piece?page=2')
   })
 
   it('rejette un segment de paramètre manquant', () => {
-    expect(safeRedirect('/source', isKnownRoute)).toBe('/')
+    expect(safeRedirect('/source')).toBe('/')
   })
 
   it('rejette une URL absolue sans même interroger le router', () => {
-    expect(safeRedirect('https://evil.com/x', isKnownRoute)).toBe('/')
+    expect(safeRedirect('https://evil.com/x')).toBe('/')
   })
 })

--- a/web/app/utils/redirect.ts
+++ b/web/app/utils/redirect.ts
@@ -3,7 +3,13 @@
 import { DEFAULT_PAGE } from '~/constants'
 import { isStatusPath } from './routes'
 
-export function safeRedirect(raw: unknown, isKnownRoute: (path: string) => boolean): string {
+function isKnownRoute(path: string): boolean {
+  const router = useRouter()
+
+  return router.resolve(path).matched.length > 0
+}
+
+export function safeRedirect(raw: unknown): string {
   const defaultRedirect = DEFAULT_PAGE as unknown as string
 
   if (typeof raw !== 'string') {

--- a/web/i18n/locales/en.json
+++ b/web/i18n/locales/en.json
@@ -54,5 +54,16 @@
       "min": "must have at least {min} items",
       "max": "must have at most {max} items"
     }
+  },
+  "login": {
+    "error": {
+      "invalid-credentials": "Invalid username/password",
+      "unknown-error": "Unknown error. Please try again."
+    },
+    "username": "Username",
+    "password": "Password",
+    "title": "Welcome back",
+    "subtitle": "Sign in to your Uchiyomi server",
+    "submit": "Sign in"
   }
 }

--- a/web/i18n/locales/fr.json
+++ b/web/i18n/locales/fr.json
@@ -54,5 +54,16 @@
       "min": "doit contenir au moins {min} éléments",
       "max": "doit contenir au maximum {max} éléments"
     }
+  },
+  "login": {
+    "error": {
+      "invalid-credentials": "Nom d'utilisateur/mot de passe invalide",
+      "unknown-error": "Erreur inconnue. \nVeuillez réessayer."
+    },
+    "username": "Nom d'utilisateur",
+    "password": "Mot de passe",
+    "title": "Bienvenue",
+    "subtitle": "Connectez-vous à votre serveur Uchiyomi",
+    "submit": "Se connecter"
   }
 }


### PR DESCRIPTION
Implements the password sign-in flow on `/login`, plus the API fixes it uncovered.

Refs #1.

## API

- `setupCtrls` was called without `AuthService`, so the controller held a typed-nil
  `*auth.Service`. `Deps.Validate()` cannot see that (a non-nil interface wrapping a
  nil pointer), so every `POST /api/auth/login` panicked on the first field access and
  answered `500`.
- `LoginWithPwd` now returns a `LoginResult{Session, User}` and the endpoint answers
  `200` with `{ id, username, isAdmin }` — the same shape as `GET /api/users/me` —
  alongside the session cookie. `401` and `400` are unchanged.

## Web

- `createAuthApi().loginWithPwd` maps the response to a discriminated result
  (`ok` + user, `invalid-credentials`, `unknown-error`), covered by unit tests.
- `useAuth().login` writes the returned user into the auth store. Previously nothing
  refreshed it after a login: `fetchMe()` short-circuits on `status === 'ready'`, which
  the `/login` guard had already set from its `401`, so the guard on `/` still saw an
  anonymous user and bounced back to `/login` — the redirect looked like a no-op.
- `login.vue` navigates to `safeRedirect(route.query.redirect)` instead of a hardcoded
  `/status`.
- `redirect.test.ts` follows `safeRedirect`'s single-argument signature, with
  `useRouter` mocked. The stub exposes the navigation-guard registration methods
  because Nuxt's `navigation-repaint` plugin calls `router.beforeResolve` on mount.

## Screenshot

<img width="713" height="689" alt="image" src="https://github.com/user-attachments/assets/1a3b0dab-60c5-4237-a955-242c833092db" />

## Verification

`go build ./...`, `go test ./...`, `golangci-lint run ./...`, `pnpm test`,
`pnpm typecheck`, `pnpm lint` and `pnpm knip` are green.

Checked against a running API with a temporary account: login answers `200` with the
user and the `uchiyomi_session` cookie, `GET /api/users/me` accepts that cookie, and a
wrong password still answers `401`.
