### PR TITLE
Admin API for OIDC provider configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,15 @@ cd web && pnpm dev                        # SPA on :3001
 ```
 
 The Go binary is configured through environment variables only — no config file,
-no flags besides `-healthcheck`. `DB_HOST`, `DB_USER`, `DB_PWD` and `DB_NAME`
-are required; see `api/cmd/uichiyomiserver/config.go` for the full list.
+no flags besides `-healthcheck`. `DB_HOST`, `DB_USER`, `DB_PWD`, `DB_NAME`,
+`PUBLIC_URL` and `OIDC_ENCRYPTION_KEY` are required; see
+`api/cmd/uichiyomiserver/config.go` for the full list.
+
+`OIDC_ENCRYPTION_KEY` is 32 bytes in base64 — `openssl rand -base64 32`. It
+encrypts the OIDC client secrets stored in the database, so changing it makes
+the existing ones unreadable. `PUBLIC_URL` is the externally reachable base URL
+of the instance, used to build the redirect URI registered at the identity
+provider.
 
 In dev, Nuxt proxies `/api` to `:3000`. In production the SPA is embedded into
 the binary through the `webui` build tag (`WITH_WEB=on`), so a single container

--- a/api/cmd/uichiyomiserver/config.go
+++ b/api/cmd/uichiyomiserver/config.go
@@ -5,6 +5,7 @@ package main
 import (
 	"encoding/base64"
 	"fmt"
+	"net/url"
 
 	"github.com/caarlos0/env/v11"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/crypto"
@@ -45,6 +46,10 @@ func newConfig() (*cfg, error) {
 		return nil, err
 	}
 
+	if err := c.validatePublicURL(); err != nil {
+		return nil, err
+	}
+
 	return &c, nil
 }
 
@@ -59,6 +64,23 @@ func (c *cfg) decodeEncryptionKey() error {
 	}
 
 	c.OIDC.EncryptionKey = key
+
+	return nil
+}
+
+func (c *cfg) validatePublicURL() error {
+	u, err := url.Parse(c.OIDC.PublicURL)
+	if err != nil {
+		return fmt.Errorf("PUBLIC_URL is not a valid URL: %w", err)
+	}
+
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("PUBLIC_URL must have an http or https scheme, got %q", c.OIDC.PublicURL)
+	}
+
+	if u.Host == "" {
+		return fmt.Errorf("PUBLIC_URL must have a host, got %q", c.OIDC.PublicURL)
+	}
 
 	return nil
 }

--- a/api/cmd/uichiyomiserver/config.go
+++ b/api/cmd/uichiyomiserver/config.go
@@ -3,19 +3,22 @@
 package main
 
 import (
+	"encoding/base64"
 	"fmt"
 
 	"github.com/caarlos0/env/v11"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/crypto"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/logging"
 )
 
 type cfg struct {
+	OIDC struct {
+		PublicURL        string `env:"PUBLIC_URL,required,notEmpty"`
+		EncryptionKeyB64 string `env:"OIDC_ENCRYPTION_KEY,required,notEmpty"`
+		EncryptionKey    []byte
+	}
 	Logger struct {
 		Level logging.LogLevel `env:"LOG_LEVEL" envDefault:"info"`
-	}
-	Http struct {
-		AllowedOrigins []string `env:"CORS_ORIGINS" envSeparator:","`
-		Port           int      `env:"PORT" envDefault:"3000"`
 	}
 	PG struct {
 		Host        string `env:"DB_HOST,required"`
@@ -26,6 +29,10 @@ type cfg struct {
 		SSLRequired bool   `env:"DB_SSL" envDefault:"false"`
 		Port        int    `env:"DB_PORT" envDefault:"5432"`
 	}
+	Http struct {
+		AllowedOrigins []string `env:"CORS_ORIGINS" envSeparator:","`
+		Port           int      `env:"PORT" envDefault:"3000"`
+	}
 }
 
 func newConfig() (*cfg, error) {
@@ -34,5 +41,24 @@ func newConfig() (*cfg, error) {
 		return nil, fmt.Errorf("env.ParseAs: %w", err)
 	}
 
+	if err := c.decodeEncryptionKey(); err != nil {
+		return nil, err
+	}
+
 	return &c, nil
+}
+
+func (c *cfg) decodeEncryptionKey() error {
+	key, err := base64.StdEncoding.DecodeString(c.OIDC.EncryptionKeyB64)
+	if err != nil {
+		return fmt.Errorf("OIDC_ENCRYPTION_KEY is not valid base64: %w", err)
+	}
+
+	if len(key) != crypto.KeyLen {
+		return fmt.Errorf("OIDC_ENCRYPTION_KEY must be %d bytes once decoded, got %d", crypto.KeyLen, len(key))
+	}
+
+	c.OIDC.EncryptionKey = key
+
+	return nil
 }

--- a/api/cmd/uichiyomiserver/config_internal_test.go
+++ b/api/cmd/uichiyomiserver/config_internal_test.go
@@ -66,6 +66,38 @@ func TestNewConfigRejectsAnUnusableEncryptionKey(t *testing.T) {
 	}
 }
 
+func TestNewConfigRejectsAnUnusablePublicURL(t *testing.T) {
+	tests := map[string]struct {
+		value   string
+		wantErr string
+	}{
+		"no scheme": {
+			value:   "manga.example.com",
+			wantErr: "must have an http or https scheme",
+		},
+		"unsupported scheme": {
+			value:   "ftp://manga.example.com",
+			wantErr: "must have an http or https scheme",
+		},
+		"no host": {
+			value:   "https://",
+			wantErr: "must have a host",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			setRequiredEnv(t)
+			t.Setenv("PUBLIC_URL", tc.value)
+
+			_, err := newConfig()
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("newConfig() = %v, want an error mentioning %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestNewConfigRequiresTheNewVariables(t *testing.T) {
 	for _, name := range []string{"OIDC_ENCRYPTION_KEY", "PUBLIC_URL"} {
 		t.Run(name, func(t *testing.T) {

--- a/api/cmd/uichiyomiserver/config_internal_test.go
+++ b/api/cmd/uichiyomiserver/config_internal_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package main
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/crypto"
+)
+
+func setRequiredEnv(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("DB_HOST", "localhost")
+	t.Setenv("DB_USER", "uchiyomi")
+	t.Setenv("DB_PWD", "uchiyomi")
+	t.Setenv("DB_NAME", "uchiyomi")
+	t.Setenv("PUBLIC_URL", "https://manga.example.com")
+	t.Setenv("OIDC_ENCRYPTION_KEY", base64.StdEncoding.EncodeToString(make([]byte, crypto.KeyLen)))
+}
+
+func TestNewConfigDecodesTheEncryptionKey(t *testing.T) {
+	setRequiredEnv(t)
+
+	c, err := newConfig()
+	if err != nil {
+		t.Fatalf("newConfig: %v", err)
+	}
+
+	if len(c.OIDC.EncryptionKey) != crypto.KeyLen {
+		t.Errorf("len(EncryptionKey) = %d, want %d", len(c.OIDC.EncryptionKey), crypto.KeyLen)
+	}
+
+	if c.OIDC.PublicURL != "https://manga.example.com" {
+		t.Errorf("PublicURL = %q", c.OIDC.PublicURL)
+	}
+}
+
+func TestNewConfigRejectsAnUnusableEncryptionKey(t *testing.T) {
+	tests := map[string]struct {
+		value   string
+		wantErr string
+	}{
+		"not base64": {
+			value:   "not-base64!!",
+			wantErr: "OIDC_ENCRYPTION_KEY",
+		},
+		"wrong length": {
+			value:   base64.StdEncoding.EncodeToString(make([]byte, 16)),
+			wantErr: "must be 32 bytes",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			setRequiredEnv(t)
+			t.Setenv("OIDC_ENCRYPTION_KEY", tc.value)
+
+			_, err := newConfig()
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("newConfig() = %v, want an error mentioning %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestNewConfigRequiresTheNewVariables(t *testing.T) {
+	for _, name := range []string{"OIDC_ENCRYPTION_KEY", "PUBLIC_URL"} {
+		t.Run(name, func(t *testing.T) {
+			setRequiredEnv(t)
+			t.Setenv(name, "")
+
+			if _, err := newConfig(); err == nil {
+				t.Errorf("newConfig() without %s = nil, want an error", name)
+			}
+		})
+	}
+}

--- a/api/cmd/uichiyomiserver/setup.go
+++ b/api/cmd/uichiyomiserver/setup.go
@@ -40,7 +40,7 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/crypto"
 )
 
-const oidcCallbackPath = "/api/auth/oidc/callback"
+const oidcCallbackPath = core.APIPrefix + "/auth/oidc/callback"
 
 func setupApp(cfg *cfg) (*core.App, error) {
 	logger := logging.New(logging.Config{Level: cfg.Logger.Level})

--- a/api/cmd/uichiyomiserver/setup.go
+++ b/api/cmd/uichiyomiserver/setup.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -23,6 +24,10 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/hash/bcrypthash"
 	pgpwd "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/password/repository/pg"
 	httpauth "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidc"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
+	httpoidcproviders "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders/gateway/http"
+	pgoidcproviders "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders/repository/pg"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
 	httpsession "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/gateway/http"
 	pgsessions "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/repository/pg"
@@ -32,7 +37,10 @@ import (
 	httpusers "github.com/kharente-deuh/uchiyomi-server/pkg/core/users/gateway/http"
 	pgusers "github.com/kharente-deuh/uchiyomi-server/pkg/core/users/repository/pg"
 	httpasura "github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/crypto"
 )
+
+const oidcCallbackPath = "/api/auth/oidc/callback"
 
 func setupApp(cfg *cfg) (*core.App, error) {
 	logger := logging.New(logging.Config{Level: cfg.Logger.Level})
@@ -44,8 +52,10 @@ func setupApp(cfg *cfg) (*core.App, error) {
 	}
 
 	services, err := setupServices(servicesDeps{
-		DBr:    dbr,
-		Logger: logger,
+		DBr:           dbr,
+		Logger:        logger,
+		EncryptionKey: cfg.OIDC.EncryptionKey,
+		PublicURL:     strings.TrimSuffix(cfg.OIDC.PublicURL, "/"),
 	})
 	if err != nil {
 		//nolint:wrapcheck
@@ -64,12 +74,13 @@ func setupApp(cfg *cfg) (*core.App, error) {
 	registry := core.NewHealthRegistry(dbr.PGDB)
 
 	ctrls, err := setupCtrls(ctrlsDeps{
-		Logger:          logger,
-		SessionsService: services.Sessions,
-		SetupService:    services.Setup,
-		AuthService:     services.Auth,
-		AsuraApp:        apps.Asura,
-		Registry:        registry,
+		Logger:               logger,
+		SessionsService:      services.Sessions,
+		SetupService:         services.Setup,
+		AuthService:          services.Auth,
+		OIDCProvidersService: services.OIDCProviders,
+		AsuraApp:             apps.Asura,
+		Registry:             registry,
 	})
 	if err != nil {
 		//nolint:wrapcheck
@@ -82,11 +93,12 @@ func setupApp(cfg *cfg) (*core.App, error) {
 			AllowedOrigins: cfg.Http.AllowedOrigins,
 		},
 		core.Deps{
-			SetupCtrl:  ctrls.Setup,
-			AsuraCtrl:  ctrls.Asura,
-			HealthCtrl: ctrls.Health,
-			AuthCtrl:   ctrls.Auth,
-			UsersCtrl:  ctrls.Users,
+			SetupCtrl:         ctrls.Setup,
+			AsuraCtrl:         ctrls.Asura,
+			HealthCtrl:        ctrls.Health,
+			AuthCtrl:          ctrls.Auth,
+			UsersCtrl:         ctrls.Users,
+			OIDCProvidersCtrl: ctrls.OIDCProviders,
 
 			Health:   registry,
 			Logger:   logger,
@@ -102,11 +114,12 @@ func setupApp(cfg *cfg) (*core.App, error) {
 }
 
 type dbRelated struct {
-	PGDB               *database.PGDB
-	Txor               *pgtx.PGTransactor
-	UsersRepository    *pgusers.PGUsersRepository
-	SessionsRepository *pgsessions.PGSessionsRepository
-	PwdRepository      *pgpwd.PGPasswordCredsRepository
+	PGDB                    *database.PGDB
+	Txor                    *pgtx.PGTransactor
+	UsersRepository         *pgusers.PGUsersRepository
+	SessionsRepository      *pgsessions.PGSessionsRepository
+	PwdRepository           *pgpwd.PGPasswordCredsRepository
+	OIDCProvidersRepository *pgoidcproviders.PGOIDCProvidersRepository
 }
 
 func setupDBRelated(c *cfg, logger *slog.Logger) (*dbRelated, error) {
@@ -146,26 +159,35 @@ func setupDBRelated(c *cfg, logger *slog.Logger) (*dbRelated, error) {
 		return nil, fmt.Errorf("failed to init pwdRepository: %w", err)
 	}
 
+	oidcProvidersRepository, err := pgoidcproviders.New(pgoidcproviders.Deps{DB: pgdb.DB})
+	if err != nil {
+		return nil, fmt.Errorf("failed to init oidcProvidersRepository: %w", err)
+	}
+
 	dbr := &dbRelated{
-		PGDB:               pgdb,
-		Txor:               txor,
-		UsersRepository:    usersRepository,
-		SessionsRepository: sessionsRepository,
-		PwdRepository:      pwdRepository,
+		PGDB:                    pgdb,
+		Txor:                    txor,
+		UsersRepository:         usersRepository,
+		SessionsRepository:      sessionsRepository,
+		PwdRepository:           pwdRepository,
+		OIDCProvidersRepository: oidcProvidersRepository,
 	}
 
 	return dbr, nil
 }
 
 type services struct {
-	Auth     *auth.Service
-	Setup    *setup.Service
-	Sessions *sessions.Service
+	Auth          *auth.Service
+	Setup         *setup.Service
+	Sessions      *sessions.Service
+	OIDCProviders *oidcproviders.Service
 }
 
 type servicesDeps struct {
-	Logger *slog.Logger
-	DBr    *dbRelated
+	Logger        *slog.Logger
+	DBr           *dbRelated
+	PublicURL     string
+	EncryptionKey []byte
 }
 
 func setupServices(deps servicesDeps) (*services, error) {
@@ -213,10 +235,36 @@ func setupServices(deps servicesDeps) (*services, error) {
 		return nil, fmt.Errorf("failed to init setupSvc: %w", err)
 	}
 
+	cipher, err := crypto.New(crypto.Config{Key: deps.EncryptionKey})
+	if err != nil {
+		return nil, fmt.Errorf("failed to init cipher: %w", err)
+	}
+
+	discoverer, err := oidc.New(
+		oidc.Config{Timeout: 10 * time.Second},
+		oidc.Deps{HTTPClient: &http.Client{Timeout: 10 * time.Second}},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init discoverer: %w", err)
+	}
+
+	oidcProvidersSvc, err := oidcproviders.NewService(
+		oidcproviders.ServiceConfig{RedirectURI: deps.PublicURL + oidcCallbackPath},
+		oidcproviders.ServiceDeps{
+			Repository: deps.DBr.OIDCProvidersRepository,
+			Cipher:     cipher,
+			Discoverer: discoverer,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init oidcProvidersSvc: %w", err)
+	}
+
 	svcs := &services{
-		Auth:     authSvc,
-		Sessions: sessionsSvc,
-		Setup:    setupSvc,
+		Auth:          authSvc,
+		Sessions:      sessionsSvc,
+		Setup:         setupSvc,
+		OIDCProviders: oidcProvidersSvc,
 	}
 
 	return svcs, nil
@@ -386,20 +434,22 @@ func setupAsura(logger *slog.Logger) (*asura.App, error) {
 }
 
 type ctrls struct {
-	Setup  *httpsetup.Controller
-	Asura  *httpasura.Controller
-	Health *httphealth.Controller
-	Auth   *httpauth.Controller
-	Users  *httpusers.Controller
+	Setup         *httpsetup.Controller
+	Asura         *httpasura.Controller
+	Health        *httphealth.Controller
+	Auth          *httpauth.Controller
+	Users         *httpusers.Controller
+	OIDCProviders *httpoidcproviders.Controller
 }
 
 type ctrlsDeps struct {
-	AsuraApp        *asura.App
-	SetupService    *setup.Service
-	SessionsService *sessions.Service
-	Logger          *slog.Logger
-	Registry        *health.Registry
-	AuthService     *auth.Service
+	AsuraApp             *asura.App
+	SetupService         *setup.Service
+	SessionsService      *sessions.Service
+	Logger               *slog.Logger
+	Registry             *health.Registry
+	AuthService          *auth.Service
+	OIDCProvidersService *oidcproviders.Service
 }
 
 func setupCtrls(deps ctrlsDeps) (*ctrls, error) {
@@ -478,12 +528,27 @@ func setupCtrls(deps ctrlsDeps) (*ctrls, error) {
 		return nil, fmt.Errorf("failed to init users controller: %w", err)
 	}
 
+	oidcProvidersCtrl, err := httpoidcproviders.New(
+		httpoidcproviders.Config{
+			Endpoint:    "/oidc/providers",
+			Middlewares: chi.Middlewares{authenticator.Middleware, authenticator.RequireAdmin},
+		},
+		httpoidcproviders.Deps{
+			Logger:  deps.Logger,
+			Service: deps.OIDCProvidersService,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init oidc providers controller: %w", err)
+	}
+
 	c := &ctrls{
-		Asura:  asura,
-		Setup:  setup,
-		Health: healthCtrl,
-		Auth:   authCtrl,
-		Users:  usersCtrl,
+		Asura:         asura,
+		Setup:         setup,
+		Health:        healthCtrl,
+		Auth:          authCtrl,
+		Users:         usersCtrl,
+		OIDCProviders: oidcProvidersCtrl,
 	}
 
 	return c, nil

--- a/api/cmd/uichiyomiserver/setup_internal_test.go
+++ b/api/cmd/uichiyomiserver/setup_internal_test.go
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/users"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/health"
+)
+
+type emptyOIDCProvidersRepository struct{}
+
+func (emptyOIDCProvidersRepository) GetByID(
+	context.Context, uuid.UUID,
+) (*oidcproviders.OIDCProvider, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (emptyOIDCProvidersRepository) GetByIssuerURL(
+	context.Context, string,
+) (*oidcproviders.OIDCProvider, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (emptyOIDCProvidersRepository) Create(
+	context.Context, oidcproviders.CreateOIDCProviderOpts,
+) (*oidcproviders.OIDCProvider, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (emptyOIDCProvidersRepository) Update(
+	context.Context, uuid.UUID, oidcproviders.UpdateOIDCProviderOpts,
+) (*oidcproviders.OIDCProvider, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (emptyOIDCProvidersRepository) DeleteByID(context.Context, uuid.UUID) error {
+	return errors.New("not implemented")
+}
+
+func (emptyOIDCProvidersRepository) GetAll(context.Context) ([]oidcproviders.LightOIDCProvider, error) {
+	return nil, nil
+}
+
+type noopCipher struct{}
+
+func (noopCipher) Seal(plaintext []byte) ([]byte, error) { return plaintext, nil }
+
+type noopDiscoverer struct{}
+
+func (noopDiscoverer) Discover(context.Context, string) (*oidcproviders.Discovery, error) {
+	return nil, errors.New("not implemented")
+}
+
+func newTestOIDCProvidersService(t *testing.T) *oidcproviders.Service {
+	t.Helper()
+
+	svc, err := oidcproviders.NewService(
+		oidcproviders.ServiceConfig{RedirectURI: "https://manga.example.com/api/auth/oidc/callback"},
+		oidcproviders.ServiceDeps{
+			Repository: emptyOIDCProvidersRepository{},
+			Cipher:     noopCipher{},
+			Discoverer: noopDiscoverer{},
+		},
+	)
+	if err != nil {
+		t.Fatalf("oidcproviders.NewService: %v", err)
+	}
+
+	return svc
+}
+
+type fixedUserSessionsRepository struct {
+	user *users.User
+}
+
+func (f *fixedUserSessionsRepository) Insert(
+	context.Context, sessions.InsertSessionOpts,
+) (*sessions.Session, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fixedUserSessionsRepository) GetByTokenHash(
+	context.Context, []byte,
+) (*sessions.Session, *users.User, error) {
+	return &sessions.Session{
+		ID:         uuid.New(),
+		UserID:     f.user.ID,
+		AuthMethod: sessions.AuthMethodPassword,
+		CreatedAt:  time.Now(),
+		ExpiresAt:  time.Now().Add(48 * time.Hour),
+	}, f.user, nil
+}
+
+func (f *fixedUserSessionsRepository) UpdateExpiry(context.Context, uuid.UUID, time.Time) error {
+	return errors.New("not implemented")
+}
+
+func (f *fixedUserSessionsRepository) DeleteByTokenHash(context.Context, []byte) error {
+	return errors.New("not implemented")
+}
+
+func (f *fixedUserSessionsRepository) DeleteByUserID(context.Context, uuid.UUID) error {
+	return errors.New("not implemented")
+}
+
+func (f *fixedUserSessionsRepository) DeleteExpired(context.Context, time.Time) (int64, error) {
+	return 0, nil
+}
+
+func newTestSessionsService(t *testing.T, user *users.User) *sessions.Service {
+	t.Helper()
+
+	svc, err := sessions.NewService(
+		sessions.ServiceConfig{
+			Password: sessions.TTL{
+				Idle:     24 * time.Hour,
+				Absolute: 30 * 24 * time.Hour,
+			},
+			OIDC: sessions.TTL{
+				Idle:     24 * time.Hour,
+				Absolute: 30 * 24 * time.Hour,
+			},
+			RenewThreshold: time.Hour,
+		},
+		sessions.ServiceDeps{Repository: &fixedUserSessionsRepository{user: user}},
+	)
+	if err != nil {
+		t.Fatalf("sessions.NewService: %v", err)
+	}
+
+	return svc
+}
+
+func newTestCtrlsForUser(t *testing.T, user *users.User) *ctrls {
+	t.Helper()
+
+	logger := slog.New(slog.DiscardHandler)
+
+	asuraApp, err := setupAsura(logger)
+	if err != nil {
+		t.Fatalf("setupAsura: %v", err)
+	}
+
+	c, err := setupCtrls(ctrlsDeps{
+		AsuraApp:             asuraApp,
+		SessionsService:      newTestSessionsService(t, user),
+		Logger:               logger,
+		Registry:             health.NewRegistry(),
+		OIDCProvidersService: newTestOIDCProvidersService(t),
+	})
+	if err != nil {
+		t.Fatalf("setupCtrls: %v", err)
+	}
+
+	return c
+}
+
+func TestOIDCProvidersController(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		user       *users.User
+		wantStatus int
+	}{
+		"non-admin is rejected": {
+			user:       &users.User{ID: uuid.New(), Name: "alice", IsAdmin: false},
+			wantStatus: http.StatusForbidden,
+		},
+		"admin is let through": {
+			user:       &users.User{ID: uuid.New(), Name: "root", IsAdmin: true},
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c := newTestCtrlsForUser(t, tc.user)
+
+			r := chi.NewRouter()
+			c.OIDCProviders.InitRouter(r)
+
+			req := httptest.NewRequest(http.MethodGet, "/oidc/providers", nil)
+			req.AddCookie(&http.Cookie{Name: "uchiyomi_session", Value: "any-token"})
+
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Errorf("GET /oidc/providers = %d, want %d (body: %s)", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+		})
+	}
+}

--- a/api/go.mod
+++ b/api/go.mod
@@ -5,6 +5,7 @@ go 1.26.5
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/caarlos0/env/v11 v11.4.1
+	github.com/coreos/go-oidc/v3 v3.20.0
 	github.com/go-chi/chi/v5 v5.3.1
 	github.com/go-chi/cors v1.2.2
 	github.com/go-playground/validator/v10 v10.30.3
@@ -21,6 +22,7 @@ require (
 
 require (
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -29,6 +31,7 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
+	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 )

--- a/api/go.sum
+++ b/api/go.sum
@@ -2,6 +2,8 @@ github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7Oputl
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/caarlos0/env/v11 v11.4.1 h1:fYwH0sWEsBSMPG7t4e/PEfTFzrWrpjyygXyUnWiSwEw=
 github.com/caarlos0/env/v11 v11.4.1/go.mod h1:qupehSf/Y0TUTsxKywqRt/vJjN5nz6vauiYEUUr8P4U=
+github.com/coreos/go-oidc/v3 v3.20.0 h1:EtE0WIBHk03N+DqGkY4+UONzzZHk7amKt6IyNd7OsZE=
+github.com/coreos/go-oidc/v3 v3.20.0/go.mod h1:DYCf24+ncYi+XkIH97GY1+dqoRlbaSI26KVTCI9SrY4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -11,6 +13,8 @@ github.com/go-chi/chi/v5 v5.3.1 h1:3j4HZLGZQ3JpMCrPJF/Jl3mYJfWLKBfNJ6quurUGCf8=
 github.com/go-chi/chi/v5 v5.3.1/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
 github.com/go-chi/cors v1.2.2 h1:Jmey33TE+b+rB7fT8MUy1u0I4L+NARQlK6LhzKPSyQE=
 github.com/go-chi/cors v1.2.2/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
@@ -51,6 +55,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
 golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
 golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=

--- a/api/pkg/core/app.go
+++ b/api/pkg/core/app.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
 	httpauth "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/gateway/http"
+	httpoidcproviders "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
 	httphealth "github.com/kharente-deuh/uchiyomi-server/pkg/core/health/gateway/http"
 	httpsetup "github.com/kharente-deuh/uchiyomi-server/pkg/core/setup/gateway/http"
@@ -59,11 +60,12 @@ type Database interface {
 type Deps struct {
 	DB Database
 
-	SetupCtrl  *httpsetup.Controller
-	AsuraCtrl  *httpasura.Controller
-	HealthCtrl *httphealth.Controller
-	AuthCtrl   *httpauth.Controller
-	UsersCtrl  *httpusers.Controller
+	SetupCtrl         *httpsetup.Controller
+	AsuraCtrl         *httpasura.Controller
+	HealthCtrl        *httphealth.Controller
+	AuthCtrl          *httpauth.Controller
+	UsersCtrl         *httpusers.Controller
+	OIDCProvidersCtrl *httpoidcproviders.Controller
 
 	Logger *slog.Logger
 	Health *health.Registry
@@ -107,6 +109,10 @@ func (deps *Deps) Validate() error {
 
 	if deps.UsersCtrl == nil {
 		return errors.New("usersCtrl is required")
+	}
+
+	if deps.OIDCProvidersCtrl == nil {
+		return errors.New("oidcProvidersCtrl is required")
 	}
 
 	if deps.Health == nil {
@@ -225,6 +231,7 @@ func (a *App) newRouter(ui http.Handler) chi.Router {
 			a.deps.SetupCtrl.InitRouter(r)
 			a.deps.AuthCtrl.InitRouter(r)
 			a.deps.UsersCtrl.InitRouter(r)
+			a.deps.OIDCProvidersCtrl.InitRouter(r)
 			r.Route("/sources", func(r chi.Router) {
 				a.deps.AsuraCtrl.InitRouter(r)
 			})

--- a/api/pkg/core/app.go
+++ b/api/pkg/core/app.go
@@ -31,7 +31,8 @@ const (
 	portMaxValue    = 65535
 	shutdownTimeout = 5 * time.Second
 
-	apiPrefix = "/api"
+	APIPrefix = "/api"
+	apiPrefix = APIPrefix
 )
 
 type Config struct {

--- a/api/pkg/core/app_internal_test.go
+++ b/api/pkg/core/app_internal_test.go
@@ -6,10 +6,26 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/health"
 )
+
+func TestRouterMountsTheOIDCProvidersRoutes(t *testing.T) {
+	t.Parallel()
+
+	app, _ := newTestApp(t, &fakeDB{}, gatePort)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/oidc/providers", nil)
+	rec := httptest.NewRecorder()
+
+	app.newRouter(nil).ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusNotFound {
+		t.Errorf("GET /api/oidc/providers = 404, want the route to be mounted")
+	}
+}
 
 func TestRunComponentMarksOKBeforeEnteringTheLoop(t *testing.T) {
 	reg := health.NewRegistry(componentAsura)

--- a/api/pkg/core/auth/oidc/discovery.go
+++ b/api/pkg/core/auth/oidc/discovery.go
@@ -88,7 +88,7 @@ func (d *Discoverer) Discover(ctx context.Context, issuerURL string) (*oidcprovi
 	}
 
 	if doc.AuthorizationEndpoint == "" || doc.TokenEndpoint == "" {
-		return nil, ErrDiscoveryIncomplete
+		return nil, fmt.Errorf("%w: %w", oidcproviders.ErrIncompleteDiscovery, ErrDiscoveryIncomplete)
 	}
 
 	return &oidcproviders.Discovery{

--- a/api/pkg/core/auth/oidc/discovery.go
+++ b/api/pkg/core/auth/oidc/discovery.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package oidc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	gooidc "github.com/coreos/go-oidc/v3/oidc"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
+)
+
+var _ oidcproviders.Discoverer = (*Discoverer)(nil)
+
+var (
+	ErrDiscoveryFailed     = errors.New("issuer discovery failed")
+	ErrDiscoveryIncomplete = errors.New("discovery document is incomplete")
+)
+
+const defaultTimeout = 10 * time.Second
+
+type Config struct {
+	Timeout time.Duration
+}
+
+func (cfg *Config) Validate() error {
+	if cfg.Timeout < 0 {
+		return errors.New("timeout must not be negative")
+	}
+
+	return nil
+}
+
+type Deps struct {
+	HTTPClient *http.Client
+}
+
+func (deps *Deps) Validate() error {
+	if deps.HTTPClient == nil {
+		return errors.New("httpClient is required")
+	}
+
+	return nil
+}
+
+type Discoverer struct {
+	deps Deps
+	cfg  Config
+}
+
+func New(cfg Config, deps Deps) (*Discoverer, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("cfg.Validate: %w", err)
+	}
+
+	if err := deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	if cfg.Timeout == 0 {
+		cfg.Timeout = defaultTimeout
+	}
+
+	return &Discoverer{cfg: cfg, deps: deps}, nil
+}
+
+func (d *Discoverer) Discover(ctx context.Context, issuerURL string) (*oidcproviders.Discovery, error) {
+	ctx, cancel := context.WithTimeout(gooidc.ClientContext(ctx, d.deps.HTTPClient), d.cfg.Timeout)
+	defer cancel()
+
+	provider, err := gooidc.NewProvider(ctx, issuerURL)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrDiscoveryFailed, err)
+	}
+
+	var doc struct {
+		AuthorizationEndpoint string `json:"authorization_endpoint"`
+		TokenEndpoint         string `json:"token_endpoint"`
+		UserInfoEndpoint      string `json:"userinfo_endpoint"`
+		EndSessionEndpoint    string `json:"end_session_endpoint"`
+	}
+
+	if err := provider.Claims(&doc); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrDiscoveryFailed, err)
+	}
+
+	if doc.AuthorizationEndpoint == "" || doc.TokenEndpoint == "" {
+		return nil, ErrDiscoveryIncomplete
+	}
+
+	return &oidcproviders.Discovery{
+		Issuer:                issuerURL,
+		AuthorizationEndpoint: doc.AuthorizationEndpoint,
+		TokenEndpoint:         doc.TokenEndpoint,
+		UserInfoEndpoint:      doc.UserInfoEndpoint,
+		EndSessionEndpoint:    doc.EndSessionEndpoint,
+	}, nil
+}

--- a/api/pkg/core/auth/oidc/discovery_test.go
+++ b/api/pkg/core/auth/oidc/discovery_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package oidc_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidc"
+)
+
+func discoveryServer(t *testing.T, body func(issuer string) string) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+
+	t.Cleanup(srv.Close)
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, body(srv.URL))
+	})
+
+	return srv
+}
+
+func fullDocument(issuer string) string {
+	return fmt.Sprintf(`{
+		"issuer": %q,
+		"authorization_endpoint": "%s/auth",
+		"token_endpoint": "%s/token",
+		"userinfo_endpoint": "%s/userinfo",
+		"end_session_endpoint": "%s/logout",
+		"jwks_uri": "%s/jwks"
+	}`, issuer, issuer, issuer, issuer, issuer, issuer)
+}
+
+func newDiscoverer(t *testing.T) *oidc.Discoverer {
+	t.Helper()
+
+	d, err := oidc.New(oidc.Config{Timeout: 5 * time.Second}, oidc.Deps{HTTPClient: http.DefaultClient})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	return d
+}
+
+func TestDiscoverReadsTheEndpoints(t *testing.T) {
+	t.Parallel()
+
+	srv := discoveryServer(t, fullDocument)
+
+	got, err := newDiscoverer(t).Discover(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	if got.Issuer != srv.URL {
+		t.Errorf("Issuer = %q, want %q", got.Issuer, srv.URL)
+	}
+
+	if got.AuthorizationEndpoint != srv.URL+"/auth" {
+		t.Errorf("AuthorizationEndpoint = %q", got.AuthorizationEndpoint)
+	}
+
+	if got.TokenEndpoint != srv.URL+"/token" {
+		t.Errorf("TokenEndpoint = %q", got.TokenEndpoint)
+	}
+
+	if got.UserInfoEndpoint != srv.URL+"/userinfo" {
+		t.Errorf("UserInfoEndpoint = %q", got.UserInfoEndpoint)
+	}
+
+	if got.EndSessionEndpoint != srv.URL+"/logout" {
+		t.Errorf("EndSessionEndpoint = %q", got.EndSessionEndpoint)
+	}
+}
+
+func TestDiscoverReportsAMissingEndSessionEndpoint(t *testing.T) {
+	t.Parallel()
+
+	srv := discoveryServer(t, func(issuer string) string {
+		return fmt.Sprintf(`{
+			"issuer": %q,
+			"authorization_endpoint": "%s/auth",
+			"token_endpoint": "%s/token"
+		}`, issuer, issuer, issuer)
+	})
+
+	got, err := newDiscoverer(t).Discover(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	if got.EndSessionEndpoint != "" {
+		t.Errorf("EndSessionEndpoint = %q, want empty", got.EndSessionEndpoint)
+	}
+}
+
+func TestDiscoverRejectsAnIncompleteDocument(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"no authorization endpoint": `{"issuer": %[1]q, "token_endpoint": "%[1]s/token"}`,
+		"no token endpoint":         `{"issuer": %[1]q, "authorization_endpoint": "%[1]s/auth"}`,
+	}
+
+	for name, tpl := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := discoveryServer(t, func(issuer string) string {
+				return fmt.Sprintf(tpl, issuer)
+			})
+
+			_, err := newDiscoverer(t).Discover(context.Background(), srv.URL)
+			if !errors.Is(err, oidc.ErrDiscoveryIncomplete) {
+				t.Errorf("Discover = %v, want ErrDiscoveryIncomplete", err)
+			}
+		})
+	}
+}
+
+func TestDiscoverRejectsAnUnreachableIssuer(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := newDiscoverer(t).Discover(context.Background(), srv.URL)
+	if !errors.Is(err, oidc.ErrDiscoveryFailed) {
+		t.Errorf("Discover = %v, want ErrDiscoveryFailed", err)
+	}
+}
+
+func TestDiscoverRejectsAnIssuerMismatch(t *testing.T) {
+	t.Parallel()
+
+	srv := discoveryServer(t, func(issuer string) string {
+		return fmt.Sprintf(`{
+			"issuer": "https://elsewhere.example.com",
+			"authorization_endpoint": "%s/auth",
+			"token_endpoint": "%s/token"
+		}`, issuer, issuer)
+	})
+
+	_, err := newDiscoverer(t).Discover(context.Background(), srv.URL)
+	if !errors.Is(err, oidc.ErrDiscoveryFailed) {
+		t.Errorf("Discover = %v, want ErrDiscoveryFailed", err)
+	}
+}
+
+func TestNewValidatesDeps(t *testing.T) {
+	t.Parallel()
+
+	if _, err := oidc.New(oidc.Config{Timeout: time.Second}, oidc.Deps{}); err == nil {
+		t.Error("New without an HTTP client = nil, want an error")
+	}
+}

--- a/api/pkg/core/auth/oidcproviders/domain.go
+++ b/api/pkg/core/auth/oidcproviders/domain.go
@@ -75,3 +75,15 @@ type LightOIDCProvider struct {
 	DisplayName string
 	ID          uuid.UUID
 }
+
+type Discoverer interface {
+	Discover(ctx context.Context, issuerURL string) (*Discovery, error)
+}
+
+type Discovery struct {
+	Issuer                string
+	AuthorizationEndpoint string
+	TokenEndpoint         string
+	UserInfoEndpoint      string
+	EndSessionEndpoint    string
+}

--- a/api/pkg/core/auth/oidcproviders/domain.go
+++ b/api/pkg/core/auth/oidcproviders/domain.go
@@ -4,6 +4,7 @@ package oidcproviders
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/google/uuid"
@@ -75,6 +76,8 @@ type LightOIDCProvider struct {
 	DisplayName string
 	ID          uuid.UUID
 }
+
+var ErrIncompleteDiscovery = errors.New("discovery document is incomplete")
 
 type Discoverer interface {
 	Discover(ctx context.Context, issuerURL string) (*Discovery, error)

--- a/api/pkg/core/auth/oidcproviders/domain.go
+++ b/api/pkg/core/auth/oidcproviders/domain.go
@@ -13,6 +13,8 @@ type OIDCProvidersRepository interface {
 	GetByID(context.Context, uuid.UUID) (*OIDCProvider, error)
 	GetByIssuerURL(context.Context, string) (*OIDCProvider, error)
 	Create(context.Context, CreateOIDCProviderOpts) (*OIDCProvider, error)
+	Update(context.Context, uuid.UUID, UpdateOIDCProviderOpts) (*OIDCProvider, error)
+	DeleteByID(context.Context, uuid.UUID) error
 	GetAll(context.Context) ([]LightOIDCProvider, error)
 }
 
@@ -31,6 +33,24 @@ type OIDCProvider struct {
 	AllowedValues   []string
 	ID              uuid.UUID
 	AutoProvision   bool
+}
+
+type UpdateOIDCProviderOpts struct {
+	DisplayName string
+
+	IssuerURL       string
+	ClientID        string
+	ClientSecretEnc []byte
+	Scopes          []string
+
+	UsernameClaim string
+
+	AdminClaim  *string
+	AdminValues []string
+
+	AllowedClaim  *string
+	AllowedValues []string
+	AutoProvision bool
 }
 
 type CreateOIDCProviderOpts struct {

--- a/api/pkg/core/auth/oidcproviders/gateway/http/controller.go
+++ b/api/pkg/core/auth/oidcproviders/gateway/http/controller.go
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/httputils"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/logging"
+)
+
+type providersService interface {
+	List(ctx context.Context) ([]oidcproviders.LightOIDCProvider, error)
+	GetByID(ctx context.Context, id uuid.UUID) (*oidcproviders.OIDCProvider, error)
+	Create(ctx context.Context, opts oidcproviders.CreateOpts) (*oidcproviders.OIDCProvider, error)
+	Update(ctx context.Context, id uuid.UUID, opts oidcproviders.UpdateOpts) (*oidcproviders.OIDCProvider, error)
+	Delete(ctx context.Context, id uuid.UUID) error
+	Probe(ctx context.Context, issuerURL string) (*oidcproviders.ProbeResult, error)
+}
+
+type Config struct {
+	Endpoint    string
+	Middlewares chi.Middlewares
+}
+
+//nolint:dupl
+func (cfg *Config) Validate() error {
+	if cfg.Endpoint == "" {
+		return errors.New("endpoint is required")
+	}
+
+	if !strings.HasPrefix(cfg.Endpoint, "/") {
+		return fmt.Errorf("endpoint must start with '/', got %q", cfg.Endpoint)
+	}
+
+	hasNilMiddlewares := slices.ContainsFunc(cfg.Middlewares, func(m func(http.Handler) http.Handler) bool {
+		return m == nil
+	})
+
+	if hasNilMiddlewares {
+		return errors.New("all middlewares must not be nil")
+	}
+
+	return nil
+}
+
+type Deps struct {
+	Service providersService
+	Logger  *slog.Logger
+}
+
+func (deps *Deps) Validate() error {
+	if deps.Service == nil {
+		return errors.New("service is required")
+	}
+
+	if deps.Logger == nil {
+		return errors.New("logger is required")
+	}
+
+	return nil
+}
+
+type Controller struct {
+	deps Deps
+	cfg  Config
+}
+
+func New(cfg Config, deps Deps) (*Controller, error) {
+	var err error
+	if err = cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("cfg.Validate: %w", err)
+	}
+
+	if err = deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	deps.Logger = deps.Logger.With("component", "oidcproviders.gateway.http")
+
+	return &Controller{cfg: cfg, deps: deps}, nil
+}
+
+func (c *Controller) InitRouter(r chi.Router) {
+	r.Route(c.cfg.Endpoint, func(r chi.Router) {
+		for _, m := range c.cfg.Middlewares {
+			r.Use(m)
+		}
+
+		r.Get("/", c.list)
+		r.Post("/", c.create)
+		r.Post("/probe", c.probe)
+		r.Get("/{id}", c.get)
+		r.Put("/{id}", c.update)
+		r.Delete("/{id}", c.delete)
+	})
+}
+
+func (c *Controller) list(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	providers, err := c.deps.Service.List(ctx)
+	if err != nil {
+		c.writeServiceError(w, r, "failed to list oidc providers", err)
+
+		return
+	}
+
+	res := make([]LightProviderResponse, 0, len(providers))
+	for _, p := range providers {
+		res = append(res, LightProviderResponse{ID: p.ID.String(), DisplayName: p.DisplayName})
+	}
+
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, res)
+}
+
+func (c *Controller) get(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	id, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "id must be a valid UUID")
+
+		return
+	}
+
+	provider, err := c.deps.Service.GetByID(ctx, id)
+	if err != nil {
+		c.writeServiceError(w, r, "failed to read an oidc provider", err)
+
+		return
+	}
+
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, toProviderResponse(provider))
+}
+
+func (c *Controller) create(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	req, err := httputils.DecodeJSON[CreateProviderRequest](r)
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, err.Error())
+
+		return
+	}
+
+	provider, err := c.deps.Service.Create(ctx, oidcproviders.CreateOpts{
+		DisplayName:   req.DisplayName.String(),
+		IssuerURL:     req.IssuerURL.String(),
+		ClientID:      req.ClientID.String(),
+		ClientSecret:  req.ClientSecret.String(),
+		UsernameClaim: req.UsernameClaim.String(),
+		Scopes:        req.Scopes,
+		AdminClaim:    req.AdminClaim,
+		AdminValues:   req.AdminValues,
+		AllowedClaim:  req.AllowedClaim,
+		AllowedValues: req.AllowedValues,
+		AutoProvision: req.AutoProvision,
+	})
+	if err != nil {
+		c.writeServiceError(w, r, "failed to create an oidc provider", err)
+
+		return
+	}
+
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusCreated, toProviderResponse(provider))
+}
+
+func (c *Controller) update(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	id, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "id must be a valid UUID")
+
+		return
+	}
+
+	req, err := httputils.DecodeJSON[UpdateProviderRequest](r)
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, err.Error())
+
+		return
+	}
+
+	var secret *string
+
+	if req.ClientSecret != nil {
+		value := req.ClientSecret.String()
+		secret = &value
+	}
+
+	provider, err := c.deps.Service.Update(ctx, id, oidcproviders.UpdateOpts{
+		ClientSecret:  secret,
+		DisplayName:   req.DisplayName.String(),
+		IssuerURL:     req.IssuerURL.String(),
+		ClientID:      req.ClientID.String(),
+		UsernameClaim: req.UsernameClaim.String(),
+		Scopes:        req.Scopes,
+		AdminClaim:    req.AdminClaim,
+		AdminValues:   req.AdminValues,
+		AllowedClaim:  req.AllowedClaim,
+		AllowedValues: req.AllowedValues,
+		AutoProvision: req.AutoProvision,
+	})
+	if err != nil {
+		c.writeServiceError(w, r, "failed to update an oidc provider", err)
+
+		return
+	}
+
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, toProviderResponse(provider))
+}
+
+func (c *Controller) delete(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	id, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "id must be a valid UUID")
+
+		return
+	}
+
+	if err := c.deps.Service.Delete(ctx, id); err != nil {
+		c.writeServiceError(w, r, "failed to delete an oidc provider", err)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (c *Controller) probe(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	req, err := httputils.DecodeJSON[ProbeRequest](r)
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, err.Error())
+
+		return
+	}
+
+	result, err := c.deps.Service.Probe(ctx, req.IssuerURL.String())
+	if err != nil {
+		c.writeServiceError(w, r, "failed to probe an oidc issuer", err)
+
+		return
+	}
+
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, ProbeResponse{
+		Issuer:                    result.Issuer,
+		AuthorizationEndpoint:     result.AuthorizationEndpoint,
+		TokenEndpoint:             result.TokenEndpoint,
+		UserInfoEndpoint:          result.UserInfoEndpoint,
+		EndSessionEndpoint:        result.EndSessionEndpoint,
+		RedirectURI:               result.RedirectURI,
+		SupportsRPInitiatedLogout: result.SupportsRPInitiatedLogout,
+	})
+}
+
+func (c *Controller) writeServiceError(w http.ResponseWriter, r *http.Request, msg string, err error) {
+	switch {
+	case errors.Is(err, oidcproviders.ErrUnreachableIssuer):
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "issuer is unreachable")
+	case errors.Is(err, domain.ErrAlreadyExists):
+		httputils.WriteError(w, c.deps.Logger, http.StatusConflict, "issuer URL is already declared")
+	case errors.Is(err, domain.ErrNotFound):
+		httputils.WriteError(w, c.deps.Logger, http.StatusNotFound, "")
+	default:
+		c.deps.Logger.ErrorContext(r.Context(), msg, logging.Err(err))
+		httputils.WriteError(w, c.deps.Logger, http.StatusInternalServerError, "")
+	}
+}
+
+func toProviderResponse(p *oidcproviders.OIDCProvider) ProviderResponse {
+	return ProviderResponse{
+		CreatedAt:     p.CreatedAt,
+		UpdatedAt:     p.UpdatedAt,
+		AdminClaim:    p.AdminClaim,
+		AllowedClaim:  p.AllowedClaim,
+		ID:            p.ID.String(),
+		DisplayName:   p.DisplayName,
+		IssuerURL:     p.IssuerURL,
+		ClientID:      p.ClientID,
+		UsernameClaim: p.UsernameClaim,
+		Scopes:        p.Scopes,
+		AdminValues:   p.AdminValues,
+		AllowedValues: p.AllowedValues,
+		AutoProvision: p.AutoProvision,
+	}
+}

--- a/api/pkg/core/auth/oidcproviders/gateway/http/controller.go
+++ b/api/pkg/core/auth/oidcproviders/gateway/http/controller.go
@@ -273,6 +273,9 @@ func (c *Controller) writeServiceError(w http.ResponseWriter, r *http.Request, m
 	switch {
 	case errors.Is(err, oidcproviders.ErrUnreachableIssuer):
 		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "issuer is unreachable")
+	case errors.Is(err, oidcproviders.ErrIncompleteIssuer):
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest,
+			"issuer discovery document does not advertise the required endpoints")
 	case errors.Is(err, domain.ErrAlreadyExists):
 		httputils.WriteError(w, c.deps.Logger, http.StatusConflict, "issuer URL is already declared")
 	case errors.Is(err, domain.ErrNotFound):

--- a/api/pkg/core/auth/oidcproviders/gateway/http/controller_test.go
+++ b/api/pkg/core/auth/oidcproviders/gateway/http/controller_test.go
@@ -1,0 +1,527 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package http_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
+	providershttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
+	sessionshttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/users"
+)
+
+const (
+	endpoint        = "/oidc/providers"
+	cookieName      = "uchiyomi_session"
+	testToken       = "letoken"
+	testDisplayName = "Keycloak"
+	testIssuerURL   = "https://sso.example.com"
+
+	//nolint:lll
+	validBody = `{"displayName":"Keycloak","issuerUrl":"https://sso.example.com","clientId":"uchiyomi","clientSecret":"s3cr3t","usernameClaim":"preferred_username","scopes":["openid"],"adminClaim":null,"adminValues":null,"allowedClaim":null,"allowedValues":null,"autoProvision":true}`
+
+	//nolint:lll
+	validPutBody = `{"displayName":"Keycloak","issuerUrl":"https://sso.example.com","clientId":"uchiyomi","usernameClaim":"preferred_username","scopes":["openid"],"adminClaim":null,"adminValues":null,"allowedClaim":null,"allowedValues":null,"autoProvision":true,"clientSecret":null}`
+)
+
+var errUnexpected = errors.New("boom")
+
+type stubService struct {
+	err       error
+	provider  *oidcproviders.OIDCProvider
+	probe     *oidcproviders.ProbeResult
+	updateOpt *oidcproviders.UpdateOpts
+	list      []oidcproviders.LightOIDCProvider
+}
+
+func (s *stubService) List(context.Context) ([]oidcproviders.LightOIDCProvider, error) {
+	return s.list, s.err
+}
+
+//nolint:lll
+func (s *stubService) GetByID(context.Context, uuid.UUID) (*oidcproviders.OIDCProvider, error) {
+	return s.provider, s.err
+}
+
+//nolint:lll
+func (s *stubService) Create(context.Context, oidcproviders.CreateOpts) (*oidcproviders.OIDCProvider, error) {
+	return s.provider, s.err
+}
+
+//nolint:lll
+func (s *stubService) Update(_ context.Context, _ uuid.UUID, opts oidcproviders.UpdateOpts) (*oidcproviders.OIDCProvider, error) {
+	s.updateOpt = &opts
+
+	return s.provider, s.err
+}
+
+func (s *stubService) Delete(context.Context, uuid.UUID) error {
+	return s.err
+}
+
+func (s *stubService) Probe(context.Context, string) (*oidcproviders.ProbeResult, error) {
+	return s.probe, s.err
+}
+
+type stubSessionService struct {
+	user *users.User
+}
+
+//nolint:lll
+func (s *stubSessionService) Authenticate(_ context.Context, _ string) (*sessions.AuthenticatedSession, error) {
+	if s.user == nil {
+		return nil, sessions.ErrInvalidSession
+	}
+
+	return &sessions.AuthenticatedSession{
+		User: s.user,
+		Session: sessions.Session{
+			ID:        uuid.New(),
+			UserID:    s.user.ID,
+			ExpiresAt: time.Now().Add(time.Hour),
+		},
+	}, nil
+}
+
+func adminMiddlewares(t *testing.T, user *users.User) chi.Middlewares {
+	t.Helper()
+
+	logger := slog.New(slog.DiscardHandler)
+
+	cookies, err := sessionshttp.NewCookieManager(sessionshttp.CookieConfig{Name: cookieName, Path: "/"})
+	if err != nil {
+		t.Fatalf("NewCookieManager: %v", err)
+	}
+
+	a, err := sessionshttp.NewAuthenticator(sessionshttp.AuthenticatorDeps{
+		SessionService: &stubSessionService{user: user},
+		Cookies:        cookies,
+		Logger:         logger,
+	})
+	if err != nil {
+		t.Fatalf("NewAuthenticator: %v", err)
+	}
+
+	return chi.Middlewares{a.Middleware, a.RequireAdmin}
+}
+
+func newRouter(t *testing.T, svc *stubService, mws chi.Middlewares) chi.Router {
+	t.Helper()
+
+	c, err := providershttp.New(
+		providershttp.Config{Endpoint: endpoint, Middlewares: mws},
+		providershttp.Deps{Logger: slog.New(slog.DiscardHandler), Service: svc},
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	r := chi.NewRouter()
+	c.InitRouter(r)
+
+	return r
+}
+
+func do(r chi.Router, method, path, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	return rec
+}
+
+func sampleProvider() *oidcproviders.OIDCProvider {
+	return &oidcproviders.OIDCProvider{
+		ID:            uuid.New(),
+		DisplayName:   testDisplayName,
+		IssuerURL:     testIssuerURL,
+		ClientID:      "uchiyomi",
+		UsernameClaim: "preferred_username",
+		Scopes:        []string{"openid"},
+		AutoProvision: true,
+	}
+}
+
+func admin() *users.User {
+	return &users.User{ID: uuid.New(), Name: "root", IsAdmin: true}
+}
+
+func TestListReturnsOnlyIDAndDisplayName(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.New()
+	svc := &stubService{list: []oidcproviders.LightOIDCProvider{{ID: id, DisplayName: testDisplayName}}}
+	r := newRouter(t, svc, adminMiddlewares(t, admin()))
+
+	rec := do(r, http.MethodGet, endpoint, "")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var got []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("undecodable body (%q): %v", rec.Body.String(), err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+
+	want := map[string]bool{"id": true, "displayName": true}
+	for key := range got[0] {
+		if !want[key] {
+			t.Errorf("the list exposes %q, which belongs to the detail response", key)
+		}
+	}
+
+	if len(got[0]) != len(want) {
+		t.Errorf("%d fields in the list entry, want %d: %s", len(got[0]), len(want), rec.Body.String())
+	}
+
+	if got[0]["id"] != id.String() {
+		t.Errorf("id = %v, want %s", got[0]["id"], id)
+	}
+}
+
+func TestGetReturnsTheProviderWithoutASecret(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubService{provider: sampleProvider()}
+	r := newRouter(t, svc, adminMiddlewares(t, admin()))
+
+	rec := do(r, http.MethodGet, endpoint+"/"+uuid.New().String(), "")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("undecodable body (%q): %v", rec.Body.String(), err)
+	}
+
+	for key := range got {
+		if strings.Contains(strings.ToLower(key), "secret") {
+			t.Errorf("the response exposes a secret-looking field %q", key)
+		}
+	}
+
+	if got["issuerUrl"] != testIssuerURL {
+		t.Errorf("issuerUrl = %v, want the full provider", got["issuerUrl"])
+	}
+}
+
+func TestGetNotFound(t *testing.T) {
+	t.Parallel()
+
+	r := newRouter(t, &stubService{err: domain.ErrNotFound}, adminMiddlewares(t, admin()))
+
+	rec := do(r, http.MethodGet, endpoint+"/"+uuid.New().String(), "")
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d (body: %s)", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+}
+
+func TestGetRejectsAMalformedID(t *testing.T) {
+	t.Parallel()
+
+	r := newRouter(t, &stubService{provider: sampleProvider()}, adminMiddlewares(t, admin()))
+
+	rec := do(r, http.MethodGet, endpoint+"/not-a-uuid", "")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestListForbiddenForANonAdmin(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: "alice", IsAdmin: false}
+	r := newRouter(t, &stubService{}, adminMiddlewares(t, user))
+
+	rec := do(r, http.MethodGet, endpoint, "")
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d (body: %s)", rec.Code, http.StatusForbidden, rec.Body.String())
+	}
+}
+
+func TestEveryRouteIsForbiddenForANonAdmin(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.New().String()
+
+	tests := map[string]struct {
+		method string
+		path   string
+		body   string
+	}{
+		"list":   {method: http.MethodGet, path: endpoint},
+		"get":    {method: http.MethodGet, path: endpoint + "/" + id},
+		"create": {method: http.MethodPost, path: endpoint, body: validBody},
+		"update": {method: http.MethodPut, path: endpoint + "/" + id, body: validPutBody},
+		"delete": {method: http.MethodDelete, path: endpoint + "/" + id},
+		"probe":  {method: http.MethodPost, path: endpoint + "/probe", body: `{"issuerUrl":"https://sso.example.com"}`},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			user := &users.User{ID: uuid.New(), Name: "alice"}
+			r := newRouter(t, &stubService{}, adminMiddlewares(t, user))
+
+			rec := do(r, tc.method, tc.path, tc.body)
+
+			if rec.Code != http.StatusForbidden {
+				t.Errorf("%s %s = %d, want %d", tc.method, tc.path, rec.Code, http.StatusForbidden)
+			}
+		})
+	}
+}
+
+func TestCreateReturnsCreated(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubService{provider: sampleProvider()}
+	r := newRouter(t, svc, adminMiddlewares(t, admin()))
+
+	rec := do(r, http.MethodPost, endpoint, validBody)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+
+	var got providershttp.ProviderResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("undecodable body (%q): %v", rec.Body.String(), err)
+	}
+
+	if got.DisplayName != testDisplayName {
+		t.Errorf("displayName = %q", got.DisplayName)
+	}
+}
+
+func TestCreateRejectsAMalformedBody(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"not json":         `{`,
+		"missing fields":   `{"displayName":"Keycloak"}`,
+		"bad issuer":       `{"displayName":"K","issuerUrl":"nope","clientId":"c","clientSecret":"s","usernameClaim":"u","scopes":["openid"]}`,                           //nolint:lll
+		"unknown field":    `{"displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","clientSecret":"s","usernameClaim":"u","scopes":["openid"],"nope":1}`, //nolint:lll
+		"no scope":         `{"displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","clientSecret":"s","usernameClaim":"u","scopes":[]}`,                  //nolint:lll
+		"no client secret": `{"displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","usernameClaim":"u","scopes":["openid"]}`,                             //nolint:lll
+	}
+
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			r := newRouter(t, &stubService{provider: sampleProvider()}, adminMiddlewares(t, admin()))
+
+			rec := do(r, http.MethodPost, endpoint, body)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestCreateConflictOnADuplicateIssuer(t *testing.T) {
+	t.Parallel()
+
+	r := newRouter(t, &stubService{err: domain.ErrAlreadyExists}, adminMiddlewares(t, admin()))
+
+	rec := do(r, http.MethodPost, endpoint, validBody)
+
+	if rec.Code != http.StatusConflict {
+		t.Errorf("status = %d, want %d (body: %s)", rec.Code, http.StatusConflict, rec.Body.String())
+	}
+}
+
+func TestCreateBadRequestOnAnUnreachableIssuer(t *testing.T) {
+	t.Parallel()
+
+	r := newRouter(t, &stubService{err: oidcproviders.ErrUnreachableIssuer}, adminMiddlewares(t, admin()))
+
+	rec := do(r, http.MethodPost, endpoint, validBody)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestUpdateWithoutASecretLeavesItNil(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubService{provider: sampleProvider()}
+	r := newRouter(t, svc, adminMiddlewares(t, admin()))
+
+	rec := do(r, http.MethodPut, endpoint+"/"+uuid.New().String(), validPutBody)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	if svc.updateOpt == nil {
+		t.Fatal("the service was never called")
+	}
+
+	if svc.updateOpt.ClientSecret != nil {
+		t.Errorf("ClientSecret = %q, want nil", *svc.updateOpt.ClientSecret)
+	}
+}
+
+func TestUpdateForwardsTheSecretWhenPresent(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubService{provider: sampleProvider()}
+	r := newRouter(t, svc, adminMiddlewares(t, admin()))
+
+	//nolint:lll
+	body := `{"displayName":"Keycloak","issuerUrl":"https://sso.example.com","clientId":"uchiyomi","clientSecret":"rotated","usernameClaim":"preferred_username","scopes":["openid"],"adminClaim":null,"adminValues":null,"allowedClaim":null,"allowedValues":null,"autoProvision":true}`
+
+	rec := do(r, http.MethodPut, endpoint+"/"+uuid.New().String(), body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	if svc.updateOpt.ClientSecret == nil || *svc.updateOpt.ClientSecret != "rotated" {
+		t.Errorf("ClientSecret = %v, want \"rotated\"", svc.updateOpt.ClientSecret)
+	}
+}
+
+func TestUpdateNotFound(t *testing.T) {
+	t.Parallel()
+
+	r := newRouter(t, &stubService{err: domain.ErrNotFound}, adminMiddlewares(t, admin()))
+
+	rec := do(r, http.MethodPut, endpoint+"/"+uuid.New().String(), validPutBody)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d (body: %s)", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+}
+
+func TestUpdateRejectsAMalformedID(t *testing.T) {
+	t.Parallel()
+
+	r := newRouter(t, &stubService{provider: sampleProvider()}, adminMiddlewares(t, admin()))
+
+	rec := do(r, http.MethodPut, endpoint+"/not-a-uuid", validPutBody)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestDeleteReturnsNoContent(t *testing.T) {
+	t.Parallel()
+
+	r := newRouter(t, &stubService{}, adminMiddlewares(t, admin()))
+
+	rec := do(r, http.MethodDelete, endpoint+"/"+uuid.New().String(), "")
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusNoContent, rec.Body.String())
+	}
+
+	if rec.Body.Len() != 0 {
+		t.Errorf("body = %q, want empty", rec.Body.String())
+	}
+}
+
+func TestDeleteNotFound(t *testing.T) {
+	t.Parallel()
+
+	r := newRouter(t, &stubService{err: domain.ErrNotFound}, adminMiddlewares(t, admin()))
+
+	rec := do(r, http.MethodDelete, endpoint+"/"+uuid.New().String(), "")
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestProbeReturnsTheDiscoveredEndpoints(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubService{probe: &oidcproviders.ProbeResult{
+		Issuer:                    testIssuerURL,
+		AuthorizationEndpoint:     "https://sso.example.com/auth",
+		TokenEndpoint:             "https://sso.example.com/token",
+		EndSessionEndpoint:        "https://sso.example.com/logout",
+		RedirectURI:               "https://manga.example.com/api/auth/oidc/callback",
+		SupportsRPInitiatedLogout: true,
+	}}
+	r := newRouter(t, svc, adminMiddlewares(t, admin()))
+
+	rec := do(r, http.MethodPost, endpoint+"/probe", `{"issuerUrl":"https://sso.example.com"}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var got providershttp.ProbeResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("undecodable body (%q): %v", rec.Body.String(), err)
+	}
+
+	if !got.SupportsRPInitiatedLogout {
+		t.Error("supportsRpInitiatedLogout = false, want true")
+	}
+
+	if got.TokenEndpoint != "https://sso.example.com/token" {
+		t.Errorf("tokenEndpoint = %q", got.TokenEndpoint)
+	}
+}
+
+func TestProbeBadRequestOnAnUnreachableIssuer(t *testing.T) {
+	t.Parallel()
+
+	r := newRouter(t, &stubService{err: oidcproviders.ErrUnreachableIssuer}, adminMiddlewares(t, admin()))
+
+	rec := do(r, http.MethodPost, endpoint+"/probe", `{"issuerUrl":"https://sso.example.com"}`)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestInternalErrorIsNotLeaked(t *testing.T) {
+	t.Parallel()
+
+	r := newRouter(t, &stubService{err: errUnexpected}, adminMiddlewares(t, admin()))
+
+	rec := do(r, http.MethodGet, endpoint, "")
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+
+	if strings.Contains(rec.Body.String(), "boom") {
+		t.Errorf("the internal error leaked in the body: %s", rec.Body.String())
+	}
+}

--- a/api/pkg/core/auth/oidcproviders/gateway/http/controller_test.go
+++ b/api/pkg/core/auth/oidcproviders/gateway/http/controller_test.go
@@ -372,6 +372,22 @@ func TestCreateBadRequestOnAnUnreachableIssuer(t *testing.T) {
 	}
 }
 
