### PR TITLE
Name JSON keys in validation error messages

### DIFF
--- a/api/pkg/utils/httputils/dto.go
+++ b/api/pkg/utils/httputils/dto.go
@@ -23,11 +23,25 @@ func DecodeJSON[T any](r *http.Request) (*T, error) {
 		return nil, errors.New("invalid request body")
 	}
 
-	if err := validator.New(validator.WithRequiredStructEnabled()).Struct(&v); err != nil {
+	if err := newValidator().Struct(&v); err != nil {
 		return nil, formatValidationErr(err)
 	}
 
 	return &v, nil
+}
+
+func newValidator() *validator.Validate {
+	v := validator.New(validator.WithRequiredStructEnabled())
+	v.RegisterTagNameFunc(func(fld reflect.StructField) string {
+		name, _, _ := strings.Cut(fld.Tag.Get("json"), ",")
+		if name == "-" {
+			return ""
+		}
+
+		return name
+	})
+
+	return v
 }
 
 type TrimmedString string

--- a/api/pkg/utils/httputils/dto_test.go
+++ b/api/pkg/utils/httputils/dto_test.go
@@ -17,6 +17,10 @@ type taggedRequest struct {
 	UsernameClaim string `json:"usernameClaim,omitempty" validate:"omitempty,oneof=sub email"`
 }
 
+type sliceRequest struct {
+	Scopes []string `json:"scopes" validate:"required,min=1,dive,required"`
+}
+
 type untaggedRequest struct {
 	IssuerURL string `validate:"required,url"`
 }