+func TestCreateBadRequestOnAnIncompleteDiscoveryDocument(t *testing.T) {
+	t.Parallel()
+
+	r := newRouter(t, &stubService{err: oidcproviders.ErrIncompleteIssuer}, adminMiddlewares(t, admin()))
+
+	rec := do(r, http.MethodPost, endpoint, validBody)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+
+	if strings.Contains(rec.Body.String(), "unreachable") {
+		t.Errorf("an incomplete discovery document must not be reported as unreachable: %s", rec.Body.String())
+	}
+}
+
 func TestUpdateWithoutASecretLeavesItNil(t *testing.T) {
 	t.Parallel()
 
@@ -502,6 +518,18 @@ func TestProbeBadRequestOnAnUnreachableIssuer(t *testing.T) {
 	t.Parallel()
 
 	r := newRouter(t, &stubService{err: oidcproviders.ErrUnreachableIssuer}, adminMiddlewares(t, admin()))
+
+	rec := do(r, http.MethodPost, endpoint+"/probe", `{"issuerUrl":"https://sso.example.com"}`)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestProbeBadRequestOnAnIncompleteDiscoveryDocument(t *testing.T) {
+	t.Parallel()
+
+	r := newRouter(t, &stubService{err: oidcproviders.ErrIncompleteIssuer}, adminMiddlewares(t, admin()))
 
 	rec := do(r, http.MethodPost, endpoint+"/probe", `{"issuerUrl":"https://sso.example.com"}`)
 

--- a/api/pkg/core/auth/oidcproviders/gateway/http/dto.go
+++ b/api/pkg/core/auth/oidcproviders/gateway/http/dto.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package http
+
+import (
+	"time"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/httputils"
+)
+
+type CreateProviderRequest struct {
+	AdminClaim    *string                 `json:"adminClaim"`
+	AllowedClaim  *string                 `json:"allowedClaim"`
+	DisplayName   httputils.TrimmedString `json:"displayName" validate:"required,max=64"`
+	IssuerURL     httputils.TrimmedString `json:"issuerUrl" validate:"required,url"`
+	ClientID      httputils.TrimmedString `json:"clientId" validate:"required"`
+	ClientSecret  httputils.TrimmedString `json:"clientSecret" validate:"required"`
+	UsernameClaim httputils.TrimmedString `json:"usernameClaim" validate:"required"`
+	Scopes        []string                `json:"scopes" validate:"required,min=1,dive,required"`
+	AdminValues   []string                `json:"adminValues"`
+	AllowedValues []string                `json:"allowedValues"`
+	AutoProvision bool                    `json:"autoProvision"`
+}
+
+type UpdateProviderRequest struct {
+	AdminClaim    *string                  `json:"adminClaim"`
+	AllowedClaim  *string                  `json:"allowedClaim"`
+	ClientSecret  *httputils.TrimmedString `json:"clientSecret" validate:"omitempty,min=1"`
+	DisplayName   httputils.TrimmedString  `json:"displayName" validate:"required,max=64"`
+	IssuerURL     httputils.TrimmedString  `json:"issuerUrl" validate:"required,url"`
+	ClientID      httputils.TrimmedString  `json:"clientId" validate:"required"`
+	UsernameClaim httputils.TrimmedString  `json:"usernameClaim" validate:"required"`
+	Scopes        []string                 `json:"scopes" validate:"required,min=1,dive,required"`
+	AdminValues   []string                 `json:"adminValues"`
+	AllowedValues []string                 `json:"allowedValues"`
+	AutoProvision bool                     `json:"autoProvision"`
+}
+
+type ProbeRequest struct {
+	IssuerURL httputils.TrimmedString `json:"issuerUrl" validate:"required,url"`
+}
+
+type LightProviderResponse struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"displayName"`
+}
+
+type ProviderResponse struct {
+	CreatedAt     time.Time `json:"createdAt"`
+	UpdatedAt     time.Time `json:"updatedAt"`
+	AdminClaim    *string   `json:"adminClaim"`
+	AllowedClaim  *string   `json:"allowedClaim"`
+	ID            string    `json:"id"`
+	DisplayName   string    `json:"displayName"`
+	IssuerURL     string    `json:"issuerUrl"`
+	ClientID      string    `json:"clientId"`
+	UsernameClaim string    `json:"usernameClaim"`
+	Scopes        []string  `json:"scopes"`
+	AdminValues   []string  `json:"adminValues"`
+	AllowedValues []string  `json:"allowedValues"`
+	AutoProvision bool      `json:"autoProvision"`
+}
+
+type ProbeResponse struct {
+	Issuer                    string `json:"issuer"`
+	AuthorizationEndpoint     string `json:"authorizationEndpoint"`
+	TokenEndpoint             string `json:"tokenEndpoint"`
+	UserInfoEndpoint          string `json:"userInfoEndpoint"`
+	EndSessionEndpoint        string `json:"endSessionEndpoint"`
+	RedirectURI               string `json:"redirectUri"`
+	SupportsRPInitiatedLogout bool   `json:"supportsRpInitiatedLogout"`
+}

--- a/api/pkg/core/auth/oidcproviders/repository/pg/repository.go
+++ b/api/pkg/core/auth/oidcproviders/repository/pg/repository.go
@@ -14,7 +14,9 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/repository/pgmodels"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/transaction/pgtx"
+	"github.com/lib/pq"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 var _ oidcproviders.OIDCProvidersRepository = (*PGOIDCProvidersRepository)(nil)
@@ -81,7 +83,7 @@ func (r *PGOIDCProvidersRepository) GetByIssuerURL(ctx context.Context, issuerUR
 }
 
 func (r *PGOIDCProvidersRepository) GetAll(ctx context.Context) ([]oidcproviders.LightOIDCProvider, error) {
-	models, err := r.db(ctx).Find(ctx)
+	models, err := r.db(ctx).Order("display_name").Find(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("r.db(ctx).Find: %w", err)
 	}
@@ -122,6 +124,55 @@ func (r *PGOIDCProvidersRepository) Create(ctx context.Context, opts oidcprovide
 	p := r.modelToDomain(*model)
 
 	return &p, nil
+}
+
+//nolint:lll
+func (r *PGOIDCProvidersRepository) Update(ctx context.Context, id uuid.UUID, opts oidcproviders.UpdateOIDCProviderOpts) (*oidcproviders.OIDCProvider, error) {
+	values := map[string]any{
+		"display_name":   opts.DisplayName,
+		"issuer_url":     opts.IssuerURL,
+		"client_id":      opts.ClientID,
+		"scopes":         pq.StringArray(opts.Scopes),
+		"username_claim": opts.UsernameClaim,
+		"admin_claim":    opts.AdminClaim,
+		"admin_values":   pq.StringArray(opts.AdminValues),
+		"allowed_claim":  opts.AllowedClaim,
+		"allowed_values": pq.StringArray(opts.AllowedValues),
+		"auto_provision": opts.AutoProvision,
+		"updated_at":     time.Now(),
+	}
+
+	if opts.ClientSecretEnc != nil {
+		values["client_secret_enc"] = opts.ClientSecretEnc
+	}
+
+	rows, err := r.db(ctx).Where("id = ?", id).Set(clause.Assignments(values)).Update(ctx)
+	if err != nil {
+		if errors.Is(err, gorm.ErrDuplicatedKey) {
+			return nil, domain.ErrAlreadyExists
+		}
+
+		return nil, fmt.Errorf("r.db(ctx).Updates: %w", err)
+	}
+
+	if rows == 0 {
+		return nil, domain.ErrNotFound
+	}
+
+	return r.GetByID(ctx, id)
+}
+
+func (r *PGOIDCProvidersRepository) DeleteByID(ctx context.Context, id uuid.UUID) error {
+	rows, err := r.db(ctx).Where("id = ?", id).Delete(ctx)
+	if err != nil {
+		return fmt.Errorf("r.db(ctx).Delete: %w", err)
+	}
+
+	if rows == 0 {
+		return domain.ErrNotFound
+	}
+
+	return nil
 }
 
 func (r *PGOIDCProvidersRepository) lightModelToDomain(model pgmodels.OIDCProvider) oidcproviders.LightOIDCProvider {

--- a/api/pkg/core/auth/oidcproviders/repository/pg/repository.go
+++ b/api/pkg/core/auth/oidcproviders/repository/pg/repository.go
@@ -83,7 +83,7 @@ func (r *PGOIDCProvidersRepository) GetByIssuerURL(ctx context.Context, issuerUR
 }
 
 func (r *PGOIDCProvidersRepository) GetAll(ctx context.Context) ([]oidcproviders.LightOIDCProvider, error) {
-	models, err := r.db(ctx).Order("display_name").Find(ctx)
+	models, err := r.db(ctx).Order("display_name, id").Find(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("r.db(ctx).Find: %w", err)
 	}

--- a/api/pkg/core/auth/oidcproviders/repository/pg/repository_test.go
+++ b/api/pkg/core/auth/oidcproviders/repository/pg/repository_test.go
@@ -223,7 +223,7 @@ func TestGetAll(t *testing.T) {
 
 	id1, id2 := uuid.New(), uuid.New()
 
-	mock.ExpectQuery(`SELECT \* FROM "oidc_providers"`).
+	mock.ExpectQuery(`SELECT \* FROM "oidc_providers" ORDER BY display_name, id`).
 		WillReturnRows(
 			sqlmock.NewRows([]string{"id", colDisplayName, colClientSecretEnc}).
 				AddRow(id1, testDisplayName, []byte("secret1")).

--- a/api/pkg/core/auth/oidcproviders/repository/pg/repository_test.go
+++ b/api/pkg/core/auth/oidcproviders/repository/pg/repository_test.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders/repository/pg"
@@ -20,15 +22,19 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/repository/pgtest"
 	"github.com/lib/pq"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
 )
 
 const (
-	colDisplayName  = "display_name"
-	testDisplayName = "Keycloak"
-	scopeOpenID     = "openid"
-	scopeProfile    = "profile"
-	adminGroupValue = "admins"
-	testIssuerURL   = "https://sso.example.com"
+	colDisplayName     = "display_name"
+	colScopes          = "scopes"
+	colClientSecretEnc = "client_secret_enc"
+	testDisplayName    = "Keycloak"
+	scopeOpenID        = "openid"
+	scopeProfile       = "profile"
+	adminGroupValue    = "admins"
+	testIssuerURL      = "https://sso.example.com"
 )
 
 func duplicateKeyErr() error {
@@ -53,8 +59,8 @@ func newRepo(t *testing.T) (*pg.PGOIDCProvidersRepository, sqlmock.Sqlmock) {
 
 func providerRows(id uuid.UUID) *sqlmock.Rows {
 	return sqlmock.NewRows([]string{
-		"id", colDisplayName, "issuer_url", "client_id", "client_secret_enc",
-		"scopes", "username_claim", "admin_claim", "admin_values",
+		"id", colDisplayName, "issuer_url", "client_id", colClientSecretEnc,
+		colScopes, "username_claim", "admin_claim", "admin_values",
 		"allowed_claim", "allowed_values", "auto_provision",
 	}).AddRow(
 		id, testDisplayName, testIssuerURL, "uchiyomi", []byte("enc"),
@@ -219,7 +225,7 @@ func TestGetAll(t *testing.T) {
 
 	mock.ExpectQuery(`SELECT \* FROM "oidc_providers"`).
 		WillReturnRows(
-			sqlmock.NewRows([]string{"id", colDisplayName, "client_secret_enc"}).
+			sqlmock.NewRows([]string{"id", colDisplayName, colClientSecretEnc}).
 				AddRow(id1, testDisplayName, []byte("secret1")).
 				AddRow(id2, "Authentik", []byte("secret2")),
 		)
@@ -350,5 +356,205 @@ func TestCreateError(t *testing.T) {
 
 	if errors.Is(err, domain.ErrAlreadyExists) {
 		t.Error("une panne SQL ne doit pas être traduite en ErrAlreadyExists")
+	}
+}
+
+func TestUpdateWritesTheSecretWhenGiven(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newRepo(t)
+
+	id := uuid.New()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "oidc_providers" SET .*"client_secret_enc"`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+	mock.ExpectQuery(`SELECT \* FROM "oidc_providers" WHERE id = \$1`).
+		WithArgs(id, 1).
+		WillReturnRows(providerRows(id))
+
+	got, err := r.Update(context.Background(), id, oidcproviders.UpdateOIDCProviderOpts{
+		DisplayName:     testDisplayName,
+		IssuerURL:       testIssuerURL,
+		ClientID:        "uchiyomi",
+		ClientSecretEnc: []byte("newenc"),
+		Scopes:          []string{scopeOpenID},
+		UsernameClaim:   "preferred_username",
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	if got.ID != id {
+		t.Errorf("Update() = %+v", got)
+	}
+}
+
+func TestUpdateLeavesTheSecretAloneWhenOmitted(t *testing.T) {
+	t.Parallel()
+
+	var updateSQL string
+
+	sqlDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherFunc(
+		func(expectedSQL, actualSQL string) error {
+			if strings.HasPrefix(actualSQL, `UPDATE "oidc_providers"`) {
+				updateSQL = actualSQL
+			}
+
+			matched, matchErr := regexp.MatchString(expectedSQL, actualSQL)
+			if matchErr != nil {
+				return fmt.Errorf("regexp.MatchString: %w", matchErr)
+			}
+
+			if !matched {
+				return fmt.Errorf("actual sql %q does not match expected regexp %q", actualSQL, expectedSQL)
+			}
+
+			return nil
+		},
+	)))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("sqlmock expectations not met: %v", err)
+		}
+
+		sqlDB.Close()
+	})
+
+	db, err := gorm.Open(
+		postgres.New(postgres.Config{Conn: sqlDB, PreferSimpleProtocol: true}),
+		&gorm.Config{TranslateError: true},
+	)
+	if err != nil {
+		t.Fatalf("gorm.Open: %v", err)
+	}
+
+	r, err := pg.New(pg.Deps{DB: db})
+	if err != nil {
+		t.Fatalf("pg.New: %v", err)
+	}
+
+	id := uuid.New()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "oidc_providers" SET`).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+	mock.ExpectQuery(`SELECT \* FROM "oidc_providers"`).WillReturnRows(providerRows(id))
+
+	if _, err := r.Update(context.Background(), id, oidcproviders.UpdateOIDCProviderOpts{
+		DisplayName: testDisplayName,
+		IssuerURL:   testIssuerURL,
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	if strings.Contains(updateSQL, colClientSecretEnc) {
+		t.Errorf("Update() SET clause included %s: %s", colClientSecretEnc, updateSQL)
+	}
+}
+
+func TestUpdateNotFound(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newRepo(t)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "oidc_providers"`).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	_, err := r.Update(context.Background(), uuid.New(), oidcproviders.UpdateOIDCProviderOpts{})
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("Update = %v, want domain.ErrNotFound", err)
+	}
+}
+
+func TestUpdateDuplicate(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newRepo(t)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "oidc_providers"`).WillReturnError(duplicateKeyErr())
+	mock.ExpectRollback()
+
+	_, err := r.Update(context.Background(), uuid.New(), oidcproviders.UpdateOIDCProviderOpts{IssuerURL: testIssuerURL})
+	if !errors.Is(err, domain.ErrAlreadyExists) {
+		t.Errorf("Update = %v, want domain.ErrAlreadyExists", err)
+	}
+}
+
+func TestUpdateError(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newRepo(t)
+
+	sentinel := errors.New("disk full")
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "oidc_providers"`).WillReturnError(sentinel)
+	mock.ExpectRollback()
+
+	_, err := r.Update(context.Background(), uuid.New(), oidcproviders.UpdateOIDCProviderOpts{})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("err = %v", err)
+	}
+
+	if errors.Is(err, domain.ErrAlreadyExists) {
+		t.Error("a plain SQL failure must not be translated into domain.ErrAlreadyExists")
+	}
+
+	if errors.Is(err, domain.ErrNotFound) {
+		t.Error("a plain SQL failure must not be translated into domain.ErrNotFound")
+	}
+}
+
+func TestDeleteByID(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newRepo(t)
+
+	id := uuid.New()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`DELETE FROM "oidc_providers" WHERE id = \$1`).
+		WithArgs(id).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	if err := r.DeleteByID(context.Background(), id); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}
+
+func TestDeleteByIDNotFound(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newRepo(t)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`DELETE FROM "oidc_providers"`).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	if err := r.DeleteByID(context.Background(), uuid.New()); !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("Delete = %v, want domain.ErrNotFound", err)
+	}
+}
+
+func TestDeleteByIDError(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newRepo(t)
+
+	sentinel := errors.New("connection reset")
+	mock.ExpectBegin()
+	mock.ExpectExec(`DELETE FROM "oidc_providers"`).WillReturnError(sentinel)
+	mock.ExpectRollback()
+
+	if err := r.DeleteByID(context.Background(), uuid.New()); !errors.Is(err, sentinel) {
+		t.Errorf("err = %v", err)
 	}
 }