@@ -40,23 +44,23 @@ func TestDecodeJSONNamesTheJSONKey(t *testing.T) {
 		body    string
 		wantErr string
 	}{
-		"url invalide": {
+		"invalid url": {
 			body:    `{"issuerUrl":"nope","clientSecret":"averylongsecret"}`,
 			wantErr: "issuerUrl must be a valid URL",
 		},
-		"champ manquant": {
+		"missing field": {
 			body:    `{"issuerUrl":"https://idp.example.com"}`,
 			wantErr: "clientSecret is required",
 		},
-		"longueur minimale": {
+		"below min length": {
 			body:    `{"issuerUrl":"https://idp.example.com","clientSecret":"short"}`,
 			wantErr: "clientSecret must be at least 8 characters",
 		},
-		"valeur hors liste": {
+		"value outside oneof": {
 			body:    `{"issuerUrl":"https://idp.example.com","clientSecret":"averylongsecret","usernameClaim":"name"}`,
 			wantErr: "usernameClaim must be one of: sub, email",
 		},
-		"erreurs cumulées": {
+		"several errors joined": {
 			body:    `{}`,
 			wantErr: "issuerUrl is required, clientSecret is required",
 		},
@@ -78,12 +82,40 @@ func TestDecodeJSONNamesTheJSONKey(t *testing.T) {
 	}
 }
 
+func TestDecodeJSONNamesTheJSONKeyInsideSlices(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		body    string
+		wantErr string
+	}{
+		"empty element": {body: `{"scopes":["openid",""]}`, wantErr: "scopes[1] is required"},
+		"empty slice":   {body: `{"scopes":[]}`, wantErr: "scopes must be at least 1"},
+		"missing key":   {body: `{}`, wantErr: "scopes is required"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := decode[sliceRequest](t, tc.body)
+			if err == nil {
+				t.Fatalf("DecodeJSON(%s) = nil, want %q", tc.body, tc.wantErr)
+			}
+
+			if got := err.Error(); got != tc.wantErr {
+				t.Errorf("err = %q, want %q", got, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestDecodeJSONFallsBackToTheGoFieldWithoutJSONTag(t *testing.T) {
 	t.Parallel()
 
 	_, err := decode[untaggedRequest](t, `{}`)
 	if err == nil {
-		t.Fatal("DecodeJSON({}) = nil, want une erreur de validation")
+		t.Fatal("DecodeJSON({}) = nil, want a validation error")
 	}
 
 	if want := "IssuerURL is required"; err.Error() != want {
@@ -96,7 +128,7 @@ func TestDecodeJSONFallsBackToTheGoFieldOnDashTag(t *testing.T) {
 
 	_, err := decode[skippedRequest](t, `{}`)
 	if err == nil {
-		t.Fatal("DecodeJSON({}) = nil, want une erreur de validation")
+		t.Fatal("DecodeJSON({}) = nil, want a validation error")
 	}
 
 	if want := "Internal is required"; err.Error() != want {
@@ -121,9 +153,9 @@ func TestDecodeJSONRejectsMalformedBody(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]string{
-		"json invalide": `{`,
-		"champ inconnu": `{"issuerUrl":"https://idp.example.com","clientSecret":"averylongsecret","nope":1}`,
-		"corps vide":    ``,
+		"malformed json": `{`,
+		"unknown field":  `{"issuerUrl":"https://idp.example.com","clientSecret":"averylongsecret","nope":1}`,
+		"empty body":     ``,
 	}
 
 	for name, body := range tests {
@@ -132,7 +164,7 @@ func TestDecodeJSONRejectsMalformedBody(t *testing.T) {
 
 			_, err := decode[taggedRequest](t, body)
 			if err == nil {
-				t.Fatalf("DecodeJSON(%q) = nil, want une erreur", body)
+				t.Fatalf("DecodeJSON(%q) = nil, want an error", body)
 			}
 
 			if want := "invalid request body"; err.Error() != want {

--- a/api/pkg/utils/httputils/dto_test.go
+++ b/api/pkg/utils/httputils/dto_test.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package httputils_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/httputils"
+)
+
+type taggedRequest struct {
+	IssuerURL     string `json:"issuerUrl"     validate:"required,url"`
+	ClientSecret  string `json:"clientSecret"  validate:"required,min=8"`
+	UsernameClaim string `json:"usernameClaim,omitempty" validate:"omitempty,oneof=sub email"`
+}
+
+type untaggedRequest struct {
+	IssuerURL string `validate:"required,url"`
+}
+
+type skippedRequest struct {
+	Internal string `json:"-" validate:"required"`
+}
+
+func decode[T any](t *testing.T, body string) (*T, error) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+
+	return httputils.DecodeJSON[T](req)
+}
+
+func TestDecodeJSONNamesTheJSONKey(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		body    string
+		wantErr string
+	}{
+		"url invalide": {
+			body:    `{"issuerUrl":"nope","clientSecret":"averylongsecret"}`,
+			wantErr: "issuerUrl must be a valid URL",
+		},
+		"champ manquant": {
+			body:    `{"issuerUrl":"https://idp.example.com"}`,
+			wantErr: "clientSecret is required",
+		},
+		"longueur minimale": {
+			body:    `{"issuerUrl":"https://idp.example.com","clientSecret":"short"}`,
+			wantErr: "clientSecret must be at least 8 characters",
+		},
+		"valeur hors liste": {
+			body:    `{"issuerUrl":"https://idp.example.com","clientSecret":"averylongsecret","usernameClaim":"name"}`,
+			wantErr: "usernameClaim must be one of: sub, email",
+		},
+		"erreurs cumulées": {
+			body:    `{}`,
+			wantErr: "issuerUrl is required, clientSecret is required",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := decode[taggedRequest](t, tc.body)
+			if err == nil {
+				t.Fatalf("DecodeJSON(%s) = nil, want %q", tc.body, tc.wantErr)
+			}
+
+			if got := err.Error(); got != tc.wantErr {
+				t.Errorf("err = %q, want %q", got, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestDecodeJSONFallsBackToTheGoFieldWithoutJSONTag(t *testing.T) {
+	t.Parallel()
+
+	_, err := decode[untaggedRequest](t, `{}`)
+	if err == nil {
+		t.Fatal("DecodeJSON({}) = nil, want une erreur de validation")
+	}
+
+	if want := "IssuerURL is required"; err.Error() != want {
+		t.Errorf("err = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestDecodeJSONFallsBackToTheGoFieldOnDashTag(t *testing.T) {
+	t.Parallel()
+
+	_, err := decode[skippedRequest](t, `{}`)
+	if err == nil {
+		t.Fatal("DecodeJSON({}) = nil, want une erreur de validation")
+	}
+
+	if want := "Internal is required"; err.Error() != want {
+		t.Errorf("err = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestDecodeJSONValidBody(t *testing.T) {
+	t.Parallel()
+
+	got, err := decode[taggedRequest](t, `{"issuerUrl":"https://idp.example.com","clientSecret":"averylongsecret"}`)
+	if err != nil {
+		t.Fatalf("DecodeJSON = %v, want nil", err)
+	}
+
+	if got.IssuerURL != "https://idp.example.com" {
+		t.Errorf("IssuerURL = %q, want %q", got.IssuerURL, "https://idp.example.com")
+	}
+}
+
+func TestDecodeJSONRejectsMalformedBody(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"json invalide": `{`,
+		"champ inconnu": `{"issuerUrl":"https://idp.example.com","clientSecret":"averylongsecret","nope":1}`,
+		"corps vide":    ``,
+	}
+
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := decode[taggedRequest](t, body)
+			if err == nil {
+				t.Fatalf("DecodeJSON(%q) = nil, want une erreur", body)
+			}
+
+			if want := "invalid request body"; err.Error() != want {
+				t.Errorf("err = %q, want %q", err.Error(), want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #11.

A rejected request body named the Go struct field instead of the JSON key the
client sent, so a form could only show the message globally:

```json
{"message":"IssuerURL must be a valid URL"}
```

`httputils.DecodeJSON` now builds its validator with a `TagNameFunc` reading the
`json` struct tag, so the same request answers `issuerUrl must be a valid URL`.
The fix sits in `httputils` and covers every controller that decodes a body.

A field with no `json` tag, or one tagged `-`, returns an empty name from the
tag function, which makes the validator fall back to the Go field name rather
than producing an empty message. Message formats are otherwise untouched.

Tests cover a tagged field for each supported tag, the slice/`dive` case
(`scopes[1] is required`), an untagged field and a field tagged `-`, plus the
malformed-body paths.

`go build ./...`, `go test ./...` and `golangci-lint run ./...` are green.