--- a/api/pkg/core/auth/oidcproviders/service.go
+++ b/api/pkg/core/auth/oidcproviders/service.go
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package oidcproviders
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+var ErrUnreachableIssuer = errors.New("issuer is unreachable")
+
+type Cipher interface {
+	Seal(plaintext []byte) ([]byte, error)
+}
+
+type ServiceConfig struct {
+	RedirectURI string
+}
+
+func (cfg *ServiceConfig) Validate() error {
+	if cfg.RedirectURI == "" {
+		return errors.New("redirectURI is required")
+	}
+
+	return nil
+}
+
+type ServiceDeps struct {
+	Repository OIDCProvidersRepository
+	Cipher     Cipher
+	Discoverer Discoverer
+}
+
+func (deps *ServiceDeps) Validate() error {
+	if deps.Repository == nil {
+		return errors.New("repository is required")
+	}
+
+	if deps.Cipher == nil {
+		return errors.New("cipher is required")
+	}
+
+	if deps.Discoverer == nil {
+		return errors.New("discoverer is required")
+	}
+
+	return nil
+}
+
+type CreateOpts struct {
+	DisplayName   string
+	IssuerURL     string
+	ClientID      string
+	ClientSecret  string
+	UsernameClaim string
+
+	Scopes []string
+
+	AdminClaim  *string
+	AdminValues []string
+
+	AllowedClaim  *string
+	AllowedValues []string
+	AutoProvision bool
+}
+
+type UpdateOpts struct {
+	ClientSecret *string
+
+	DisplayName   string
+	IssuerURL     string
+	ClientID      string
+	UsernameClaim string
+
+	Scopes []string
+
+	AdminClaim  *string
+	AdminValues []string
+
+	AllowedClaim  *string
+	AllowedValues []string
+	AutoProvision bool
+}
+
+type ProbeResult struct {
+	Issuer                    string
+	AuthorizationEndpoint     string
+	TokenEndpoint             string
+	UserInfoEndpoint          string
+	EndSessionEndpoint        string
+	RedirectURI               string
+	SupportsRPInitiatedLogout bool
+}
+
+type Service struct {
+	deps ServiceDeps
+	cfg  ServiceConfig
+}
+
+func NewService(cfg ServiceConfig, deps ServiceDeps) (*Service, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("cfg.Validate: %w", err)
+	}
+
+	if err := deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	return &Service{cfg: cfg, deps: deps}, nil
+}
+
+func (s *Service) List(ctx context.Context) ([]LightOIDCProvider, error) {
+	providers, err := s.deps.Repository.GetAll(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.Repository.GetAll: %w", err)
+	}
+
+	return providers, nil
+}
+
+func (s *Service) GetByID(ctx context.Context, id uuid.UUID) (*OIDCProvider, error) {
+	provider, err := s.deps.Repository.GetByID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.Repository.GetByID: %w", err)
+	}
+
+	return withoutSecret(provider), nil
+}
+
+func (s *Service) Create(ctx context.Context, opts CreateOpts) (*OIDCProvider, error) {
+	if _, err := s.discover(ctx, opts.IssuerURL); err != nil {
+		return nil, err
+	}
+
+	secretEnc, err := s.deps.Cipher.Seal([]byte(opts.ClientSecret))
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.Cipher.Seal: %w", err)
+	}
+
+	provider, err := s.deps.Repository.Create(ctx, CreateOIDCProviderOpts{
+		DisplayName:     opts.DisplayName,
+		IssuerURL:       opts.IssuerURL,
+		ClientID:        opts.ClientID,
+		ClientSecretEnc: secretEnc,
+		Scopes:          opts.Scopes,
+		UsernameClaim:   opts.UsernameClaim,
+		AdminClaim:      opts.AdminClaim,
+		AdminValues:     opts.AdminValues,
+		AllowedClaim:    opts.AllowedClaim,
+		AllowedValues:   opts.AllowedValues,
+		AutoProvision:   opts.AutoProvision,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.Repository.Create: %w", err)
+	}
+
+	return withoutSecret(provider), nil
+}
+
+func (s *Service) Update(ctx context.Context, id uuid.UUID, opts UpdateOpts) (*OIDCProvider, error) {
+	if _, err := s.discover(ctx, opts.IssuerURL); err != nil {
+		return nil, err
+	}
+
+	var secretEnc []byte
+
+	if opts.ClientSecret != nil {
+		sealed, err := s.deps.Cipher.Seal([]byte(*opts.ClientSecret))
+		if err != nil {
+			return nil, fmt.Errorf("s.deps.Cipher.Seal: %w", err)
+		}
+
+		secretEnc = sealed
+	}
+
+	provider, err := s.deps.Repository.Update(ctx, id, UpdateOIDCProviderOpts{
+		DisplayName:     opts.DisplayName,
+		IssuerURL:       opts.IssuerURL,
+		ClientID:        opts.ClientID,
+		ClientSecretEnc: secretEnc,
+		Scopes:          opts.Scopes,
+		UsernameClaim:   opts.UsernameClaim,
+		AdminClaim:      opts.AdminClaim,
+		AdminValues:     opts.AdminValues,
+		AllowedClaim:    opts.AllowedClaim,
+		AllowedValues:   opts.AllowedValues,
+		AutoProvision:   opts.AutoProvision,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.Repository.Update: %w", err)
+	}
+
+	return withoutSecret(provider), nil
+}
+
+func (s *Service) Delete(ctx context.Context, id uuid.UUID) error {
+	if err := s.deps.Repository.DeleteByID(ctx, id); err != nil {
+		return fmt.Errorf("s.deps.Repository.DeleteByID: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Service) Probe(ctx context.Context, issuerURL string) (*ProbeResult, error) {
+	discovery, err := s.discover(ctx, issuerURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ProbeResult{
+		Issuer:                    discovery.Issuer,
+		AuthorizationEndpoint:     discovery.AuthorizationEndpoint,
+		TokenEndpoint:             discovery.TokenEndpoint,
+		UserInfoEndpoint:          discovery.UserInfoEndpoint,
+		EndSessionEndpoint:        discovery.EndSessionEndpoint,
+		RedirectURI:               s.cfg.RedirectURI,
+		SupportsRPInitiatedLogout: discovery.EndSessionEndpoint != "",
+	}, nil
+}
+
+func (s *Service) discover(ctx context.Context, issuerURL string) (*Discovery, error) {
+	discovery, err := s.deps.Discoverer.Discover(ctx, issuerURL)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrUnreachableIssuer, err)
+	}
+
+	return discovery, nil
+}
+
+func withoutSecret(provider *OIDCProvider) *OIDCProvider {
+	if provider == nil {
+		return nil
+	}
+
+	provider.ClientSecretEnc = nil
+
+	return provider
+}

--- a/api/pkg/core/auth/oidcproviders/service.go
+++ b/api/pkg/core/auth/oidcproviders/service.go
@@ -10,7 +10,10 @@ import (
 	"github.com/google/uuid"
 )
 
-var ErrUnreachableIssuer = errors.New("issuer is unreachable")
+var (
+	ErrUnreachableIssuer = errors.New("issuer is unreachable")
+	ErrIncompleteIssuer  = errors.New("issuer discovery document is incomplete")
+)
 
 type Cipher interface {
 	Seal(plaintext []byte) ([]byte, error)
@@ -224,6 +227,10 @@ func (s *Service) Probe(ctx context.Context, issuerURL string) (*ProbeResult, er
 func (s *Service) discover(ctx context.Context, issuerURL string) (*Discovery, error) {
 	discovery, err := s.deps.Discoverer.Discover(ctx, issuerURL)
 	if err != nil {
+		if errors.Is(err, ErrIncompleteDiscovery) {
+			return nil, fmt.Errorf("%w: %w", ErrIncompleteIssuer, err)
+		}
+
 		return nil, fmt.Errorf("%w: %w", ErrUnreachableIssuer, err)
 	}
 

--- a/api/pkg/core/auth/oidcproviders/service_test.go
+++ b/api/pkg/core/auth/oidcproviders/service_test.go
@@ -189,6 +189,26 @@ func TestCreateRejectsAnIssuerThatFailsDiscovery(t *testing.T) {
 	}
 }
 
+func TestCreateRejectsAnIncompleteDiscoveryDocument(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepository{}
+	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{err: oidcproviders.ErrIncompleteDiscovery})
+
+	_, err := s.Create(context.Background(), createOpts())
+	if !errors.Is(err, oidcproviders.ErrIncompleteIssuer) {
+		t.Fatalf("Create = %v, want ErrIncompleteIssuer", err)
+	}
+
+	if errors.Is(err, oidcproviders.ErrUnreachableIssuer) {
+		t.Error("an incomplete document must not also read as ErrUnreachableIssuer")
+	}
+
+	if repo.created != nil {
+		t.Error("the provider was written despite the incomplete discovery document")
+	}
+}
+
 func TestCreatePropagatesADuplicateIssuer(t *testing.T) {
 	t.Parallel()
 
@@ -399,6 +419,16 @@ func TestProbeRejectsAnUnreachableIssuer(t *testing.T) {
 
 	if _, err := s.Probe(context.Background(), testIssuerURL); !errors.Is(err, oidcproviders.ErrUnreachableIssuer) {
 		t.Errorf("Probe = %v, want ErrUnreachableIssuer", err)
+	}
+}
+
+func TestProbeRejectsAnIncompleteDiscoveryDocument(t *testing.T) {
+	t.Parallel()
+
+	s := newService(t, &fakeRepository{}, &fakeCipher{}, &fakeDiscoverer{err: oidcproviders.ErrIncompleteDiscovery})
+
+	if _, err := s.Probe(context.Background(), testIssuerURL); !errors.Is(err, oidcproviders.ErrIncompleteIssuer) {
+		t.Errorf("Probe = %v, want ErrIncompleteIssuer", err)
 	}
 }
 

--- a/api/pkg/core/auth/oidcproviders/service_test.go
+++ b/api/pkg/core/auth/oidcproviders/service_test.go
@@ -1,0 +1,447 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package oidcproviders_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+)
+
+const (
+	testIssuerURL     = "https://sso.example.com"
+	testRedirect      = "https://manga.example.com/api/auth/oidc/callback"
+	testSecret        = "s3cr3t"
+	testDisplayName   = "Keycloak"
+	testClientID      = "uchiyomi"
+	testUsernameClaim = "preferred_username"
+	testScope         = "openid"
+)
+
+type fakeRepository struct {
+	created  *oidcproviders.CreateOIDCProviderOpts
+	updated  *oidcproviders.UpdateOIDCProviderOpts
+	provider *oidcproviders.OIDCProvider
+	all      []oidcproviders.LightOIDCProvider
+	err      error
+	deleted  []uuid.UUID
+}
+
+func (f *fakeRepository) GetByID(context.Context, uuid.UUID) (*oidcproviders.OIDCProvider, error) {
+	return f.provider, f.err
+}
+
+func (f *fakeRepository) GetByIssuerURL(context.Context, string) (*oidcproviders.OIDCProvider, error) {
+	return f.provider, f.err
+}
+
+//nolint:lll
+func (f *fakeRepository) Create(_ context.Context, opts oidcproviders.CreateOIDCProviderOpts) (*oidcproviders.OIDCProvider, error) {
+	f.created = &opts
+
+	return f.provider, f.err
+}
+
+//nolint:lll
+func (f *fakeRepository) Update(_ context.Context, _ uuid.UUID, opts oidcproviders.UpdateOIDCProviderOpts) (*oidcproviders.OIDCProvider, error) {
+	f.updated = &opts
+
+	return f.provider, f.err
+}
+
+func (f *fakeRepository) DeleteByID(_ context.Context, id uuid.UUID) error {
+	f.deleted = append(f.deleted, id)
+
+	return f.err
+}
+
+func (f *fakeRepository) GetAll(context.Context) ([]oidcproviders.LightOIDCProvider, error) {
+	return f.all, f.err
+}
+
+type fakeCipher struct {
+	err error
+}
+
+func (f *fakeCipher) Seal(plaintext []byte) ([]byte, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+
+	return append([]byte("sealed:"), plaintext...), nil
+}
+
+type fakeDiscoverer struct {
+	discovery *oidcproviders.Discovery
+	err       error
+	issuers   []string
+}
+
+func (f *fakeDiscoverer) Discover(_ context.Context, issuerURL string) (*oidcproviders.Discovery, error) {
+	f.issuers = append(f.issuers, issuerURL)
+
+	if f.err != nil {
+		return nil, f.err
+	}
+
+	if f.discovery != nil {
+		return f.discovery, nil
+	}
+
+	return &oidcproviders.Discovery{
+		Issuer:                issuerURL,
+		AuthorizationEndpoint: issuerURL + "/auth",
+		TokenEndpoint:         issuerURL + "/token",
+	}, nil
+}
+
+func newService(
+	t *testing.T,
+	repo *fakeRepository,
+	cipher *fakeCipher,
+	disco *fakeDiscoverer,
+) *oidcproviders.Service {
+	t.Helper()
+
+	s, err := oidcproviders.NewService(
+		oidcproviders.ServiceConfig{RedirectURI: testRedirect},
+		oidcproviders.ServiceDeps{Repository: repo, Cipher: cipher, Discoverer: disco},
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	return s
+}
+
+func createOpts() oidcproviders.CreateOpts {
+	return oidcproviders.CreateOpts{
+		DisplayName:   testDisplayName,
+		IssuerURL:     testIssuerURL,
+		ClientID:      testClientID,
+		ClientSecret:  testSecret,
+		Scopes:        []string{testScope, "profile"},
+		UsernameClaim: testUsernameClaim,
+	}
+}
+
+func TestCreateEncryptsTheClientSecret(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepository{provider: &oidcproviders.OIDCProvider{ID: uuid.New()}}
+	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{})
+
+	if _, err := s.Create(context.Background(), createOpts()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if repo.created == nil {
+		t.Fatal("the repository was never called")
+	}
+
+	if bytes.Contains(repo.created.ClientSecretEnc, []byte(testSecret)) &&
+		!bytes.HasPrefix(repo.created.ClientSecretEnc, []byte("sealed:")) {
+		t.Errorf("the secret reached the repository unencrypted: %q", repo.created.ClientSecretEnc)
+	}
+
+	if !bytes.Equal(repo.created.ClientSecretEnc, []byte("sealed:"+testSecret)) {
+		t.Errorf("ClientSecretEnc = %q, want the sealed secret", repo.created.ClientSecretEnc)
+	}
+}
+
+func TestCreateNeverReturnsTheSecret(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepository{provider: &oidcproviders.OIDCProvider{
+		ID:              uuid.New(),
+		ClientSecretEnc: []byte("sealed:s3cr3t"),
+	}}
+	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{})
+
+	got, err := s.Create(context.Background(), createOpts())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if got.ClientSecretEnc != nil {
+		t.Errorf("ClientSecretEnc = %q, want nil", got.ClientSecretEnc)
+	}
+}
+
+func TestCreateRejectsAnIssuerThatFailsDiscovery(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepository{}
+	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{err: errors.New("connection refused")})
+
+	_, err := s.Create(context.Background(), createOpts())
+	if !errors.Is(err, oidcproviders.ErrUnreachableIssuer) {
+		t.Fatalf("Create = %v, want ErrUnreachableIssuer", err)
+	}
+
+	if repo.created != nil {
+		t.Error("the provider was written despite the discovery failure")
+	}
+}
+
+func TestCreatePropagatesADuplicateIssuer(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepository{err: domain.ErrAlreadyExists}
+	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{})
+
+	if _, err := s.Create(context.Background(), createOpts()); !errors.Is(err, domain.ErrAlreadyExists) {
+		t.Errorf("Create = %v, want domain.ErrAlreadyExists", err)
+	}
+}
+
+func TestUpdateLeavesTheSecretUntouchedWhenOmitted(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepository{provider: &oidcproviders.OIDCProvider{ID: uuid.New()}}
+	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{})
+
+	_, err := s.Update(context.Background(), uuid.New(), oidcproviders.UpdateOpts{
+		DisplayName:   testDisplayName,
+		IssuerURL:     testIssuerURL,
+		ClientID:      testClientID,
+		Scopes:        []string{testScope},
+		UsernameClaim: testUsernameClaim,
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	if repo.updated == nil {
+		t.Fatal("the repository was never called")
+	}
+
+	if repo.updated.ClientSecretEnc != nil {
+		t.Errorf("ClientSecretEnc = %q, want nil so the stored secret is kept", repo.updated.ClientSecretEnc)
+	}
+}
+
+func TestUpdateEncryptsTheSecretWhenGiven(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepository{provider: &oidcproviders.OIDCProvider{ID: uuid.New()}}
+	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{})
+
+	secret := "rotated"
+
+	_, err := s.Update(context.Background(), uuid.New(), oidcproviders.UpdateOpts{
+		DisplayName:   testDisplayName,
+		IssuerURL:     testIssuerURL,
+		ClientID:      testClientID,
+		ClientSecret:  &secret,
+		Scopes:        []string{testScope},
+		UsernameClaim: testUsernameClaim,
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	if !bytes.Equal(repo.updated.ClientSecretEnc, []byte("sealed:rotated")) {
+		t.Errorf("ClientSecretEnc = %q, want the sealed secret", repo.updated.ClientSecretEnc)
+	}
+}
+
+func TestUpdateRejectsAnIssuerThatFailsDiscovery(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepository{}
+	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{err: errors.New("no such host")})
+
+	_, err := s.Update(context.Background(), uuid.New(), oidcproviders.UpdateOpts{IssuerURL: testIssuerURL})
+	if !errors.Is(err, oidcproviders.ErrUnreachableIssuer) {
+		t.Fatalf("Update = %v, want ErrUnreachableIssuer", err)
+	}
+
+	if repo.updated != nil {
+		t.Error("the provider was written despite the discovery failure")
+	}
+}
+
+func TestListReturnsTheLightShape(t *testing.T) {
+	t.Parallel()
+
+	id1, id2 := uuid.New(), uuid.New()
+	repo := &fakeRepository{all: []oidcproviders.LightOIDCProvider{
+		{ID: id1, DisplayName: "Authentik"},
+		{ID: id2, DisplayName: testDisplayName},
+	}}
+	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{})
+
+	got, err := s.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if len(got) != 2 || got[0].ID != id1 || got[1].ID != id2 {
+		t.Errorf("List() = %+v, want the repository's light providers in order", got)
+	}
+}
+
+func TestGetByIDNeverReturnsTheSecret(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepository{provider: &oidcproviders.OIDCProvider{
+		ID:              uuid.New(),
+		DisplayName:     testDisplayName,
+		ClientSecretEnc: []byte("sealed:s3cr3t"),
+	}}
+	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{})
+
+	got, err := s.GetByID(context.Background(), uuid.New())
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+
+	if got.ClientSecretEnc != nil {
+		t.Errorf("ClientSecretEnc = %q, want nil", got.ClientSecretEnc)
+	}
+
+	if got.DisplayName != testDisplayName {
+		t.Errorf("DisplayName = %q, want the rest of the provider to come through", got.DisplayName)
+	}
+}
+
+func TestGetByIDPropagatesNotFound(t *testing.T) {
+	t.Parallel()
+
+	s := newService(t, &fakeRepository{err: domain.ErrNotFound}, &fakeCipher{}, &fakeDiscoverer{})
+
+	if _, err := s.GetByID(context.Background(), uuid.New()); !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("GetByID = %v, want domain.ErrNotFound", err)
+	}
+}
+
+func TestDeleteForwardsTheID(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepository{}
+	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{})
+
+	id := uuid.New()
+	if err := s.Delete(context.Background(), id); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if len(repo.deleted) != 1 || repo.deleted[0] != id {
+		t.Errorf("deleted = %v, want [%s]", repo.deleted, id)
+	}
+}
+
+func TestDeletePropagatesNotFound(t *testing.T) {
+	t.Parallel()
+
+	s := newService(t, &fakeRepository{err: domain.ErrNotFound}, &fakeCipher{}, &fakeDiscoverer{})
+
+	if err := s.Delete(context.Background(), uuid.New()); !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("Delete = %v, want domain.ErrNotFound", err)
+	}
+}
+
+func TestProbeReportsTheEndpointsAndTheRedirectURI(t *testing.T) {
+	t.Parallel()
+
+	disco := &fakeDiscoverer{discovery: &oidcproviders.Discovery{
+		Issuer:                testIssuerURL,
+		AuthorizationEndpoint: testIssuerURL + "/auth",
+		TokenEndpoint:         testIssuerURL + "/token",
+		UserInfoEndpoint:      testIssuerURL + "/userinfo",
+		EndSessionEndpoint:    testIssuerURL + "/logout",
+	}}
+	s := newService(t, &fakeRepository{}, &fakeCipher{}, disco)
+
+	got, err := s.Probe(context.Background(), testIssuerURL)
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+
+	if !got.SupportsRPInitiatedLogout {
+		t.Error("SupportsRPInitiatedLogout = false, want true")
+	}
+
+	if got.RedirectURI != testRedirect {
+		t.Errorf("RedirectURI = %q, want %q", got.RedirectURI, testRedirect)
+	}
+
+	if got.TokenEndpoint != testIssuerURL+"/token" {
+		t.Errorf("TokenEndpoint = %q", got.TokenEndpoint)
+	}
+}
+
+func TestProbeReportsAProviderWithoutEndSession(t *testing.T) {
+	t.Parallel()
+
+	s := newService(t, &fakeRepository{}, &fakeCipher{}, &fakeDiscoverer{})
+
+	got, err := s.Probe(context.Background(), testIssuerURL)
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+
+	if got.SupportsRPInitiatedLogout {
+		t.Error("SupportsRPInitiatedLogout = true, want false")
+	}
+}
+
+func TestProbeRejectsAnUnreachableIssuer(t *testing.T) {
+	t.Parallel()
+
+	s := newService(t, &fakeRepository{}, &fakeCipher{}, &fakeDiscoverer{err: errors.New("timeout")})
+
+	if _, err := s.Probe(context.Background(), testIssuerURL); !errors.Is(err, oidcproviders.ErrUnreachableIssuer) {
+		t.Errorf("Probe = %v, want ErrUnreachableIssuer", err)
+	}
+}
+
+func TestNewServiceValidates(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		deps    oidcproviders.ServiceDeps
+		cfg     oidcproviders.ServiceConfig
+		wantErr string
+	}{
+		"no redirect uri": {
+			cfg: oidcproviders.ServiceConfig{},
+			deps: oidcproviders.ServiceDeps{
+				Repository: &fakeRepository{}, Cipher: &fakeCipher{}, Discoverer: &fakeDiscoverer{},
+			},
+			wantErr: "cfg.Validate: redirectURI is required",
+		},
+		"no repository": {
+			cfg:     oidcproviders.ServiceConfig{RedirectURI: testRedirect},
+			deps:    oidcproviders.ServiceDeps{Cipher: &fakeCipher{}, Discoverer: &fakeDiscoverer{}},
+			wantErr: "deps.Validate: repository is required",
+		},
+		"no cipher": {
+			cfg:     oidcproviders.ServiceConfig{RedirectURI: testRedirect},
+			deps:    oidcproviders.ServiceDeps{Repository: &fakeRepository{}, Discoverer: &fakeDiscoverer{}},
+			wantErr: "deps.Validate: cipher is required",
+		},
+		"no discoverer": {
+			cfg:     oidcproviders.ServiceConfig{RedirectURI: testRedirect},
+			deps:    oidcproviders.ServiceDeps{Repository: &fakeRepository{}, Cipher: &fakeCipher{}},
+			wantErr: "deps.Validate: discoverer is required",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := oidcproviders.NewService(tc.cfg, tc.deps)
+			if err == nil || err.Error() != tc.wantErr {
+				t.Errorf("NewService() = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/api/pkg/core/auth/sessions/gateway/http/middleware.go
+++ b/api/pkg/core/auth/sessions/gateway/http/middleware.go
@@ -104,3 +104,16 @@ func (a *Authenticator) Middleware(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r.WithContext(context.WithValue(ctx, userCtxKey{}, authenticated.User)))
 	})
 }
+
+func (a *Authenticator) RequireAdmin(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, ok := UserFrom(r.Context())
+		if !ok || !user.IsAdmin {
+			httputils.WriteError(w, a.deps.Logger, http.StatusForbidden, "")
+
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/api/pkg/core/auth/sessions/gateway/http/middleware_test.go
+++ b/api/pkg/core/auth/sessions/gateway/http/middleware_test.go
@@ -249,3 +249,90 @@ func TestUserFromReturnsFalseWithoutMiddleware(t *testing.T) {
 		t.Error("UserFrom a trouvé un utilisateur dans un contexte vierge")
 	}
 }
+
+func newAuthenticatorForUser(t *testing.T, user *users.User) *sessionshttp.Authenticator {
+	t.Helper()
+
+	logger, _ := testLogger()
+
+	a, err := sessionshttp.NewAuthenticator(sessionshttp.AuthenticatorDeps{
+		SessionService: &stubSessionService{result: &sessions.AuthenticatedSession{
+			User: user,
+			Session: sessions.Session{
+				ID:        uuid.New(),
+				UserID:    user.ID,
+				ExpiresAt: time.Date(2026, time.August, 9, 12, 0, 0, 0, time.UTC).Add(time.Hour),
+			},
+		}},
+		Cookies: newCookies(t, true),
+		Logger:  logger,
+	})
+	if err != nil {
+		t.Fatalf("NewAuthenticator: %v", err)
+	}
+
+	return a
+}
+
+func serveThroughAdminChain(t *testing.T, a *sessionshttp.Authenticator, withCookie bool) *httptest.ResponseRecorder {
+	t.Helper()
+
+	handler := a.Middleware(a.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	if withCookie {
+		req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	}
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	return rec
+}
+
+func TestRequireAdminAllowsAnAdmin(t *testing.T) {
+	t.Parallel()
+
+	a := newAuthenticatorForUser(t, &users.User{ID: uuid.New(), Name: "root", IsAdmin: true})
+
+	rec := serveThroughAdminChain(t, a, true)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+}
+
+func TestRequireAdminRejectsANonAdmin(t *testing.T) {
+	t.Parallel()
+
+	a := newAuthenticatorForUser(t, &users.User{ID: uuid.New(), Name: "alice", IsAdmin: false})
+
+	rec := serveThroughAdminChain(t, a, true)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d (body: %s)", rec.Code, http.StatusForbidden, rec.Body.String())
+	}
+
+	if strings.Contains(rec.Body.String(), "alice") {
+		t.Errorf("the identity leaked in the 403 body: %s", rec.Body.String())
+	}
+}
+
+func TestRequireAdminRejectsAnEmptyContext(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+
+	a := newAuthenticatorForUser(t, &users.User{ID: uuid.New(), Name: "alice", IsAdmin: true})
+	handler := a.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth"
 	httpauth "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
+	httpoidcproviders "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
 	sessionshttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/gateway/http"
 	healthhttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/health/gateway/http"
@@ -121,6 +123,35 @@ func (fakeAuthService) LoginWithPwd(context.Context, auth.LoginWithPwdOpts) (*au
 }
 
 func (fakeAuthService) CreateUserWithPwd(context.Context, auth.CreateUserWithPwdOpts) (*users.User, error) {
+	return nil, errors.New(notImplemented)
+}
+
+type fakeOIDCProvidersService struct{}
+
+func (fakeOIDCProvidersService) List(context.Context) ([]oidcproviders.LightOIDCProvider, error) {
+	return nil, nil
+}
+
+//nolint:lll
+func (fakeOIDCProvidersService) GetByID(context.Context, uuid.UUID) (*oidcproviders.OIDCProvider, error) {
+	return nil, errors.New(notImplemented)
+}
+
+//nolint:lll
+func (fakeOIDCProvidersService) Create(context.Context, oidcproviders.CreateOpts) (*oidcproviders.OIDCProvider, error) {
+	return nil, errors.New(notImplemented)
+}
+
+//nolint:lll
+func (fakeOIDCProvidersService) Update(context.Context, uuid.UUID, oidcproviders.UpdateOpts) (*oidcproviders.OIDCProvider, error) {
+	return nil, errors.New(notImplemented)
+}
+
+func (fakeOIDCProvidersService) Delete(context.Context, uuid.UUID) error {
+	return errors.New(notImplemented)
+}
+
+func (fakeOIDCProvidersService) Probe(context.Context, string) (*oidcproviders.ProbeResult, error) {
 	return nil, errors.New(notImplemented)
 }
 
@@ -230,19 +261,28 @@ func newTestApp(t *testing.T, db Database, port int) (*App, *health.Registry) {
 		t.Fatalf("healthhttp.New: %v", err)
 	}
 
+	oidcProvidersCtrl, err := httpoidcproviders.New(
+		httpoidcproviders.Config{Endpoint: "/oidc/providers"},
+		httpoidcproviders.Deps{Logger: logger, Service: fakeOIDCProvidersService{}},
+	)
+	if err != nil {
+		t.Fatalf("httpoidcproviders.New: %v", err)
+	}
+
 	app, err := New(
 		Config{ServerPort: port, AllowedOrigins: []string{"*"}},
 		Deps{
-			DB:         db,
-			SetupCtrl:  setupCtrl,
-			AuthCtrl:   authCtrl,
-			UsersCtrl:  usersCtrl,
-			AsuraCtrl:  asuraCtrl,
-			HealthCtrl: healthCtrl,
-			Logger:     logger,
-			Health:     registry,
-			Asura:      asuraApp,
-			Sessions:   sessionsApp,
+			DB:                db,
+			SetupCtrl:         setupCtrl,
+			AuthCtrl:          authCtrl,
+			UsersCtrl:         usersCtrl,
+			AsuraCtrl:         asuraCtrl,
+			HealthCtrl:        healthCtrl,
+			OIDCProvidersCtrl: oidcProvidersCtrl,
+			Logger:            logger,
+			Health:            registry,
+			Asura:             asuraApp,
+			Sessions:          sessionsApp,
 		})
 	if err != nil {
 		t.Fatalf("New: %v", err)

--- a/api/pkg/utils/crypto/cipher.go
+++ b/api/pkg/utils/crypto/cipher.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+)
+
+const KeyLen = 32
+
+var ErrInvalidCiphertext = errors.New("invalid ciphertext")
+
+type Config struct {
+	Key []byte
+}
+
+func (cfg *Config) Validate() error {
+	if len(cfg.Key) != KeyLen {
+		return fmt.Errorf("key must be %d bytes, got %d", KeyLen, len(cfg.Key))
+	}
+
+	return nil
+}
+
+type Cipher struct {
+	aead cipher.AEAD
+}
+
+func New(cfg Config) (*Cipher, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("cfg.Validate: %w", err)
+	}
+
+	block, err := aes.NewCipher(cfg.Key)
+	if err != nil {
+		return nil, fmt.Errorf("aes.NewCipher: %w", err)
+	}
+
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("cipher.NewGCM: %w", err)
+	}
+
+	return &Cipher{aead: aead}, nil
+}
+
+func (c *Cipher) Seal(plaintext []byte) ([]byte, error) {
+	nonce := make([]byte, c.aead.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("io.ReadFull: %w", err)
+	}
+
+	return c.aead.Seal(nonce, nonce, plaintext, nil), nil
+}
+
+func (c *Cipher) Open(ciphertext []byte) ([]byte, error) {
+	nonceSize := c.aead.NonceSize()
+	if len(ciphertext) < nonceSize {
+		return nil, ErrInvalidCiphertext
+	}
+
+	plaintext, err := c.aead.Open(nil, ciphertext[:nonceSize], ciphertext[nonceSize:], nil)
+	if err != nil {
+		return nil, ErrInvalidCiphertext
+	}
+
+	return plaintext, nil
+}

--- a/api/pkg/utils/crypto/cipher_test.go
+++ b/api/pkg/utils/crypto/cipher_test.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package crypto_test
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/crypto"
+)
+
+func testKey() []byte {
+	key := make([]byte, crypto.KeyLen)
+	for i := range key {
+		key[i] = byte(i)
+	}
+
+	return key
+}
+
+func newCipher(t *testing.T) *crypto.Cipher {
+	t.Helper()
+
+	c, err := crypto.New(crypto.Config{Key: testKey()})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	return c
+}
+
+func TestNewRejectsKeysOfTheWrongLength(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]int{"empty": 0, "too short": 16, "too long": 64}
+
+	for name, size := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := crypto.New(crypto.Config{Key: make([]byte, size)})
+			if err == nil {
+				t.Fatalf("New(%d bytes) = nil, want an error", size)
+			}
+
+			if c != nil {
+				t.Error("New returned a cipher alongside the error")
+			}
+		})
+	}
+}
+
+func TestSealOpenRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	c := newCipher(t)
+	plaintext := []byte("s3cr3t")
+
+	sealed, err := c.Seal(plaintext)
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	if bytes.Contains(sealed, plaintext) {
+		t.Error("the plaintext appears verbatim in the ciphertext")
+	}
+
+	got, err := c.Open(sealed)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	if !bytes.Equal(got, plaintext) {
+		t.Errorf("Open() = %q, want %q", got, plaintext)
+	}
+}
+
+func TestSealIsNotDeterministic(t *testing.T) {
+	t.Parallel()
+
+	c := newCipher(t)
+
+	first, err := c.Seal([]byte("same"))
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	second, err := c.Seal([]byte("same"))
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	if bytes.Equal(first, second) {
+		t.Error("two seals of the same plaintext produced the same ciphertext")
+	}
+}
+
+func TestOpenRejectsTamperedCiphertext(t *testing.T) {
+	t.Parallel()
+
+	c := newCipher(t)
+
+	sealed, err := c.Seal([]byte("s3cr3t"))
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	tampered := bytes.Clone(sealed)
+	tampered[len(tampered)-1] ^= 0xff
+
+	if _, err := c.Open(tampered); !errors.Is(err, crypto.ErrInvalidCiphertext) {
+		t.Errorf("Open(tampered) = %v, want ErrInvalidCiphertext", err)
+	}
+}
+
+func TestOpenRejectsTruncatedCiphertext(t *testing.T) {
+	t.Parallel()
+
+	c := newCipher(t)
+
+	if _, err := c.Open([]byte("short")); !errors.Is(err, crypto.ErrInvalidCiphertext) {
+		t.Errorf("Open(short) = %v, want ErrInvalidCiphertext", err)
+	}
+}
+
+func TestOpenRejectsAnotherKeysCiphertext(t *testing.T) {
+	t.Parallel()
+
+	sealed, err := newCipher(t).Seal([]byte("s3cr3t"))
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	other, err := crypto.New(crypto.Config{Key: make([]byte, crypto.KeyLen)})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if _, err := other.Open(sealed); !errors.Is(err, crypto.ErrInvalidCiphertext) {
+		t.Errorf("Open(other key) = %v, want ErrInvalidCiphertext", err)
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       PORT: 3000
       CORS_ORIGINS: ${CORS_ORIGINS:-}
       PUBLIC_URL: ${PUBLIC_URL:-http://localhost:3000}
-      OIDC_ENCRYPTION_KEY: "${OIDC_ENCRYPTION_KEY:-YG6a9pnUcmSbP20o15twaWqp6fiYAgq7AGa0xJ4H9x8=}"
+      OIDC_ENCRYPTION_KEY: "${OIDC_ENCRYPTION_KEY:?set OIDC_ENCRYPTION_KEY, e.g. openssl rand -base64 32}"
     healthcheck:
       test: ["CMD", "/uichiyomiserver", "-healthcheck"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
       LOG_LEVEL: ${LOG_LEVEL:-info}
       PORT: 3000
       CORS_ORIGINS: ${CORS_ORIGINS:-}
+      PUBLIC_URL: ${PUBLIC_URL:-http://localhost:3000}
+      OIDC_ENCRYPTION_KEY: "${OIDC_ENCRYPTION_KEY:-YG6a9pnUcmSbP20o15twaWqp6fiYAgq7AGa0xJ4H9x8=}"
     healthcheck:
       test: ["CMD", "/uichiyomiserver", "-healthcheck"]
       interval: 10s


### PR DESCRIPTION
Adds the admin half of OIDC provider configuration, plus the two pieces the rest
of the milestone depends on: an AES-256-GCM cipher for the client secrets and an
admin-only middleware next to the session authenticator.

## Routes

All of them sit behind `Authenticator.Middleware` then `Authenticator.RequireAdmin`.

| Method | Path | Answer |
|---|---|---|
| GET | `/api/oidc/providers` | `[{ id, displayName }]` for the admin table |
| GET | `/api/oidc/providers/{id}` | one provider, without its secret |
| POST | `/api/oidc/providers` | `201`, `409` on a duplicate issuer |
| PUT | `/api/oidc/providers/{id}` | `200`, the stored secret is kept when the body omits it |
| DELETE | `/api/oidc/providers/{id}` | `204`, cascading on the federated identities |
| POST | `/api/oidc/providers/probe` | the discovered endpoints, whether RP-initiated logout is advertised, and the redirect URI to register at the IdP |

There is deliberately no full-list read: the table uses the light shape and the
editor loads one provider at a time, so no route ever returns every provider's
issuer, client ID and claim mapping at once.

An issuer whose discovery document cannot be fetched is refused on create,
update and probe; one that is reachable but advertises no authorization or token
endpoint is refused with a distinct message, so the admin is not sent to debug
the network.

The client secret is sealed with AES-256-GCM before it reaches the database and
is never returned on a read — no response DTO carries a field for it.

## Configuration

Two new required variables, documented in `CONTRIBUTING.md` and `docker-compose.yml`:

- `OIDC_ENCRYPTION_KEY` — 32 bytes in base64, `openssl rand -base64 32`. Rotating
  it makes the stored secrets unreadable. Compose refuses to start without it.
- `PUBLIC_URL` — the externally reachable base URL. It cannot be derived from the
  request `Host`, which the client controls, and it is what the redirect URI is
  built from.

Both are validated at startup: the key is base64-decoded and length-checked, and
`PUBLIC_URL` must have an http or https scheme and a host.

## Also in this branch

`setupApp` never passed the auth service to `setupCtrls`, so the server refused
to start on `authService is required`. Fixed here because nothing else in the
branch was testable end to end otherwise.

## Verification

`go build ./...`, `go test ./...` (658 tests) and `golangci-lint run ./...` are
green. The routes were also exercised against a running server: `401`
unauthenticated, `403` for an authenticated non-admin, `200` with an admin
session, and a probe against `accounts.google.com` returning Google's endpoints
and the expected redirect URI.

No screenshot: the change is API-only. The settings page consuming it is a
separate ticket.

Closes #3
