### PR TITLE
Sign in with an OIDC provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,6 @@ docs/design
 .claude
 .conductor
 **/dist
+
 **/CLAUDE.md
+**/cursor.md

--- a/api/cmd/uichiyomiserver/setup.go
+++ b/api/cmd/uichiyomiserver/setup.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/transaction/pgtx"
 
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth"
+	pgfederatedidentities "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/federatedidentities/repository/pg"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/hash/bcrypthash"
 	pgpwd "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/password/repository/pg"
 	httpauth "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/gateway/http"
@@ -114,12 +115,13 @@ func setupApp(cfg *cfg) (*core.App, error) {
 }
 
 type dbRelated struct {
-	PGDB                    *database.PGDB
-	Txor                    *pgtx.PGTransactor
-	UsersRepository         *pgusers.PGUsersRepository
-	SessionsRepository      *pgsessions.PGSessionsRepository
-	PwdRepository           *pgpwd.PGPasswordCredsRepository
-	OIDCProvidersRepository *pgoidcproviders.PGOIDCProvidersRepository
+	PGDB                          *database.PGDB
+	Txor                          *pgtx.PGTransactor
+	UsersRepository               *pgusers.PGUsersRepository
+	SessionsRepository            *pgsessions.PGSessionsRepository
+	PwdRepository                 *pgpwd.PGPasswordCredsRepository
+	OIDCProvidersRepository       *pgoidcproviders.PGOIDCProvidersRepository
+	FederatedIdentitiesRepository *pgfederatedidentities.PGFederatedIdentitiesRepository
 }
 
 func setupDBRelated(c *cfg, logger *slog.Logger) (*dbRelated, error) {
@@ -164,13 +166,19 @@ func setupDBRelated(c *cfg, logger *slog.Logger) (*dbRelated, error) {
 		return nil, fmt.Errorf("failed to init oidcProvidersRepository: %w", err)
 	}
 
+	federatedIdentitiesRepository, err := pgfederatedidentities.New(pgfederatedidentities.Deps{DB: pgdb.DB})
+	if err != nil {
+		return nil, fmt.Errorf("failed to init federatedIdentitiesRepository: %w", err)
+	}
+
 	dbr := &dbRelated{
-		PGDB:                    pgdb,
-		Txor:                    txor,
-		UsersRepository:         usersRepository,
-		SessionsRepository:      sessionsRepository,
-		PwdRepository:           pwdRepository,
-		OIDCProvidersRepository: oidcProvidersRepository,
+		PGDB:                          pgdb,
+		Txor:                          txor,
+		UsersRepository:               usersRepository,
+		SessionsRepository:            sessionsRepository,
+		PwdRepository:                 pwdRepository,
+		OIDCProvidersRepository:       oidcProvidersRepository,
+		FederatedIdentitiesRepository: federatedIdentitiesRepository,
 	}
 
 	return dbr, nil
@@ -214,13 +222,43 @@ func setupServices(deps servicesDeps) (*services, error) {
 		return nil, fmt.Errorf("failed to init hashSvc: %w", err)
 	}
 
-	authSvc, err := auth.New(auth.Deps{
-		Transactor:      deps.DBr.Txor,
-		UsersRepository: deps.DBr.UsersRepository,
-		PwdRepository:   deps.DBr.PwdRepository,
-		HashService:     hashSvc,
-		SessionService:  sessionsSvc,
-	})
+	cipher, err := crypto.New(crypto.Config{Key: deps.EncryptionKey})
+	if err != nil {
+		return nil, fmt.Errorf("failed to init cipher: %w", err)
+	}
+
+	discoverer, err := oidc.New(
+		oidc.Config{Timeout: 10 * time.Second},
+		oidc.Deps{HTTPClient: &http.Client{Timeout: 10 * time.Second}},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init discoverer: %w", err)
+	}
+
+	oidcClient, err := oidc.NewClient(
+		oidc.ClientConfig{Timeout: 10 * time.Second, CacheTTL: 15 * time.Minute},
+		oidc.ClientDeps{HTTPClient: &http.Client{Timeout: 10 * time.Second}, Cipher: cipher},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init oidcClient: %w", err)
+	}
+
+	redirectURI := deps.PublicURL + oidcCallbackPath
+
+	authSvc, err := auth.New(
+		auth.Config{RedirectURI: redirectURI, StateCookieTTL: 10 * time.Minute},
+		auth.Deps{
+			Transactor:                    deps.DBr.Txor,
+			UsersRepository:               deps.DBr.UsersRepository,
+			PwdRepository:                 deps.DBr.PwdRepository,
+			HashService:                   hashSvc,
+			SessionService:                sessionsSvc,
+			OIDCProvidersRepository:       deps.DBr.OIDCProvidersRepository,
+			FederatedIdentitiesRepository: deps.DBr.FederatedIdentitiesRepository,
+			OIDCClient:                    oidcClient,
+			StateCipher:                   cipher,
+		},
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to init authSvc: %w", err)
 	}
@@ -235,25 +273,13 @@ func setupServices(deps servicesDeps) (*services, error) {
 		return nil, fmt.Errorf("failed to init setupSvc: %w", err)
 	}
 
-	cipher, err := crypto.New(crypto.Config{Key: deps.EncryptionKey})
-	if err != nil {
-		return nil, fmt.Errorf("failed to init cipher: %w", err)
-	}
-
-	discoverer, err := oidc.New(
-		oidc.Config{Timeout: 10 * time.Second},
-		oidc.Deps{HTTPClient: &http.Client{Timeout: 10 * time.Second}},
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to init discoverer: %w", err)
-	}
-
 	oidcProvidersSvc, err := oidcproviders.NewService(
-		oidcproviders.ServiceConfig{RedirectURI: deps.PublicURL + oidcCallbackPath},
+		oidcproviders.ServiceConfig{RedirectURI: redirectURI},
 		oidcproviders.ServiceDeps{
 			Repository: deps.DBr.OIDCProvidersRepository,
 			Cipher:     cipher,
 			Discoverer: discoverer,
+			Cache:      oidcClient,
 		},
 	)
 	if err != nil {
@@ -462,6 +488,15 @@ func setupCtrls(deps ctrlsDeps) (*ctrls, error) {
 		return nil, fmt.Errorf("failed to init cookiesManager: %w", err)
 	}
 
+	oidcStateCookiesMgr, err := httpsession.NewCookieManager(httpsession.CookieConfig{
+		Name:   "uchiyomi_oidc_state",
+		Path:   "/api/auth/oidc",
+		Secure: false, //TODO: update that at release
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to init oidcStateCookiesManager: %w", err)
+	}
+
 	authenticator, err := httpsession.NewAuthenticator(httpsession.AuthenticatorDeps{
 		SessionService: deps.SessionsService,
 		Cookies:        cookiesMgr,
@@ -506,9 +541,11 @@ func setupCtrls(deps ctrlsDeps) (*ctrls, error) {
 	authCtrl, err := httpauth.New(
 		httpauth.Config{Endpoint: "/auth"},
 		httpauth.Deps{
-			AuthService: deps.AuthService,
-			Cookies:     cookiesMgr,
-			Logger:      deps.Logger,
+			AuthService:      deps.AuthService,
+			Cookies:          cookiesMgr,
+			OIDCStateCookies: oidcStateCookiesMgr,
+			ProvidersLister:  deps.OIDCProvidersService,
+			Logger:           deps.Logger,
 		},
 	)
 	if err != nil {

--- a/api/cmd/uichiyomiserver/setup.go
+++ b/api/cmd/uichiyomiserver/setup.go
@@ -257,6 +257,7 @@ func setupServices(deps servicesDeps) (*services, error) {
 			FederatedIdentitiesRepository: deps.DBr.FederatedIdentitiesRepository,
 			OIDCClient:                    oidcClient,
 			StateCipher:                   cipher,
+			Logger:                        deps.Logger,
 		},
 	)
 	if err != nil {

--- a/api/cmd/uichiyomiserver/setup_internal_test.go
+++ b/api/cmd/uichiyomiserver/setup_internal_test.go
@@ -69,6 +69,10 @@ func (noopDiscoverer) Discover(context.Context, string) (*oidcproviders.Discover
 	return nil, errors.New("not implemented")
 }
 
+type noopCacheEvictor struct{}
+
+func (noopCacheEvictor) Evict(uuid.UUID) {}
+
 func newTestOIDCProvidersService(t *testing.T) *oidcproviders.Service {
 	t.Helper()
 
@@ -78,6 +82,7 @@ func newTestOIDCProvidersService(t *testing.T) *oidcproviders.Service {
 			Repository: emptyOIDCProvidersRepository{},
 			Cipher:     noopCipher{},
 			Discoverer: noopDiscoverer{},
+			Cache:      noopCacheEvictor{},
 		},
 	)
 	if err != nil {

--- a/api/go.mod
+++ b/api/go.mod
@@ -8,12 +8,14 @@ require (
 	github.com/coreos/go-oidc/v3 v3.20.0
 	github.com/go-chi/chi/v5 v5.3.1
 	github.com/go-chi/cors v1.2.2
+	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-playground/validator/v10 v10.30.3
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/lib/pq v1.12.3
 	github.com/lmittmann/tint v1.2.0
 	golang.org/x/crypto v0.54.0
+	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/time v0.15.0
 	gorm.io/driver/postgres v1.6.2
@@ -22,7 +24,6 @@ require (
 
 require (
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -31,7 +32,6 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 )

--- a/api/pkg/core/app_internal_test.go
+++ b/api/pkg/core/app_internal_test.go
@@ -27,6 +27,26 @@ func TestRouterMountsTheOIDCProvidersRoutes(t *testing.T) {
 	}
 }
 
+func TestRouterMountsTheOIDCCallbackAdvertisedAsRedirectURI(t *testing.T) {
+	t.Parallel()
+
+	app, registry := newTestApp(t, &fakeDB{}, gatePort)
+	registry.Set(componentMigrations, nil)
+
+	req := httptest.NewRequest(http.MethodGet, APIPrefix+"/auth/oidc/callback", nil)
+	rec := httptest.NewRecorder()
+
+	app.newRouter(nil).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("GET %s/auth/oidc/callback = %d, want %d", APIPrefix, rec.Code, http.StatusFound)
+	}
+
+	if loc := rec.Header().Get("Location"); loc != "/login?error=oidcUnavailable" {
+		t.Errorf("Location = %q, want the callback handler's redirect", loc)
+	}
+}
+
 func TestRunComponentMarksOKBeforeEnteringTheLoop(t *testing.T) {
 	reg := health.NewRegistry(componentAsura)
 	a := &App{deps: Deps{Health: reg}}

--- a/api/pkg/core/auth/domain.go
+++ b/api/pkg/core/auth/domain.go
@@ -5,7 +5,9 @@ package auth
 import (
 	"context"
 	"errors"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/users"
 )
@@ -14,6 +16,8 @@ type AuthService interface {
 	LoginWithPwd(context.Context, LoginWithPwdOpts) (*LoginResult, error)
 	CreateUserWithPwd(context.Context, CreateUserWithPwdOpts) (*users.User, error)
 	Logout(context.Context, string) error
+	StartOIDCLogin(context.Context, StartOIDCLoginOpts) (*OIDCStart, error)
+	FinishOIDCLogin(context.Context, FinishOIDCLoginOpts) (*OIDCLoginResult, error)
 }
 
 type LoginResult struct {
@@ -32,6 +36,34 @@ type LoginWithPwdOpts struct {
 	Password string
 }
 
+type StartOIDCLoginOpts struct {
+	Redirect   string
+	ProviderID uuid.UUID
+}
+
+type OIDCStart struct {
+	ExpiresAt        time.Time
+	AuthCodeURL      string
+	StateCookieValue string
+}
+
+type FinishOIDCLoginOpts struct {
+	Code             string
+	State            string
+	ErrorParam       string
+	StateCookieValue string
+}
+
+type OIDCLoginResult struct {
+	Session  *sessions.IssuedSession
+	Redirect string
+}
+
 var (
 	ErrInvalidLoginPwd = errors.New("invalid login/password")
+	ErrOIDCState       = errors.New("oidc state is missing, expired or invalid")
+	ErrOIDCDenied      = errors.New("oidc provider denied the request")
+	ErrOIDCNotAllowed  = errors.New("oidc claims do not satisfy the allowed values")
+	ErrOIDCNoAccount   = errors.New("oidc login did not resolve to an account")
+	ErrOIDCUnavailable = errors.New("oidc provider is unavailable")
 )

--- a/api/pkg/core/auth/gateway/http/controller.go
+++ b/api/pkg/core/auth/gateway/http/controller.go
@@ -201,7 +201,7 @@ func (c *Controller) startOIDCLogin(w http.ResponseWriter, r *http.Request) {
 		Redirect:   r.URL.Query().Get("redirect"),
 	})
 	if err != nil {
-		c.deps.Logger.ErrorContext(ctx, "failed to start oidc login", logging.Err(err))
+		c.logOIDCError(ctx, "failed to start oidc login", err)
 		http.Redirect(w, r, "/login?error="+oidcErrorCode(err), http.StatusFound)
 
 		return
@@ -226,7 +226,7 @@ func (c *Controller) oidcCallback(w http.ResponseWriter, r *http.Request) {
 		StateCookieValue: stateCookieValue,
 	})
 	if err != nil {
-		c.deps.Logger.ErrorContext(ctx, "failed to finish oidc login", logging.Err(err))
+		c.logOIDCError(ctx, "failed to finish oidc login", err)
 		http.Redirect(w, r, "/login?error="+oidcErrorCode(err), http.StatusFound)
 
 		return
@@ -234,6 +234,23 @@ func (c *Controller) oidcCallback(w http.ResponseWriter, r *http.Request) {
 
 	c.deps.Cookies.Set(w, res.Session.Token, res.Session.ExpiresAt, c.deps.Now())
 	http.Redirect(w, r, res.Redirect, http.StatusFound)
+}
+
+func (c *Controller) logOIDCError(ctx context.Context, msg string, err error) {
+	if isExpectedOIDCOutcome(err) {
+		c.deps.Logger.WarnContext(ctx, msg, logging.Err(err))
+
+		return
+	}
+
+	c.deps.Logger.ErrorContext(ctx, msg, logging.Err(err))
+}
+
+func isExpectedOIDCOutcome(err error) bool {
+	return errors.Is(err, auth.ErrOIDCDenied) ||
+		errors.Is(err, auth.ErrOIDCState) ||
+		errors.Is(err, auth.ErrOIDCNotAllowed) ||
+		errors.Is(err, auth.ErrOIDCNoAccount)
 }
 
 func oidcErrorCode(err error) string {

--- a/api/pkg/core/auth/gateway/http/controller.go
+++ b/api/pkg/core/auth/gateway/http/controller.go
@@ -3,6 +3,7 @@
 package http
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -11,7 +12,9 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
 	sessionshttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/httputils"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/logging"
@@ -33,16 +36,26 @@ func (cfg *Config) Validate() error {
 	return nil
 }
 
+type providersLister interface {
+	List(ctx context.Context) ([]oidcproviders.LightOIDCProvider, error)
+}
+
 type Deps struct {
-	AuthService auth.AuthService
-	Cookies     *sessionshttp.CookieManager
-	Logger      *slog.Logger
-	Now         func() time.Time
+	AuthService      auth.AuthService
+	Cookies          *sessionshttp.CookieManager
+	OIDCStateCookies *sessionshttp.CookieManager
+	ProvidersLister  providersLister
+	Logger           *slog.Logger
+	Now              func() time.Time
 }
 
 func (deps *Deps) Validate() error {
 	if deps.Cookies == nil {
 		return errors.New("cookies is required")
+	}
+
+	if deps.OIDCStateCookies == nil {
+		return errors.New("oidcStateCookies is required")
 	}
 
 	if deps.Logger == nil {
@@ -51,6 +64,10 @@ func (deps *Deps) Validate() error {
 
 	if deps.AuthService == nil {
 		return errors.New("authService is required")
+	}
+
+	if deps.ProvidersLister == nil {
+		return errors.New("providersLister is required")
 	}
 
 	return nil
@@ -89,6 +106,9 @@ func (c *Controller) InitRouter(r chi.Router) {
 	r.Route(c.cfg.Endpoint, func(r chi.Router) {
 		r.Post("/login", c.loginWithPwd)
 		r.Post("/logout", c.logout)
+		r.Get("/providers", c.listProviders)
+		r.Get("/oidc/{id}/start", c.startOIDCLogin)
+		r.Get("/oidc/callback", c.oidcCallback)
 	})
 }
 
@@ -142,4 +162,93 @@ func (c *Controller) logout(w http.ResponseWriter, r *http.Request) {
 
 	c.deps.Cookies.Clear(w)
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func (c *Controller) listProviders(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	providers, err := c.deps.ProvidersLister.List(ctx)
+	if err != nil {
+		c.deps.Logger.ErrorContext(ctx, "failed to list oidc providers", logging.Err(err))
+		httputils.WriteError(w, c.deps.Logger, http.StatusInternalServerError, "")
+
+		return
+	}
+
+	res := make([]ProviderSummaryResponse, 0, len(providers))
+	for _, p := range providers {
+		res = append(res, ProviderSummaryResponse{
+			ID:          p.ID.String(),
+			DisplayName: p.DisplayName,
+		})
+	}
+
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, res)
+}
+
+func (c *Controller) startOIDCLogin(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	id, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		http.Redirect(w, r, "/login?error=oidcUnavailable", http.StatusFound)
+
+		return
+	}
+
+	res, err := c.deps.AuthService.StartOIDCLogin(ctx, auth.StartOIDCLoginOpts{
+		ProviderID: id,
+		Redirect:   r.URL.Query().Get("redirect"),
+	})
+	if err != nil {
+		c.deps.Logger.ErrorContext(ctx, "failed to start oidc login", logging.Err(err))
+		http.Redirect(w, r, "/login?error="+oidcErrorCode(err), http.StatusFound)
+
+		return
+	}
+
+	c.deps.OIDCStateCookies.Set(w, res.StateCookieValue, res.ExpiresAt, c.deps.Now())
+	http.Redirect(w, r, res.AuthCodeURL, http.StatusFound)
+}
+
+func (c *Controller) oidcCallback(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	stateCookieValue := c.deps.OIDCStateCookies.Read(r)
+	c.deps.OIDCStateCookies.Clear(w)
+
+	query := r.URL.Query()
+
+	res, err := c.deps.AuthService.FinishOIDCLogin(ctx, auth.FinishOIDCLoginOpts{
+		Code:             query.Get("code"),
+		State:            query.Get("state"),
+		ErrorParam:       query.Get("error"),
+		StateCookieValue: stateCookieValue,
+	})
+	if err != nil {
+		c.deps.Logger.ErrorContext(ctx, "failed to finish oidc login", logging.Err(err))
+		http.Redirect(w, r, "/login?error="+oidcErrorCode(err), http.StatusFound)
+
+		return
+	}
+
+	c.deps.Cookies.Set(w, res.Session.Token, res.Session.ExpiresAt, c.deps.Now())
+	http.Redirect(w, r, res.Redirect, http.StatusFound)
+}
+
+func oidcErrorCode(err error) string {
+	switch {
+	case errors.Is(err, auth.ErrOIDCDenied):
+		return "oidcDenied"
+	case errors.Is(err, auth.ErrOIDCNotAllowed):
+		return "oidcNotAllowed"
+	case errors.Is(err, auth.ErrOIDCNoAccount):
+		return "oidcNoAccount"
+	case errors.Is(err, auth.ErrOIDCState):
+		return "oidcState"
+	case errors.Is(err, auth.ErrOIDCUnavailable):
+		return "oidcUnavailable"
+	default:
+		return "oidcUnavailable"
+	}
 }

--- a/api/pkg/core/auth/gateway/http/controller_test.go
+++ b/api/pkg/core/auth/gateway/http/controller_test.go
@@ -69,6 +69,14 @@ func (s *stubAuthService) Logout(_ context.Context, token string) error {
 	return s.logoutErr
 }
 
+func (s *stubAuthService) StartOIDCLogin(context.Context, auth.StartOIDCLoginOpts) (*auth.OIDCStart, error) {
+	panic("StartOIDCLogin n'est pas exposée par ce controller")
+}
+
+func (s *stubAuthService) FinishOIDCLogin(context.Context, auth.FinishOIDCLoginOpts) (*auth.OIDCLoginResult, error) {
+	panic("FinishOIDCLogin n'est pas exposée par ce controller")
+}
+
 func frozenNow() time.Time {
 	return time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
 }

--- a/api/pkg/core/auth/gateway/http/controller_test.go
+++ b/api/pkg/core/auth/gateway/http/controller_test.go
@@ -869,6 +869,15 @@ func TestStartOIDCLoginHappyPathRedirectsAndSetsStateCookie(t *testing.T) {
 			t.Errorf("Set-Cookie = %q, want attribute %q", raw, attr)
 		}
 	}
+
+	cookies := rec.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("%d cookies posés, want 1", len(cookies))
+	}
+
+	if want := int(svc.startResult.ExpiresAt.Sub(frozenNow()).Seconds()); cookies[0].MaxAge != want {
+		t.Errorf("MaxAge = %d, want %d", cookies[0].MaxAge, want)
+	}
 }
 
 func TestOIDCCallbackNoStateCookieRedirects(t *testing.T) {
@@ -981,6 +990,10 @@ func TestOIDCCallbackHappyPathRedirectsSetsSessionAndClearsState(t *testing.T) {
 
 	if !session.HttpOnly {
 		t.Error("session HttpOnly absent")
+	}
+
+	if want := int(svc.finishResult.Session.ExpiresAt.Sub(frozenNow()).Seconds()); session.MaxAge != want {
+		t.Errorf("session MaxAge = %d, want %d", session.MaxAge, want)
 	}
 
 	if state == nil {

--- a/api/pkg/core/auth/gateway/http/controller_test.go
+++ b/api/pkg/core/auth/gateway/http/controller_test.go
@@ -37,6 +37,7 @@ const (
 	sessionCookieName   = "uchiyomi_session"
 	oidcStateCookieName = "uchiyomi_oidc_state"
 	oidcStateCookiePath = "/api/auth/oidc"
+	logLevelWarn        = "WARN"
 )
 
 type stubAuthService struct {
@@ -1013,10 +1014,10 @@ func TestOIDCCallbackSentinelErrors(t *testing.T) {
 		wantCode  string
 		wantLevel string
 	}{
-		"denied":      {finishErr: auth.ErrOIDCDenied, wantCode: "oidcDenied", wantLevel: "WARN"},
-		"state":       {finishErr: auth.ErrOIDCState, wantCode: "oidcState", wantLevel: "WARN"},
-		"not allowed": {finishErr: auth.ErrOIDCNotAllowed, wantCode: "oidcNotAllowed", wantLevel: "WARN"},
-		"no account":  {finishErr: auth.ErrOIDCNoAccount, wantCode: "oidcNoAccount", wantLevel: "WARN"},
+		"denied":      {finishErr: auth.ErrOIDCDenied, wantCode: "oidcDenied", wantLevel: logLevelWarn},
+		"state":       {finishErr: auth.ErrOIDCState, wantCode: "oidcState", wantLevel: logLevelWarn},
+		"not allowed": {finishErr: auth.ErrOIDCNotAllowed, wantCode: "oidcNotAllowed", wantLevel: logLevelWarn},
+		"no account":  {finishErr: auth.ErrOIDCNoAccount, wantCode: "oidcNoAccount", wantLevel: logLevelWarn},
 		"unavailable": {finishErr: auth.ErrOIDCUnavailable, wantCode: "oidcUnavailable", wantLevel: "ERROR"},
 		"inconnue":    {finishErr: errors.New("boom"), wantCode: "oidcUnavailable", wantLevel: "ERROR"},
 	}

--- a/api/pkg/core/auth/gateway/http/controller_test.go
+++ b/api/pkg/core/auth/gateway/http/controller_test.go
@@ -1011,10 +1011,14 @@ func TestOIDCCallbackSentinelErrors(t *testing.T) {
 	tests := map[string]struct {
 		finishErr error
 		wantCode  string
+		wantLevel string
 	}{
-		"not allowed": {finishErr: auth.ErrOIDCNotAllowed, wantCode: "oidcNotAllowed"},
-		"no account":  {finishErr: auth.ErrOIDCNoAccount, wantCode: "oidcNoAccount"},
-		"unavailable": {finishErr: auth.ErrOIDCUnavailable, wantCode: "oidcUnavailable"},
+		"denied":      {finishErr: auth.ErrOIDCDenied, wantCode: "oidcDenied", wantLevel: "WARN"},
+		"state":       {finishErr: auth.ErrOIDCState, wantCode: "oidcState", wantLevel: "WARN"},
+		"not allowed": {finishErr: auth.ErrOIDCNotAllowed, wantCode: "oidcNotAllowed", wantLevel: "WARN"},
+		"no account":  {finishErr: auth.ErrOIDCNoAccount, wantCode: "oidcNoAccount", wantLevel: "WARN"},
+		"unavailable": {finishErr: auth.ErrOIDCUnavailable, wantCode: "oidcUnavailable", wantLevel: "ERROR"},
+		"inconnue":    {finishErr: errors.New("boom"), wantCode: "oidcUnavailable", wantLevel: "ERROR"},
 	}
 
 	for name, tc := range tests {
@@ -1022,7 +1026,7 @@ func TestOIDCCallbackSentinelErrors(t *testing.T) {
 			t.Parallel()
 
 			svc := &stubAuthService{finishErr: tc.finishErr}
-			r, _ := newTestRouterWithProviders(t, svc, &stubProvidersLister{})
+			r, logs := newTestRouterWithProviders(t, svc, &stubProvidersLister{})
 
 			stateCookie := &http.Cookie{Name: oidcStateCookieName, Value: "state-value"}
 			rec := getOIDCCallback(t, r, "?code=abc&state=state-value", stateCookie)
@@ -1034,6 +1038,15 @@ func TestOIDCCallbackSentinelErrors(t *testing.T) {
 			want := "/login?error=" + tc.wantCode
 			if loc := rec.Header().Get("Location"); loc != want {
 				t.Errorf("Location = %q, want %q", loc, want)
+			}
+
+			var entry map[string]any
+			if err := json.Unmarshal(bytes.TrimSpace(logs.Bytes()), &entry); err != nil {
+				t.Fatalf("log non décodable (%q): %v", logs.String(), err)
+			}
+
+			if entry["level"] != tc.wantLevel {
+				t.Errorf("level = %v, want %v", entry["level"], tc.wantLevel)
 			}
 		})
 	}

--- a/api/pkg/core/auth/gateway/http/controller_test.go
+++ b/api/pkg/core/auth/gateway/http/controller_test.go
@@ -19,29 +19,42 @@ import (
 	"github.com/google/uuid"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth"
 	authhttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
 	sessionshttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/users"
 )
 
 const (
-	authEndpoint      = "/auth"
-	loginPath         = "/auth/login"
-	logoutPath        = "/auth/logout"
-	username          = "alice"
-	password          = "hunter2hunter2"
-	token             = "letoken"
-	sessionCookieName = "uchiyomi_session"
+	authEndpoint        = "/auth"
+	loginPath           = "/auth/login"
+	logoutPath          = "/auth/logout"
+	providersPath       = "/auth/providers"
+	oidcCallbackPath    = "/auth/oidc/callback"
+	username            = "alice"
+	password            = "hunter2hunter2"
+	token               = "letoken"
+	sessionCookieName   = "uchiyomi_session"
+	oidcStateCookieName = "uchiyomi_oidc_state"
+	oidcStateCookiePath = "/api/auth/oidc"
 )
 
 type stubAuthService struct {
-	err         error
-	logoutErr   error
-	result      *auth.LoginResult
-	gotOpts     auth.LoginWithPwdOpts
-	logoutToken string
-	calls       int
-	logoutCalls int
+	err           error
+	finishErr     error
+	startErr      error
+	logoutErr     error
+	startResult   *auth.OIDCStart
+	result        *auth.LoginResult
+	finishResult  *auth.OIDCLoginResult
+	gotFinishOpts auth.FinishOIDCLoginOpts
+	gotOpts       auth.LoginWithPwdOpts
+	logoutToken   string
+	gotStartOpts  auth.StartOIDCLoginOpts
+	calls         int
+	logoutCalls   int
+	startCalls    int
+	finishCalls   int
 }
 
 func (s *stubAuthService) LoginWithPwd(
@@ -69,12 +82,29 @@ func (s *stubAuthService) Logout(_ context.Context, token string) error {
 	return s.logoutErr
 }
 
-func (s *stubAuthService) StartOIDCLogin(context.Context, auth.StartOIDCLoginOpts) (*auth.OIDCStart, error) {
-	panic("StartOIDCLogin n'est pas exposée par ce controller")
+func (s *stubAuthService) StartOIDCLogin(_ context.Context, opts auth.StartOIDCLoginOpts) (*auth.OIDCStart, error) {
+	s.startCalls++
+	s.gotStartOpts = opts
+
+	if s.startErr != nil {
+		return nil, s.startErr
+	}
+
+	return s.startResult, nil
 }
 
-func (s *stubAuthService) FinishOIDCLogin(context.Context, auth.FinishOIDCLoginOpts) (*auth.OIDCLoginResult, error) {
-	panic("FinishOIDCLogin n'est pas exposée par ce controller")
+func (s *stubAuthService) FinishOIDCLogin(
+	_ context.Context,
+	opts auth.FinishOIDCLoginOpts,
+) (*auth.OIDCLoginResult, error) {
+	s.finishCalls++
+	s.gotFinishOpts = opts
+
+	if s.finishErr != nil {
+		return nil, s.finishErr
+	}
+
+	return s.finishResult, nil
 }
 
 func frozenNow() time.Time {
@@ -96,6 +126,22 @@ func loggedInStub() *stubAuthService {
 	return &stubAuthService{result: &auth.LoginResult{Session: issuedSession(), User: loggedInUser()}}
 }
 
+type stubProvidersLister struct {
+	err    error
+	result []oidcproviders.LightOIDCProvider
+	calls  int
+}
+
+func (s *stubProvidersLister) List(context.Context) ([]oidcproviders.LightOIDCProvider, error) {
+	s.calls++
+
+	if s.err != nil {
+		return nil, s.err
+	}
+
+	return s.result, nil
+}
+
 func testLogger() (*slog.Logger, *bytes.Buffer) {
 	var buf bytes.Buffer
 
@@ -113,6 +159,20 @@ func newCookies(t *testing.T) *sessionshttp.CookieManager {
 	return m
 }
 
+func newOIDCStateCookies(t *testing.T) *sessionshttp.CookieManager {
+	t.Helper()
+
+	m, err := sessionshttp.NewCookieManager(sessionshttp.CookieConfig{
+		Name: oidcStateCookieName,
+		Path: oidcStateCookiePath,
+	})
+	if err != nil {
+		t.Fatalf("NewCookieManager: %v", err)
+	}
+
+	return m
+}
+
 func loginBody(user, pwd string) string {
 	return fmt.Sprintf(`{"username":%q,"password":%q}`, user, pwd)
 }
@@ -120,13 +180,25 @@ func loginBody(user, pwd string) string {
 func newTestRouter(t *testing.T, svc *stubAuthService) (chi.Router, *bytes.Buffer) {
 	t.Helper()
 
+	return newTestRouterWithProviders(t, svc, &stubProvidersLister{})
+}
+
+func newTestRouterWithProviders(
+	t *testing.T,
+	svc *stubAuthService,
+	providers *stubProvidersLister,
+) (chi.Router, *bytes.Buffer) {
+	t.Helper()
+
 	logger, logs := testLogger()
 
 	c, err := authhttp.New(authhttp.Config{Endpoint: authEndpoint}, authhttp.Deps{
-		AuthService: svc,
-		Cookies:     newCookies(t),
-		Logger:      logger,
-		Now:         frozenNow,
+		AuthService:      svc,
+		Cookies:          newCookies(t),
+		OIDCStateCookies: newOIDCStateCookies(t),
+		ProvidersLister:  providers,
+		Logger:           logger,
+		Now:              frozenNow,
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -194,19 +266,58 @@ func TestDepsValidate(t *testing.T) {
 		wantErr string
 	}{
 		"complet": {
-			deps:    authhttp.Deps{AuthService: &stubAuthService{}, Cookies: newCookies(t), Logger: logger},
+			deps: authhttp.Deps{
+				AuthService:      &stubAuthService{},
+				Cookies:          newCookies(t),
+				OIDCStateCookies: newOIDCStateCookies(t),
+				ProvidersLister:  &stubProvidersLister{},
+				Logger:           logger,
+			},
 			wantErr: "",
 		},
 		"sans service": {
-			deps:    authhttp.Deps{Cookies: newCookies(t), Logger: logger},
+			deps: authhttp.Deps{
+				Cookies:          newCookies(t),
+				OIDCStateCookies: newOIDCStateCookies(t),
+				ProvidersLister:  &stubProvidersLister{},
+				Logger:           logger,
+			},
 			wantErr: "authService is required",
 		},
 		"sans cookies": {
-			deps:    authhttp.Deps{AuthService: &stubAuthService{}, Logger: logger},
+			deps: authhttp.Deps{
+				AuthService:      &stubAuthService{},
+				OIDCStateCookies: newOIDCStateCookies(t),
+				ProvidersLister:  &stubProvidersLister{},
+				Logger:           logger,
+			},
 			wantErr: "cookies is required",
 		},
+		"sans oidcStateCookies": {
+			deps: authhttp.Deps{
+				AuthService:     &stubAuthService{},
+				Cookies:         newCookies(t),
+				ProvidersLister: &stubProvidersLister{},
+				Logger:          logger,
+			},
+			wantErr: "oidcStateCookies is required",
+		},
+		"sans providersLister": {
+			deps: authhttp.Deps{
+				AuthService:      &stubAuthService{},
+				Cookies:          newCookies(t),
+				OIDCStateCookies: newOIDCStateCookies(t),
+				Logger:           logger,
+			},
+			wantErr: "providersLister is required",
+		},
 		"sans logger": {
-			deps:    authhttp.Deps{AuthService: &stubAuthService{}, Cookies: newCookies(t)},
+			deps: authhttp.Deps{
+				AuthService:      &stubAuthService{},
+				Cookies:          newCookies(t),
+				OIDCStateCookies: newOIDCStateCookies(t),
+				ProvidersLister:  &stubProvidersLister{},
+			},
 			wantErr: "logger is required",
 		},
 		"tout manquant": {deps: authhttp.Deps{}, wantErr: "cookies is required"},
@@ -296,10 +407,12 @@ func TestInitRouterMountsUnderEndpoint(t *testing.T) {
 
 			logger, _ := testLogger()
 			c, err := authhttp.New(authhttp.Config{Endpoint: tc.endpoint}, authhttp.Deps{
-				AuthService: loggedInStub(),
-				Cookies:     newCookies(t),
-				Logger:      logger,
-				Now:         frozenNow,
+				AuthService:      loggedInStub(),
+				Cookies:          newCookies(t),
+				OIDCStateCookies: newOIDCStateCookies(t),
+				ProvidersLister:  &stubProvidersLister{},
+				Logger:           logger,
+				Now:              frozenNow,
 			})
 			if err != nil {
 				t.Fatalf("New: %v", err)
@@ -622,5 +735,293 @@ func TestLogoutServiceErrorLeavesCookieIntact(t *testing.T) {
 
 	if !strings.Contains(logs.String(), "failed to logout") {
 		t.Errorf("message de log attendu absent: %s", logs.String())
+	}
+}
+
+func getProviders(t *testing.T, r chi.Router) *httptest.ResponseRecorder {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, providersPath, nil))
+
+	return rec
+}
+
+func getOIDCStart(t *testing.T, r chi.Router, id string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/auth/oidc/"+id+"/start", nil))
+
+	return rec
+}
+
+func getOIDCCallback(t *testing.T, r chi.Router, query string, stateCookie *http.Cookie) *httptest.ResponseRecorder {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, oidcCallbackPath+query, nil)
+
+	if stateCookie != nil {
+		req.AddCookie(stateCookie)
+	}
+
+	r.ServeHTTP(rec, req)
+
+	return rec
+}
+
+func TestListProvidersReturnsMappedShape(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.New()
+	providers := &stubProvidersLister{result: []oidcproviders.LightOIDCProvider{
+		{ID: id, DisplayName: "Acme SSO"},
+	}}
+	r, _ := newTestRouterWithProviders(t, &stubAuthService{}, providers)
+
+	rec := getProviders(t, r)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var got []authhttp.ProviderSummaryResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("json.Unmarshal(%s): %v", rec.Body.String(), err)
+	}
+
+	want := []authhttp.ProviderSummaryResponse{{ID: id.String(), DisplayName: "Acme SSO"}}
+	if len(got) != 1 || got[0] != want[0] {
+		t.Errorf("body = %+v, want %+v", got, want)
+	}
+}
+
+func TestListProvidersServiceError(t *testing.T) {
+	t.Parallel()
+
+	providers := &stubProvidersLister{err: errors.New("database is down")}
+	r, logs := newTestRouterWithProviders(t, &stubAuthService{}, providers)
+
+	rec := getProviders(t, r)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+
+	if strings.Contains(rec.Body.String(), "database is down") {
+		t.Errorf("l'erreur interne a fuité dans la réponse: %s", rec.Body.String())
+	}
+
+	if !strings.Contains(logs.String(), "database is down") {
+		t.Errorf("l'erreur interne est absente des logs: %s", logs.String())
+	}
+}
+
+func TestStartOIDCLoginBadUUIDRedirects(t *testing.T) {
+	t.Parallel()
+
+	r, _ := newTestRouterWithProviders(t, &stubAuthService{}, &stubProvidersLister{})
+
+	rec := getOIDCStart(t, r, "not-a-uuid")
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusFound)
+	}
+
+	if loc := rec.Header().Get("Location"); loc != "/login?error=oidcUnavailable" {
+		t.Errorf("Location = %q, want %q", loc, "/login?error=oidcUnavailable")
+	}
+}
+
+func TestStartOIDCLoginHappyPathRedirectsAndSetsStateCookie(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.New()
+	svc := &stubAuthService{startResult: &auth.OIDCStart{
+		AuthCodeURL:      "https://idp.example.com/authorize?state=abc",
+		StateCookieValue: "opaque-state",
+		ExpiresAt:        frozenNow().Add(10 * time.Minute),
+	}}
+	r, _ := newTestRouterWithProviders(t, svc, &stubProvidersLister{})
+
+	rec := getOIDCStart(t, r, id.String())
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusFound, rec.Body.String())
+	}
+
+	if loc := rec.Header().Get("Location"); loc != svc.startResult.AuthCodeURL {
+		t.Errorf("Location = %q, want %q", loc, svc.startResult.AuthCodeURL)
+	}
+
+	if svc.gotStartOpts.ProviderID != id {
+		t.Errorf("ProviderID = %v, want %v", svc.gotStartOpts.ProviderID, id)
+	}
+
+	raw := rec.Header().Get("Set-Cookie")
+	if !strings.HasPrefix(raw, "uchiyomi_oidc_state=opaque-state") {
+		t.Errorf("Set-Cookie = %q, want value uchiyomi_oidc_state=opaque-state", raw)
+	}
+
+	for _, attr := range []string{"Path=/api/auth/oidc", "HttpOnly", "SameSite=Lax"} {
+		if !strings.Contains(raw, attr) {
+			t.Errorf("Set-Cookie = %q, want attribute %q", raw, attr)
+		}
+	}
+}
+
+func TestOIDCCallbackNoStateCookieRedirects(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubAuthService{finishErr: auth.ErrOIDCState}
+	r, _ := newTestRouterWithProviders(t, svc, &stubProvidersLister{})
+
+	rec := getOIDCCallback(t, r, "?code=abc&state=xyz", nil)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusFound, rec.Body.String())
+	}
+
+	if loc := rec.Header().Get("Location"); loc != "/login?error=oidcState" {
+		t.Errorf("Location = %q, want %q", loc, "/login?error=oidcState")
+	}
+
+	if svc.gotFinishOpts.StateCookieValue != "" {
+		t.Errorf("StateCookieValue = %q, want vide", svc.gotFinishOpts.StateCookieValue)
+	}
+}
+
+func TestOIDCCallbackStateMismatchRedirects(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubAuthService{finishErr: auth.ErrOIDCState}
+	r, _ := newTestRouterWithProviders(t, svc, &stubProvidersLister{})
+
+	stateCookie := &http.Cookie{Name: oidcStateCookieName, Value: "stale-state"}
+	rec := getOIDCCallback(t, r, "?code=abc&state=xyz", stateCookie)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusFound)
+	}
+
+	if loc := rec.Header().Get("Location"); loc != "/login?error=oidcState" {
+		t.Errorf("Location = %q, want %q", loc, "/login?error=oidcState")
+	}
+
+	if svc.gotFinishOpts.StateCookieValue != "stale-state" {
+		t.Errorf("StateCookieValue = %q, want %q", svc.gotFinishOpts.StateCookieValue, "stale-state")
+	}
+}
+
+func TestOIDCCallbackAccessDeniedRedirects(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubAuthService{finishErr: auth.ErrOIDCDenied}
+	r, _ := newTestRouterWithProviders(t, svc, &stubProvidersLister{})
+
+	stateCookie := &http.Cookie{Name: oidcStateCookieName, Value: "state-value"}
+	rec := getOIDCCallback(t, r, "?error=access_denied&state=state-value", stateCookie)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusFound)
+	}
+
+	if loc := rec.Header().Get("Location"); loc != "/login?error=oidcDenied" {
+		t.Errorf("Location = %q, want %q", loc, "/login?error=oidcDenied")
+	}
+
+	if svc.gotFinishOpts.ErrorParam != "access_denied" {
+		t.Errorf("ErrorParam = %q, want %q", svc.gotFinishOpts.ErrorParam, "access_denied")
+	}
+}
+
+func TestOIDCCallbackHappyPathRedirectsSetsSessionAndClearsState(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubAuthService{finishResult: &auth.OIDCLoginResult{
+		Session:  issuedSession(),
+		Redirect: "/library",
+	}}
+	r, _ := newTestRouterWithProviders(t, svc, &stubProvidersLister{})
+
+	stateCookie := &http.Cookie{Name: oidcStateCookieName, Value: "good-state"}
+	rec := getOIDCCallback(t, r, "?code=abc&state=good-state", stateCookie)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusFound, rec.Body.String())
+	}
+
+	if loc := rec.Header().Get("Location"); loc != "/library" {
+		t.Errorf("Location = %q, want %q", loc, "/library")
+	}
+
+	if svc.gotFinishOpts.StateCookieValue != "good-state" {
+		t.Errorf("StateCookieValue = %q, want %q", svc.gotFinishOpts.StateCookieValue, "good-state")
+	}
+
+	var session, state *http.Cookie
+
+	for _, c := range rec.Result().Cookies() {
+		switch c.Name {
+		case sessionCookieName:
+			session = c
+		case oidcStateCookieName:
+			state = c
+		}
+	}
+
+	if session == nil {
+		t.Fatalf("cookie de session absent (headers: %v)", rec.Header())
+	}
+
+	if session.Value != token {
+		t.Errorf("session Value = %q, want %q", session.Value, token)
+	}
+
+	if !session.HttpOnly {
+		t.Error("session HttpOnly absent")
+	}
+
+	if state == nil {
+		t.Fatalf("cookie d'état oidc absent (headers: %v)", rec.Header())
+	}
+
+	if state.MaxAge != -1 {
+		t.Errorf("state MaxAge = %d, want -1", state.MaxAge)
+	}
+}
+
+func TestOIDCCallbackSentinelErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		finishErr error
+		wantCode  string
+	}{
+		"not allowed": {finishErr: auth.ErrOIDCNotAllowed, wantCode: "oidcNotAllowed"},
+		"no account":  {finishErr: auth.ErrOIDCNoAccount, wantCode: "oidcNoAccount"},
+		"unavailable": {finishErr: auth.ErrOIDCUnavailable, wantCode: "oidcUnavailable"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			svc := &stubAuthService{finishErr: tc.finishErr}
+			r, _ := newTestRouterWithProviders(t, svc, &stubProvidersLister{})
+
+			stateCookie := &http.Cookie{Name: oidcStateCookieName, Value: "state-value"}
+			rec := getOIDCCallback(t, r, "?code=abc&state=state-value", stateCookie)
+
+			if rec.Code != http.StatusFound {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusFound)
+			}
+
+			want := "/login?error=" + tc.wantCode
+			if loc := rec.Header().Get("Location"); loc != want {
+				t.Errorf("Location = %q, want %q", loc, want)
+			}
+		})
 	}
 }

--- a/api/pkg/core/auth/gateway/http/dto.go
+++ b/api/pkg/core/auth/gateway/http/dto.go
@@ -14,3 +14,8 @@ type LoginWithPwdResponse struct {
 	Username string `json:"username"`
 	IsAdmin  bool   `json:"isAdmin"`
 }
+
+type ProviderSummaryResponse struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"displayName"`
+}

--- a/api/pkg/core/auth/oidc/client.go
+++ b/api/pkg/core/auth/oidc/client.go
@@ -133,8 +133,16 @@ func (c *Client) AuthCodeURL(
 func (c *Client) Exchange(
 	ctx context.Context,
 	provider oidcproviders.OIDCProvider,
-	code, verifier, nonce string,
+	code, verifier, nonce, redirectURI string,
 ) (*oidcproviders.TokenSet, error) {
+	if nonce == "" {
+		return nil, fmt.Errorf("%w: nonce must not be empty", ErrNonceMismatch)
+	}
+
+	if verifier == "" {
+		return nil, fmt.Errorf("%w: verifier must not be empty", ErrExchangeFailed)
+	}
+
 	p, err := c.providerFor(ctx, provider)
 	if err != nil {
 		return nil, fmt.Errorf("client.providerFor: %w", err)
@@ -152,7 +160,8 @@ func (c *Client) Exchange(
 			AuthURL:  p.Endpoint().AuthURL,
 			TokenURL: p.Endpoint().TokenURL,
 		},
-		Scopes: dedup(provider.Scopes, offlineAccessScope),
+		RedirectURL: redirectURI,
+		Scopes:      dedup(provider.Scopes, offlineAccessScope),
 	}
 
 	exchangeCtx := gooidc.ClientContext(ctx, c.deps.HTTPClient)

--- a/api/pkg/core/auth/oidc/client.go
+++ b/api/pkg/core/auth/oidc/client.go
@@ -29,6 +29,7 @@ const (
 	defaultClientTimeout = 10 * time.Second
 	defaultCacheTTL      = 15 * time.Minute
 
+	openIDScope        = "openid"
 	offlineAccessScope = "offline_access"
 	sidClaim           = "sid"
 )
@@ -120,7 +121,7 @@ func (c *Client) AuthCodeURL(
 			TokenURL: p.Endpoint().TokenURL,
 		},
 		RedirectURL: params.RedirectURI,
-		Scopes:      dedup(provider.Scopes, offlineAccessScope),
+		Scopes:      dedup(provider.Scopes, openIDScope, offlineAccessScope),
 	}
 
 	return cfg.AuthCodeURL(
@@ -161,7 +162,6 @@ func (c *Client) Exchange(
 			TokenURL: p.Endpoint().TokenURL,
 		},
 		RedirectURL: redirectURI,
-		Scopes:      dedup(provider.Scopes, offlineAccessScope),
 	}
 
 	exchangeCtx := gooidc.ClientContext(ctx, c.deps.HTTPClient)

--- a/api/pkg/core/auth/oidc/client.go
+++ b/api/pkg/core/auth/oidc/client.go
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package oidc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	gooidc "github.com/coreos/go-oidc/v3/oidc"
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
+	"golang.org/x/oauth2"
+)
+
+var _ oidcproviders.Client = (*Client)(nil)
+
+var (
+	ErrClientUnavailable = errors.New("oidc client: provider is unavailable")
+	ErrExchangeFailed    = errors.New("oidc client: token exchange failed")
+	ErrIDTokenInvalid    = errors.New("oidc client: id token verification failed")
+	ErrNonceMismatch     = errors.New("oidc client: id token nonce mismatch")
+)
+
+const (
+	defaultClientTimeout = 10 * time.Second
+	defaultCacheTTL      = 15 * time.Minute
+
+	offlineAccessScope = "offline_access"
+	sidClaim           = "sid"
+)
+
+type Decrypter interface {
+	Open(ciphertext []byte) ([]byte, error)
+}
+
+type ClientConfig struct {
+	Timeout  time.Duration
+	CacheTTL time.Duration
+}
+
+func (cfg *ClientConfig) Validate() error {
+	if cfg.Timeout < 0 {
+		return errors.New("timeout must not be negative")
+	}
+
+	if cfg.CacheTTL < 0 {
+		return errors.New("cacheTTL must not be negative")
+	}
+
+	return nil
+}
+
+type ClientDeps struct {
+	HTTPClient *http.Client
+	Cipher     Decrypter
+}
+
+func (deps *ClientDeps) Validate() error {
+	if deps.HTTPClient == nil {
+		return errors.New("httpClient is required")
+	}
+
+	if deps.Cipher == nil {
+		return errors.New("cipher is required")
+	}
+
+	return nil
+}
+
+type cacheEntry struct {
+	provider  *gooidc.Provider
+	fetchedAt time.Time
+}
+
+type Client struct {
+	cache map[uuid.UUID]cacheEntry
+	deps  ClientDeps
+	cfg   ClientConfig
+	mu    sync.RWMutex
+}
+
+func NewClient(cfg ClientConfig, deps ClientDeps) (*Client, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("cfg.Validate: %w", err)
+	}
+
+	if err := deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	if cfg.Timeout == 0 {
+		cfg.Timeout = defaultClientTimeout
+	}
+
+	if cfg.CacheTTL == 0 {
+		cfg.CacheTTL = defaultCacheTTL
+	}
+
+	return &Client{cfg: cfg, deps: deps, cache: make(map[uuid.UUID]cacheEntry)}, nil
+}
+
+func (c *Client) AuthCodeURL(
+	ctx context.Context,
+	provider oidcproviders.OIDCProvider,
+	params oidcproviders.AuthCodeParams,
+) (string, error) {
+	p, err := c.providerFor(ctx, provider)
+	if err != nil {
+		return "", fmt.Errorf("client.providerFor: %w", err)
+	}
+
+	cfg := oauth2.Config{
+		ClientID: provider.ClientID,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  p.Endpoint().AuthURL,
+			TokenURL: p.Endpoint().TokenURL,
+		},
+		RedirectURL: params.RedirectURI,
+		Scopes:      dedup(provider.Scopes, offlineAccessScope),
+	}
+
+	return cfg.AuthCodeURL(
+		params.State,
+		oauth2.SetAuthURLParam("nonce", params.Nonce),
+		oauth2.S256ChallengeOption(params.Verifier),
+	), nil
+}
+
+func (c *Client) Exchange(
+	ctx context.Context,
+	provider oidcproviders.OIDCProvider,
+	code, verifier, nonce string,
+) (*oidcproviders.TokenSet, error) {
+	p, err := c.providerFor(ctx, provider)
+	if err != nil {
+		return nil, fmt.Errorf("client.providerFor: %w", err)
+	}
+
+	secret, err := c.deps.Cipher.Open(provider.ClientSecretEnc)
+	if err != nil {
+		return nil, fmt.Errorf("cipher.Open: %w", err)
+	}
+
+	cfg := oauth2.Config{
+		ClientID:     provider.ClientID,
+		ClientSecret: string(secret),
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  p.Endpoint().AuthURL,
+			TokenURL: p.Endpoint().TokenURL,
+		},
+		Scopes: dedup(provider.Scopes, offlineAccessScope),
+	}
+
+	exchangeCtx := gooidc.ClientContext(ctx, c.deps.HTTPClient)
+
+	token, err := cfg.Exchange(exchangeCtx, code, oauth2.VerifierOption(verifier))
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrExchangeFailed, err)
+	}
+
+	rawIDToken, ok := token.Extra("id_token").(string)
+	if !ok || rawIDToken == "" {
+		return nil, fmt.Errorf("%w: token response is missing the id_token", ErrExchangeFailed)
+	}
+
+	idTokenVerifier := p.Verifier(&gooidc.Config{ClientID: provider.ClientID})
+
+	idToken, err := idTokenVerifier.Verify(exchangeCtx, rawIDToken)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrIDTokenInvalid, err)
+	}
+
+	if idToken.Nonce != nonce {
+		return nil, ErrNonceMismatch
+	}
+
+	var claims map[string]any
+	if err := idToken.Claims(&claims); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrIDTokenInvalid, err)
+	}
+
+	sid, _ := claims[sidClaim].(string)
+
+	return &oidcproviders.TokenSet{Subject: idToken.Subject, SID: sid, Claims: claims}, nil
+}
+
+func (c *Client) Evict(id uuid.UUID) {
+	c.mu.Lock()
+	delete(c.cache, id)
+	c.mu.Unlock()
+}
+
+func (c *Client) providerFor(ctx context.Context, provider oidcproviders.OIDCProvider) (*gooidc.Provider, error) {
+	c.mu.RLock()
+	entry, ok := c.cache[provider.ID]
+	c.mu.RUnlock()
+
+	if ok && time.Since(entry.fetchedAt) < c.cfg.CacheTTL {
+		return entry.provider, nil
+	}
+
+	fetchCtx, cancel := context.WithTimeout(gooidc.ClientContext(ctx, c.deps.HTTPClient), c.cfg.Timeout)
+	defer cancel()
+
+	fetched, err := gooidc.NewProvider(fetchCtx, provider.IssuerURL)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrClientUnavailable, err)
+	}
+
+	c.mu.Lock()
+	c.cache[provider.ID] = cacheEntry{provider: fetched, fetchedAt: time.Now()}
+	c.mu.Unlock()
+
+	return fetched, nil
+}
+
+func dedup(scopes []string, extra ...string) []string {
+	seen := make(map[string]bool, len(scopes)+len(extra))
+	out := make([]string, 0, len(scopes)+len(extra))
+
+	for _, s := range append(append([]string{}, scopes...), extra...) {
+		if seen[s] {
+			continue
+		}
+
+		seen[s] = true
+
+		out = append(out, s)
+	}
+
+	return out
+}

--- a/api/pkg/core/auth/oidc/client_test.go
+++ b/api/pkg/core/auth/oidc/client_test.go
@@ -1,0 +1,463 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package oidc_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v4"
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidc"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
+)
+
+const (
+	testRedirectURI = "https://app.example.com/callback"
+	testNonce       = "test-nonce"
+	testSubject     = "user-123"
+)
+
+type testIdP struct {
+	tokenHandler  func(w http.ResponseWriter, r *http.Request)
+	srv           *httptest.Server
+	key           *rsa.PrivateKey
+	keyID         string
+	mu            sync.Mutex
+	discoveryHits int32
+}
+
+func newTestIdP(t *testing.T) *testIdP {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+
+	idp := &testIdP{key: key, keyID: "test-key-1"}
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	idp.srv = srv
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&idp.discoveryHits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{
+			"issuer": %q,
+			"authorization_endpoint": "%s/auth",
+			"token_endpoint": "%s/token",
+			"jwks_uri": "%s/jwks"
+		}`, srv.URL, srv.URL, srv.URL, srv.URL)
+	})
+
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		set := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{
+			{Key: &key.PublicKey, KeyID: idp.keyID, Algorithm: "RS256", Use: "sig"},
+		}}
+
+		if err := json.NewEncoder(w).Encode(set); err != nil {
+			t.Fatalf("json.NewEncoder.Encode: %v", err)
+		}
+	})
+
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		idp.mu.Lock()
+		h := idp.tokenHandler
+		idp.mu.Unlock()
+
+		if h == nil {
+			t.Fatalf("token endpoint called without a handler set")
+
+			return
+		}
+
+		h(w, r)
+	})
+
+	return idp
+}
+
+func (idp *testIdP) setTokenHandler(h func(w http.ResponseWriter, r *http.Request)) {
+	idp.mu.Lock()
+	idp.tokenHandler = h
+	idp.mu.Unlock()
+}
+
+func jsonTokenResponse(rawIDToken string) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w,
+			`{"access_token":"test-access-token","token_type":"Bearer","expires_in":3600,"id_token":%q}`,
+			rawIDToken)
+	}
+}
+
+func invalidGrantResponse() func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"error":"invalid_grant","error_description":"the code is invalid"}`)
+	}
+}
+
+func signClaims(t *testing.T, key *rsa.PrivateKey, keyID string, claims map[string]any) string {
+	t.Helper()
+
+	signer, err := jose.NewSigner(jose.SigningKey{
+		Algorithm: jose.RS256,
+		Key:       jose.JSONWebKey{Key: key, KeyID: keyID, Algorithm: "RS256", Use: "sig"},
+	}, (&jose.SignerOptions{}).WithType("JWT"))
+	if err != nil {
+		t.Fatalf("jose.NewSigner: %v", err)
+	}
+
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	jws, err := signer.Sign(payload)
+	if err != nil {
+		t.Fatalf("signer.Sign: %v", err)
+	}
+
+	compact, err := jws.CompactSerialize()
+	if err != nil {
+		t.Fatalf("jws.CompactSerialize: %v", err)
+	}
+
+	return compact
+}
+
+func baseClaims(issuer, clientID, nonce string) map[string]any {
+	now := time.Now()
+
+	return map[string]any{
+		"iss":   issuer,
+		"aud":   clientID,
+		"sub":   testSubject,
+		"exp":   now.Add(time.Hour).Unix(),
+		"iat":   now.Unix(),
+		"nonce": nonce,
+	}
+}
+
+func testProvider(issuer string) oidcproviders.OIDCProvider {
+	return oidcproviders.OIDCProvider{
+		ID:              uuid.New(),
+		IssuerURL:       issuer,
+		ClientID:        "test-client",
+		ClientSecretEnc: []byte("encrypted-secret"),
+		Scopes:          []string{"openid", "profile"},
+	}
+}
+
+type stubDecrypter struct {
+	err       error
+	plaintext []byte
+}
+
+func (s stubDecrypter) Open(_ []byte) ([]byte, error) {
+	return s.plaintext, s.err
+}
+
+func newTestClient(t *testing.T) *oidc.Client {
+	t.Helper()
+
+	c, err := oidc.NewClient(oidc.ClientConfig{Timeout: 5 * time.Second}, oidc.ClientDeps{
+		HTTPClient: http.DefaultClient,
+		Cipher:     stubDecrypter{plaintext: []byte("test-client-secret")},
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	return c
+}
+
+func TestAuthCodeURLIncludesPKCEStateNonceAndOfflineAccess(t *testing.T) {
+	t.Parallel()
+
+	idp := newTestIdP(t)
+	c := newTestClient(t)
+	provider := testProvider(idp.srv.URL)
+
+	rawURL, err := c.AuthCodeURL(context.Background(), provider, oidcproviders.AuthCodeParams{
+		RedirectURI: testRedirectURI,
+		State:       "test-state",
+		Nonce:       testNonce,
+		Verifier:    "test-verifier-that-is-long-enough-for-pkce-1234567890",
+	})
+	if err != nil {
+		t.Fatalf("AuthCodeURL: %v", err)
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+
+	q := parsed.Query()
+
+	if q.Get("state") != "test-state" {
+		t.Errorf("state = %q, want %q", q.Get("state"), "test-state")
+	}
+
+	if q.Get("nonce") != testNonce {
+		t.Errorf("nonce = %q, want %q", q.Get("nonce"), testNonce)
+	}
+
+	if q.Get("code_challenge_method") != "S256" {
+		t.Errorf("code_challenge_method = %q, want %q", q.Get("code_challenge_method"), "S256")
+	}
+
+	if q.Get("code_challenge") == "" {
+		t.Error("code_challenge is empty")
+	}
+
+	scopes := strings.Fields(q.Get("scope"))
+
+	var offlineCount int
+
+	var hasOpenID, hasProfile bool
+
+	for _, s := range scopes {
+		switch s {
+		case "offline_access":
+			offlineCount++
+		case "openid":
+			hasOpenID = true
+		case "profile":
+			hasProfile = true
+		}
+	}
+
+	if offlineCount != 1 {
+		t.Errorf("offline_access count in scope = %d, want 1 (scope=%q)", offlineCount, q.Get("scope"))
+	}
+
+	if !hasOpenID || !hasProfile {
+		t.Errorf("scope = %q, want it to include openid and profile", q.Get("scope"))
+	}
+}
+
+func TestExchangeVerifiesTheIDToken(t *testing.T) {
+	t.Parallel()
+
+	idp := newTestIdP(t)
+	provider := testProvider(idp.srv.URL)
+
+	rawIDToken := signClaims(t, idp.key, idp.keyID, baseClaims(idp.srv.URL, provider.ClientID, testNonce))
+	idp.setTokenHandler(jsonTokenResponse(rawIDToken))
+
+	c := newTestClient(t)
+
+	ts, err := c.Exchange(context.Background(), provider, "test-code", "test-verifier", testNonce)
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+
+	if ts.Subject != testSubject {
+		t.Errorf("Subject = %q, want %q", ts.Subject, testSubject)
+	}
+
+	if ts.Claims["sub"] != testSubject {
+		t.Errorf("Claims[sub] = %v, want %q", ts.Claims["sub"], testSubject)
+	}
+}
+
+func TestExchangeRejectsANonceMismatch(t *testing.T) {
+	t.Parallel()
+
+	idp := newTestIdP(t)
+	provider := testProvider(idp.srv.URL)
+
+	rawIDToken := signClaims(t, idp.key, idp.keyID, baseClaims(idp.srv.URL, provider.ClientID, "correct-nonce"))
+	idp.setTokenHandler(jsonTokenResponse(rawIDToken))
+
+	c := newTestClient(t)
+
+	_, err := c.Exchange(context.Background(), provider, "test-code", "test-verifier", "wrong-nonce")
+	if !errors.Is(err, oidc.ErrNonceMismatch) {
+		t.Errorf("Exchange = %v, want ErrNonceMismatch", err)
+	}
+}
+
+func TestExchangeRejectsAnExpiredIDToken(t *testing.T) {
+	t.Parallel()
+
+	idp := newTestIdP(t)
+	provider := testProvider(idp.srv.URL)
+
+	claims := baseClaims(idp.srv.URL, provider.ClientID, testNonce)
+	claims["exp"] = time.Now().Add(-time.Hour).Unix()
+
+	idp.setTokenHandler(jsonTokenResponse(signClaims(t, idp.key, idp.keyID, claims)))
+
+	c := newTestClient(t)
+
+	_, err := c.Exchange(context.Background(), provider, "test-code", "test-verifier", testNonce)
+	if !errors.Is(err, oidc.ErrIDTokenInvalid) {
+		t.Errorf("Exchange = %v, want ErrIDTokenInvalid", err)
+	}
+}
+
+func TestExchangeRejectsABadSignature(t *testing.T) {
+	t.Parallel()
+
+	idp := newTestIdP(t)
+	provider := testProvider(idp.srv.URL)
+
+	otherKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+
+	// Signed with a key that isn't the one published under this kid in the JWKS.
+	rawIDToken := signClaims(t, otherKey, idp.keyID, baseClaims(idp.srv.URL, provider.ClientID, testNonce))
+	idp.setTokenHandler(jsonTokenResponse(rawIDToken))
+
+	c := newTestClient(t)
+
+	_, err = c.Exchange(context.Background(), provider, "test-code", "test-verifier", testNonce)
+	if !errors.Is(err, oidc.ErrIDTokenInvalid) {
+		t.Errorf("Exchange = %v, want ErrIDTokenInvalid", err)
+	}
+}
+
+func TestExchangeSurfacesATokenEndpointError(t *testing.T) {
+	t.Parallel()
+
+	idp := newTestIdP(t)
+	provider := testProvider(idp.srv.URL)
+	idp.setTokenHandler(invalidGrantResponse())
+
+	c := newTestClient(t)
+
+	_, err := c.Exchange(context.Background(), provider, "bad-code", "test-verifier", testNonce)
+	if !errors.Is(err, oidc.ErrExchangeFailed) {
+		t.Errorf("Exchange = %v, want ErrExchangeFailed", err)
+	}
+}
+
+func TestExchangeReadsTheSIDClaim(t *testing.T) {
+	t.Parallel()
+
+	idp := newTestIdP(t)
+	provider := testProvider(idp.srv.URL)
+	c := newTestClient(t)
+
+	t.Run("with sid", func(t *testing.T) {
+		claims := baseClaims(idp.srv.URL, provider.ClientID, testNonce)
+		claims["sid"] = "session-abc"
+		idp.setTokenHandler(jsonTokenResponse(signClaims(t, idp.key, idp.keyID, claims)))
+
+		ts, err := c.Exchange(context.Background(), provider, "test-code", "test-verifier", testNonce)
+		if err != nil {
+			t.Fatalf("Exchange: %v", err)
+		}
+
+		if ts.SID != "session-abc" {
+			t.Errorf("SID = %q, want %q", ts.SID, "session-abc")
+		}
+	})
+
+	t.Run("without sid", func(t *testing.T) {
+		claims := baseClaims(idp.srv.URL, provider.ClientID, testNonce)
+		idp.setTokenHandler(jsonTokenResponse(signClaims(t, idp.key, idp.keyID, claims)))
+
+		ts, err := c.Exchange(context.Background(), provider, "test-code", "test-verifier", testNonce)
+		if err != nil {
+			t.Fatalf("Exchange: %v", err)
+		}
+
+		if ts.SID != "" {
+			t.Errorf("SID = %q, want empty", ts.SID)
+		}
+	})
+}
+
+func TestClientCachesTheProviderAcrossCalls(t *testing.T) {
+	t.Parallel()
+
+	idp := newTestIdP(t)
+	provider := testProvider(idp.srv.URL)
+	c := newTestClient(t)
+
+	params := oidcproviders.AuthCodeParams{
+		RedirectURI: testRedirectURI,
+		State:       "state",
+		Nonce:       testNonce,
+		Verifier:    "verifier",
+	}
+
+	if _, err := c.AuthCodeURL(context.Background(), provider, params); err != nil {
+		t.Fatalf("AuthCodeURL #1: %v", err)
+	}
+
+	if _, err := c.AuthCodeURL(context.Background(), provider, params); err != nil {
+		t.Fatalf("AuthCodeURL #2: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&idp.discoveryHits); got != 1 {
+		t.Errorf("discoveryHits = %d, want 1", got)
+	}
+}
+
+func TestEvictForcesARediscovery(t *testing.T) {
+	t.Parallel()
+
+	idp := newTestIdP(t)
+	provider := testProvider(idp.srv.URL)
+	c := newTestClient(t)
+
+	params := oidcproviders.AuthCodeParams{
+		RedirectURI: testRedirectURI,
+		State:       "state",
+		Nonce:       testNonce,
+		Verifier:    "verifier",
+	}
+
+	if _, err := c.AuthCodeURL(context.Background(), provider, params); err != nil {
+		t.Fatalf("AuthCodeURL #1: %v", err)
+	}
+
+	c.Evict(provider.ID)
+
+	if _, err := c.AuthCodeURL(context.Background(), provider, params); err != nil {
+		t.Fatalf("AuthCodeURL #2: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&idp.discoveryHits); got != 2 {
+		t.Errorf("discoveryHits = %d, want 2", got)
+	}
+}
+
+func TestNewClientValidatesDeps(t *testing.T) {
+	t.Parallel()
+
+	if _, err := oidc.NewClient(oidc.ClientConfig{}, oidc.ClientDeps{Cipher: stubDecrypter{}}); err == nil {
+		t.Error("NewClient without an HTTP client = nil, want an error")
+	}
+
+	if _, err := oidc.NewClient(oidc.ClientConfig{}, oidc.ClientDeps{HTTPClient: http.DefaultClient}); err == nil {
+		t.Error("NewClient without a cipher = nil, want an error")
+	}
+}

--- a/api/pkg/core/auth/oidc/client_test.go
+++ b/api/pkg/core/auth/oidc/client_test.go
@@ -109,10 +109,6 @@ func jsonTokenResponse(rawIDToken string) func(w http.ResponseWriter, r *http.Re
 	}
 }
 
-// assertingTokenResponse wraps jsonTokenResponse with assertions on the actual
-// token request, so a regression like a missing redirect_uri (which real IdPs
-// reject with invalid_grant) fails a test instead of only ever being caught
-// against a live provider.
 func assertingTokenResponse(
 	t *testing.T,
 	wantCode, wantVerifier, wantRedirectURI, rawIDToken string,
@@ -391,8 +387,6 @@ func TestExchangeRejectsAnEmptyNonce(t *testing.T) {
 	idp := newTestIdP(t)
 	provider := testProvider(idp.srv.URL)
 
-	// The IdP token happens to omit the nonce claim too: an empty argument must
-	// still be rejected up front, rather than comparing "" == "" and passing.
 	rawIDToken := signClaims(t, idp.key, idp.keyID, baseClaims(idp.srv.URL, provider.ClientID, ""))
 	idp.setTokenHandler(jsonTokenResponse(rawIDToken))
 
@@ -447,7 +441,6 @@ func TestExchangeRejectsABadSignature(t *testing.T) {
 		t.Fatalf("rsa.GenerateKey: %v", err)
 	}
 
-	// Signed with a key that isn't the one published under this kid in the JWKS.
 	rawIDToken := signClaims(t, otherKey, idp.keyID, baseClaims(idp.srv.URL, provider.ClientID, testNonce))
 	idp.setTokenHandler(jsonTokenResponse(rawIDToken))
 

--- a/api/pkg/core/auth/oidc/client_test.go
+++ b/api/pkg/core/auth/oidc/client_test.go
@@ -28,6 +28,9 @@ const (
 	testRedirectURI = "https://app.example.com/callback"
 	testNonce       = "test-nonce"
 	testSubject     = "user-123"
+	testState       = "test-state"
+	scopeOpenID     = "openid"
+	scopeProfile    = "profile"
 )
 
 type testIdP struct {
@@ -198,7 +201,7 @@ func testProvider(issuer string) oidcproviders.OIDCProvider {
 		IssuerURL:       issuer,
 		ClientID:        "test-client",
 		ClientSecretEnc: []byte("encrypted-secret"),
-		Scopes:          []string{"openid", "profile"},
+		Scopes:          []string{scopeOpenID, scopeProfile},
 	}
 }
 
@@ -234,7 +237,7 @@ func TestAuthCodeURLIncludesPKCEStateNonceAndOfflineAccess(t *testing.T) {
 
 	rawURL, err := c.AuthCodeURL(context.Background(), provider, oidcproviders.AuthCodeParams{
 		RedirectURI: testRedirectURI,
-		State:       "test-state",
+		State:       testState,
 		Nonce:       testNonce,
 		Verifier:    "test-verifier-that-is-long-enough-for-pkce-1234567890",
 	})
@@ -249,8 +252,8 @@ func TestAuthCodeURLIncludesPKCEStateNonceAndOfflineAccess(t *testing.T) {
 
 	q := parsed.Query()
 
-	if q.Get("state") != "test-state" {
-		t.Errorf("state = %q, want %q", q.Get("state"), "test-state")
+	if q.Get("state") != testState {
+		t.Errorf("state = %q, want %q", q.Get("state"), testState)
 	}
 
 	if q.Get("nonce") != testNonce {
@@ -275,9 +278,9 @@ func TestAuthCodeURLIncludesPKCEStateNonceAndOfflineAccess(t *testing.T) {
 		switch s {
 		case "offline_access":
 			offlineCount++
-		case "openid":
+		case scopeOpenID:
 			hasOpenID = true
-		case "profile":
+		case scopeProfile:
 			hasProfile = true
 		}
 	}
@@ -295,8 +298,8 @@ func TestAuthCodeURLAlwaysRequestsTheOpenIDScope(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string][]string{
-		"scopes sans openid": {"profile", "email"},
-		"scopes avec openid": {"openid", "profile"},
+		"scopes sans openid": {scopeProfile, "email"},
+		"scopes avec openid": {scopeOpenID, scopeProfile},
 		"aucun scope":        nil,
 	}
 
@@ -311,7 +314,7 @@ func TestAuthCodeURLAlwaysRequestsTheOpenIDScope(t *testing.T) {
 
 			rawURL, err := c.AuthCodeURL(context.Background(), provider, oidcproviders.AuthCodeParams{
 				RedirectURI: testRedirectURI,
-				State:       "test-state",
+				State:       testState,
 				Nonce:       testNonce,
 				Verifier:    "test-verifier-that-is-long-enough-for-pkce-1234567890",
 			})
@@ -327,7 +330,7 @@ func TestAuthCodeURLAlwaysRequestsTheOpenIDScope(t *testing.T) {
 			var openIDCount int
 
 			for _, s := range strings.Fields(parsed.Query().Get("scope")) {
-				if s == "openid" {
+				if s == scopeOpenID {
 					openIDCount++
 				}
 			}

--- a/api/pkg/core/auth/oidc/client_test.go
+++ b/api/pkg/core/auth/oidc/client_test.go
@@ -295,6 +295,54 @@ func TestAuthCodeURLIncludesPKCEStateNonceAndOfflineAccess(t *testing.T) {
 	}
 }
 
+func TestAuthCodeURLAlwaysRequestsTheOpenIDScope(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string][]string{
+		"scopes sans openid": {"profile", "email"},
+		"scopes avec openid": {"openid", "profile"},
+		"aucun scope":        nil,
+	}
+
+	for name, scopes := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			idp := newTestIdP(t)
+			c := newTestClient(t)
+			provider := testProvider(idp.srv.URL)
+			provider.Scopes = scopes
+
+			rawURL, err := c.AuthCodeURL(context.Background(), provider, oidcproviders.AuthCodeParams{
+				RedirectURI: testRedirectURI,
+				State:       "test-state",
+				Nonce:       testNonce,
+				Verifier:    "test-verifier-that-is-long-enough-for-pkce-1234567890",
+			})
+			if err != nil {
+				t.Fatalf("AuthCodeURL: %v", err)
+			}
+
+			parsed, err := url.Parse(rawURL)
+			if err != nil {
+				t.Fatalf("url.Parse: %v", err)
+			}
+
+			var openIDCount int
+
+			for _, s := range strings.Fields(parsed.Query().Get("scope")) {
+				if s == "openid" {
+					openIDCount++
+				}
+			}
+
+			if openIDCount != 1 {
+				t.Errorf("openid count in scope = %d, want 1 (scope=%q)", openIDCount, parsed.Query().Get("scope"))
+			}
+		})
+	}
+}
+
 func TestExchangeVerifiesTheIDToken(t *testing.T) {
 	t.Parallel()
 

--- a/api/pkg/core/auth/oidc/client_test.go
+++ b/api/pkg/core/auth/oidc/client_test.go
@@ -109,6 +109,43 @@ func jsonTokenResponse(rawIDToken string) func(w http.ResponseWriter, r *http.Re
 	}
 }
 
+// assertingTokenResponse wraps jsonTokenResponse with assertions on the actual
+// token request, so a regression like a missing redirect_uri (which real IdPs
+// reject with invalid_grant) fails a test instead of only ever being caught
+// against a live provider.
+func assertingTokenResponse(
+	t *testing.T,
+	wantCode, wantVerifier, wantRedirectURI, rawIDToken string,
+) func(w http.ResponseWriter, r *http.Request) {
+	t.Helper()
+
+	inner := jsonTokenResponse(rawIDToken)
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("r.ParseForm: %v", err)
+		}
+
+		if got := r.PostFormValue("code"); got != wantCode {
+			t.Errorf("token request code = %q, want %q", got, wantCode)
+		}
+
+		if got := r.PostFormValue("code_verifier"); got != wantVerifier {
+			t.Errorf("token request code_verifier = %q, want %q", got, wantVerifier)
+		}
+
+		if got := r.PostFormValue("redirect_uri"); got != wantRedirectURI {
+			t.Errorf("token request redirect_uri = %q, want %q", got, wantRedirectURI)
+		}
+
+		if got := r.PostFormValue("grant_type"); got != "authorization_code" {
+			t.Errorf("token request grant_type = %q, want %q", got, "authorization_code")
+		}
+
+		inner(w, r)
+	}
+}
+
 func invalidGrantResponse() func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -265,11 +302,11 @@ func TestExchangeVerifiesTheIDToken(t *testing.T) {
 	provider := testProvider(idp.srv.URL)
 
 	rawIDToken := signClaims(t, idp.key, idp.keyID, baseClaims(idp.srv.URL, provider.ClientID, testNonce))
-	idp.setTokenHandler(jsonTokenResponse(rawIDToken))
+	idp.setTokenHandler(assertingTokenResponse(t, "test-code", "test-verifier", testRedirectURI, rawIDToken))
 
 	c := newTestClient(t)
 
-	ts, err := c.Exchange(context.Background(), provider, "test-code", "test-verifier", testNonce)
+	ts, err := c.Exchange(context.Background(), provider, "test-code", "test-verifier", testNonce, testRedirectURI)
 	if err != nil {
 		t.Fatalf("Exchange: %v", err)
 	}
@@ -294,9 +331,41 @@ func TestExchangeRejectsANonceMismatch(t *testing.T) {
 
 	c := newTestClient(t)
 
-	_, err := c.Exchange(context.Background(), provider, "test-code", "test-verifier", "wrong-nonce")
+	_, err := c.Exchange(context.Background(), provider, "test-code", "test-verifier", "wrong-nonce", testRedirectURI)
 	if !errors.Is(err, oidc.ErrNonceMismatch) {
 		t.Errorf("Exchange = %v, want ErrNonceMismatch", err)
+	}
+}
+
+func TestExchangeRejectsAnEmptyNonce(t *testing.T) {
+	t.Parallel()
+
+	idp := newTestIdP(t)
+	provider := testProvider(idp.srv.URL)
+
+	// The IdP token happens to omit the nonce claim too: an empty argument must
+	// still be rejected up front, rather than comparing "" == "" and passing.
+	rawIDToken := signClaims(t, idp.key, idp.keyID, baseClaims(idp.srv.URL, provider.ClientID, ""))
+	idp.setTokenHandler(jsonTokenResponse(rawIDToken))
+
+	c := newTestClient(t)
+
+	_, err := c.Exchange(context.Background(), provider, "test-code", "test-verifier", "", testRedirectURI)
+	if !errors.Is(err, oidc.ErrNonceMismatch) {
+		t.Errorf("Exchange = %v, want ErrNonceMismatch", err)
+	}
+}
+
+func TestExchangeRejectsAnEmptyVerifier(t *testing.T) {
+	t.Parallel()
+
+	idp := newTestIdP(t)
+	provider := testProvider(idp.srv.URL)
+	c := newTestClient(t)
+
+	_, err := c.Exchange(context.Background(), provider, "test-code", "", testNonce, testRedirectURI)
+	if !errors.Is(err, oidc.ErrExchangeFailed) {
+		t.Errorf("Exchange = %v, want ErrExchangeFailed", err)
 	}
 }
 
@@ -313,7 +382,7 @@ func TestExchangeRejectsAnExpiredIDToken(t *testing.T) {
 
 	c := newTestClient(t)
 
-	_, err := c.Exchange(context.Background(), provider, "test-code", "test-verifier", testNonce)
+	_, err := c.Exchange(context.Background(), provider, "test-code", "test-verifier", testNonce, testRedirectURI)
 	if !errors.Is(err, oidc.ErrIDTokenInvalid) {
 		t.Errorf("Exchange = %v, want ErrIDTokenInvalid", err)
 	}
@@ -336,7 +405,7 @@ func TestExchangeRejectsABadSignature(t *testing.T) {
 
 	c := newTestClient(t)
 
-	_, err = c.Exchange(context.Background(), provider, "test-code", "test-verifier", testNonce)
+	_, err = c.Exchange(context.Background(), provider, "test-code", "test-verifier", testNonce, testRedirectURI)
 	if !errors.Is(err, oidc.ErrIDTokenInvalid) {
 		t.Errorf("Exchange = %v, want ErrIDTokenInvalid", err)
 	}
@@ -351,7 +420,7 @@ func TestExchangeSurfacesATokenEndpointError(t *testing.T) {
 
 	c := newTestClient(t)
 
-	_, err := c.Exchange(context.Background(), provider, "bad-code", "test-verifier", testNonce)
+	_, err := c.Exchange(context.Background(), provider, "bad-code", "test-verifier", testNonce, testRedirectURI)
 	if !errors.Is(err, oidc.ErrExchangeFailed) {
 		t.Errorf("Exchange = %v, want ErrExchangeFailed", err)
 	}
@@ -369,7 +438,7 @@ func TestExchangeReadsTheSIDClaim(t *testing.T) {
 		claims["sid"] = "session-abc"
 		idp.setTokenHandler(jsonTokenResponse(signClaims(t, idp.key, idp.keyID, claims)))
 
-		ts, err := c.Exchange(context.Background(), provider, "test-code", "test-verifier", testNonce)
+		ts, err := c.Exchange(context.Background(), provider, "test-code", "test-verifier", testNonce, testRedirectURI)
 		if err != nil {
 			t.Fatalf("Exchange: %v", err)
 		}
@@ -383,7 +452,7 @@ func TestExchangeReadsTheSIDClaim(t *testing.T) {
 		claims := baseClaims(idp.srv.URL, provider.ClientID, testNonce)
 		idp.setTokenHandler(jsonTokenResponse(signClaims(t, idp.key, idp.keyID, claims)))
 
-		ts, err := c.Exchange(context.Background(), provider, "test-code", "test-verifier", testNonce)
+		ts, err := c.Exchange(context.Background(), provider, "test-code", "test-verifier", testNonce, testRedirectURI)
 		if err != nil {
 			t.Fatalf("Exchange: %v", err)
 		}

--- a/api/pkg/core/auth/oidc_claims.go
+++ b/api/pkg/core/auth/oidc_claims.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package auth
+
+import "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
+
+func (s *Service) mapClaims(
+	provider oidcproviders.OIDCProvider,
+	tokenSet *oidcproviders.TokenSet,
+) (username string, isAdmin, allowed bool) {
+	username, ok := usernameClaim(tokenSet.Claims, provider.UsernameClaim)
+	if !ok {
+		return "", false, false
+	}
+
+	if provider.RoleClaim == nil {
+		return username, false, true
+	}
+
+	values := claimValues(tokenSet.Claims, *provider.RoleClaim)
+
+	allowed = len(provider.AllowedValues) == 0 || intersects(values, provider.AllowedValues)
+	isAdmin = len(provider.AdminValues) > 0 && intersects(values, provider.AdminValues)
+
+	return username, isAdmin, allowed
+}
+
+func usernameClaim(claims map[string]any, key string) (string, bool) {
+	raw, ok := claims[key]
+	if !ok {
+		return "", false
+	}
+
+	username, ok := raw.(string)
+	if !ok || username == "" {
+		return "", false
+	}
+
+	return username, true
+}
+
+func claimValues(claims map[string]any, key string) []string {
+	switch v := claims[key].(type) {
+	case string:
+		return []string{v}
+	case []string:
+		return v
+	case []any:
+		values := make([]string, 0, len(v))
+
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				values = append(values, s)
+			}
+		}
+
+		return values
+	default:
+		return nil
+	}
+}
+
+func intersects(a, b []string) bool {
+	set := make(map[string]struct{}, len(b))
+	for _, v := range b {
+		set[v] = struct{}{}
+	}
+
+	for _, v := range a {
+		if _, ok := set[v]; ok {
+			return true
+		}
+	}
+
+	return false
+}

--- a/api/pkg/core/auth/oidc_claims.go
+++ b/api/pkg/core/auth/oidc_claims.go
@@ -20,9 +20,13 @@ func (s *Service) mapClaims(
 	values := claimValues(tokenSet.Claims, *provider.RoleClaim)
 
 	allowed = len(provider.AllowedValues) == 0 || intersects(values, provider.AllowedValues)
-	isAdmin = len(provider.AdminValues) > 0 && intersects(values, provider.AdminValues)
+	isAdmin = mapsAdminRole(provider) && intersects(values, provider.AdminValues)
 
 	return username, isAdmin, allowed
+}
+
+func mapsAdminRole(provider oidcproviders.OIDCProvider) bool {
+	return provider.RoleClaim != nil && len(provider.AdminValues) > 0
 }
 
 func usernameClaim(claims map[string]any, key string) (string, bool) {

--- a/api/pkg/core/auth/oidc_identity.go
+++ b/api/pkg/core/auth/oidc_identity.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/federatedidentities"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/users"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/transaction"
+)
+
+func (s *Service) resolveIdentity(
+	ctx context.Context,
+	provider oidcproviders.OIDCProvider,
+	tokenSet *oidcproviders.TokenSet,
+	username string,
+) (*users.User, error) {
+	fi, err := s.deps.FederatedIdentitiesRepository.Get(ctx, federatedidentities.GetFederatedIdentityOpts{
+		Subject:    tokenSet.Subject,
+		ProviderID: provider.ID,
+	})
+	if err == nil {
+		return s.reuseIdentity(ctx, *fi, tokenSet)
+	}
+
+	if !errors.Is(err, domain.ErrNotFound) {
+		return nil, fmt.Errorf("s.deps.FederatedIdentitiesRepository.Get: %w", err)
+	}
+
+	user, err := s.deps.UsersRepository.GetByUsername(ctx, username)
+	if err == nil {
+		return s.linkIdentity(ctx, provider, tokenSet, user)
+	}
+
+	if !errors.Is(err, domain.ErrNotFound) {
+		return nil, fmt.Errorf("s.deps.UsersRepository.GetByUsername: %w", err)
+	}
+
+	if !provider.AutoProvision {
+		return nil, ErrOIDCNoAccount
+	}
+
+	return s.provisionIdentity(ctx, provider, tokenSet, username)
+}
+
+func (s *Service) reuseIdentity(
+	ctx context.Context,
+	fi federatedidentities.FederatedIdentity,
+	tokenSet *oidcproviders.TokenSet,
+) (*users.User, error) {
+	user, err := s.deps.UsersRepository.GetByID(ctx, fi.UserID)
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.UsersRepository.GetByID: %w", err)
+	}
+
+	err = s.deps.FederatedIdentitiesRepository.Update(ctx, federatedidentities.UpdateFederatedIdentityOpts{
+		ID:          fi.ID,
+		Claims:      tokenSet.Claims,
+		LastLoginAt: s.now(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.FederatedIdentitiesRepository.Update: %w", err)
+	}
+
+	return user, nil
+}
+
+func (s *Service) linkIdentity(
+	ctx context.Context,
+	provider oidcproviders.OIDCProvider,
+	tokenSet *oidcproviders.TokenSet,
+	user *users.User,
+) (*users.User, error) {
+	_, err := s.deps.FederatedIdentitiesRepository.Create(ctx, federatedidentities.CreateFederatedIdentityOpts{
+		Subject:    tokenSet.Subject,
+		ProviderID: provider.ID,
+		UserID:     user.ID,
+		Claims:     tokenSet.Claims,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.FederatedIdentitiesRepository.Create: %w", err)
+	}
+
+	return user, nil
+}
+
+func (s *Service) provisionIdentity(
+	ctx context.Context,
+	provider oidcproviders.OIDCProvider,
+	tokenSet *oidcproviders.TokenSet,
+	username string,
+) (*users.User, error) {
+	var user *users.User
+
+	err := s.deps.Transactor.WithinTx(ctx, transaction.TxOpts{}, func(ctx context.Context) error {
+		var err error
+
+		user, err = s.deps.UsersRepository.Create(ctx, users.CreateUserOpts{Name: username, IsAdmin: false})
+		if err != nil {
+			return fmt.Errorf("s.deps.UsersRepository.Create: %w", err)
+		}
+
+		_, err = s.deps.FederatedIdentitiesRepository.Create(ctx, federatedidentities.CreateFederatedIdentityOpts{
+			Subject:    tokenSet.Subject,
+			ProviderID: provider.ID,
+			UserID:     user.ID,
+			Claims:     tokenSet.Claims,
+		})
+		if err != nil {
+			return fmt.Errorf("s.deps.FederatedIdentitiesRepository.Create: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.Transactor.WithinTx: %w", err)
+	}
+
+	return user, nil
+}

--- a/api/pkg/core/auth/oidc_login.go
+++ b/api/pkg/core/auth/oidc_login.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -211,7 +212,9 @@ func nilIfEmpty(s string) *string {
 }
 
 func safeRedirectPath(p string) string {
-	if !strings.HasPrefix(p, "/") || strings.HasPrefix(p, "//") || strings.Contains(p, "\\") {
+	u, err := url.Parse(p)
+	if err != nil || u.Scheme != "" || u.Host != "" ||
+		!strings.HasPrefix(u.Path, "/") || strings.HasPrefix(u.Path, "//") || strings.Contains(u.Path, "\\") {
 		return "/"
 	}
 

--- a/api/pkg/core/auth/oidc_login.go
+++ b/api/pkg/core/auth/oidc_login.go
@@ -136,8 +136,8 @@ func (s *Service) FinishOIDCLogin(ctx context.Context, opts FinishOIDCLoginOpts)
 		return nil, err
 	}
 
-	if _, err := s.deps.UsersRepository.Update(ctx, users.UpdateUserOpts{ID: user.ID, IsAdmin: isAdmin}); err != nil {
-		return nil, fmt.Errorf("s.deps.UsersRepository.Update: %w", err)
+	if err := s.syncIsAdmin(ctx, *provider, user, isAdmin); err != nil {
+		return nil, err
 	}
 
 	session, err := s.deps.SessionService.Create(ctx, sessions.CreateSessionOpts{
@@ -151,6 +151,39 @@ func (s *Service) FinishOIDCLogin(ctx context.Context, opts FinishOIDCLoginOpts)
 	}
 
 	return &OIDCLoginResult{Session: session, Redirect: safeRedirectPath(payload.Redirect)}, nil
+}
+
+func (s *Service) syncIsAdmin(
+	ctx context.Context,
+	provider oidcproviders.OIDCProvider,
+	user *users.User,
+	isAdmin bool,
+) error {
+	if !mapsAdminRole(provider) {
+		return nil
+	}
+
+	if user.IsAdmin && !isAdmin {
+		admins, err := s.deps.UsersRepository.CountAdmins(ctx)
+		if err != nil {
+			return fmt.Errorf("s.deps.UsersRepository.CountAdmins: %w", err)
+		}
+
+		if admins <= 1 {
+			s.deps.Logger.WarnContext(ctx,
+				"kept the last admin: the oidc provider maps them to a non-admin role",
+				"userID", user.ID, "providerID", provider.ID,
+			)
+
+			return nil
+		}
+	}
+
+	if _, err := s.deps.UsersRepository.Update(ctx, users.UpdateUserOpts{ID: user.ID, IsAdmin: isAdmin}); err != nil {
+		return fmt.Errorf("s.deps.UsersRepository.Update: %w", err)
+	}
+
+	return nil
 }
 
 func (s *Service) now() time.Time {

--- a/api/pkg/core/auth/oidc_login.go
+++ b/api/pkg/core/auth/oidc_login.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidc"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/users"
+	"golang.org/x/oauth2"
+)
+
+const stateTokenBytes = 32
+
+type oidcStatePayload struct {
+	IssuedAt   time.Time
+	State      string
+	Nonce      string
+	Verifier   string
+	Redirect   string
+	ProviderID uuid.UUID
+}
+
+func (s *Service) StartOIDCLogin(ctx context.Context, opts StartOIDCLoginOpts) (*OIDCStart, error) {
+	provider, err := s.deps.OIDCProvidersRepository.GetByID(ctx, opts.ProviderID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil, ErrOIDCUnavailable
+		}
+
+		return nil, fmt.Errorf("%w: %w", ErrOIDCUnavailable, err)
+	}
+
+	state, err := randomToken()
+	if err != nil {
+		return nil, fmt.Errorf("randomToken: %w", err)
+	}
+
+	nonce, err := randomToken()
+	if err != nil {
+		return nil, fmt.Errorf("randomToken: %w", err)
+	}
+
+	verifier := oauth2.GenerateVerifier()
+
+	authCodeURL, err := s.deps.OIDCClient.AuthCodeURL(ctx, *provider, oidcproviders.AuthCodeParams{
+		RedirectURI: s.cfg.RedirectURI,
+		State:       state,
+		Nonce:       nonce,
+		Verifier:    verifier,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrOIDCUnavailable, err)
+	}
+
+	cookieValue, err := s.encodeState(oidcStatePayload{
+		ProviderID: provider.ID,
+		State:      state,
+		Nonce:      nonce,
+		Verifier:   verifier,
+		Redirect:   opts.Redirect,
+		IssuedAt:   s.now(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("s.encodeState: %w", err)
+	}
+
+	return &OIDCStart{
+		AuthCodeURL:      authCodeURL,
+		StateCookieValue: cookieValue,
+		ExpiresAt:        s.now().Add(s.cfg.StateCookieTTL),
+	}, nil
+}
+
+func (s *Service) FinishOIDCLogin(ctx context.Context, opts FinishOIDCLoginOpts) (*OIDCLoginResult, error) {
+	payload, err := s.decodeState(opts.StateCookieValue)
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.State == "" || payload.State != opts.State {
+		return nil, ErrOIDCState
+	}
+
+	if s.now().Sub(payload.IssuedAt) > s.cfg.StateCookieTTL {
+		return nil, ErrOIDCState
+	}
+
+	if opts.ErrorParam == "access_denied" {
+		return nil, ErrOIDCDenied
+	}
+
+	if opts.ErrorParam != "" {
+		return nil, ErrOIDCUnavailable
+	}
+
+	provider, err := s.deps.OIDCProvidersRepository.GetByID(ctx, payload.ProviderID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil, ErrOIDCUnavailable
+		}
+
+		return nil, fmt.Errorf("%w: %w", ErrOIDCUnavailable, err)
+	}
+
+	tokenSet, err := s.deps.OIDCClient.Exchange(
+		ctx, *provider, opts.Code, payload.Verifier, payload.Nonce, s.cfg.RedirectURI,
+	)
+	if err != nil {
+		if errors.Is(err, oidc.ErrNonceMismatch) {
+			return nil, ErrOIDCState
+		}
+
+		return nil, fmt.Errorf("%w: %w", ErrOIDCUnavailable, err)
+	}
+
+	username, isAdmin, allowed := s.mapClaims(*provider, tokenSet)
+	if !allowed {
+		return nil, ErrOIDCNotAllowed
+	}
+
+	user, err := s.resolveIdentity(ctx, *provider, tokenSet, username)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := s.deps.UsersRepository.Update(ctx, users.UpdateUserOpts{ID: user.ID, IsAdmin: isAdmin}); err != nil {
+		return nil, fmt.Errorf("s.deps.UsersRepository.Update: %w", err)
+	}
+
+	session, err := s.deps.SessionService.Create(ctx, sessions.CreateSessionOpts{
+		UserID:      user.ID,
+		AuthMethod:  sessions.AuthMethodOIDC,
+		ProviderID:  &provider.ID,
+		ProviderSID: nilIfEmpty(tokenSet.SID),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.SessionService.Create: %w", err)
+	}
+
+	return &OIDCLoginResult{Session: session, Redirect: safeRedirectPath(payload.Redirect)}, nil
+}
+
+func (s *Service) now() time.Time {
+	return s.deps.Now()
+}
+
+func (s *Service) encodeState(payload oidcStatePayload) (string, error) {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("json.Marshal: %w", err)
+	}
+
+	sealed, err := s.deps.StateCipher.Seal(raw)
+	if err != nil {
+		return "", fmt.Errorf("s.deps.StateCipher.Seal: %w", err)
+	}
+
+	return base64.RawURLEncoding.EncodeToString(sealed), nil
+}
+
+func (s *Service) decodeState(cookieValue string) (*oidcStatePayload, error) {
+	if cookieValue == "" {
+		return nil, ErrOIDCState
+	}
+
+	sealed, err := base64.RawURLEncoding.DecodeString(cookieValue)
+	if err != nil {
+		return nil, ErrOIDCState
+	}
+
+	raw, err := s.deps.StateCipher.Open(sealed)
+	if err != nil {
+		return nil, ErrOIDCState
+	}
+
+	var payload oidcStatePayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, ErrOIDCState
+	}
+
+	return &payload, nil
+}
+
+func randomToken() (string, error) {
+	buf := make([]byte, stateTokenBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("rand.Read: %w", err)
+	}
+
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+func nilIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+
+	return &s
+}
+
+func safeRedirectPath(p string) string {
+	if !strings.HasPrefix(p, "/") || strings.HasPrefix(p, "//") || strings.Contains(p, "\\") {
+		return "/"
+	}
+
+	return p
+}

--- a/api/pkg/core/auth/oidc_login_internal_test.go
+++ b/api/pkg/core/auth/oidc_login_internal_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package auth
+
+import "testing"
+
+func TestSafeRedirectPath(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		in   string
+		want string
+	}{
+		"vide":                             {in: "", want: "/"},
+		"pas de slash initial":             {in: "foo", want: "/"},
+		"chemin local valide":              {in: "/ok", want: "/ok"},
+		"double slash protocol-relative":   {in: "//x", want: "/"},
+		"antislash":                        {in: "/a\\b", want: "/"},
+		"URL avec schéma et hôte":          {in: "https://x", want: "/"},
+		"tabulation avant un double slash": {in: "/\t/evil.example.com", want: "/"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := safeRedirectPath(tc.in); got != tc.want {
+				t.Errorf("safeRedirectPath(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/api/pkg/core/auth/oidc_login_test.go
+++ b/api/pkg/core/auth/oidc_login_test.go
@@ -5,6 +5,7 @@ package auth_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -518,8 +519,8 @@ func TestFinishOIDCLoginHappyPathIssuesOIDCSession(t *testing.T) {
 		t.Errorf("Redirect = %q, want /library", got.Redirect)
 	}
 
-	if f.ur.updateCalls != 1 {
-		t.Errorf("UsersRepository.Update appelée %d fois, want 1", f.ur.updateCalls)
+	if f.ur.updateCalls != 0 {
+		t.Errorf("UsersRepository.Update appelée %d fois sans RoleClaim configuré, want 0", f.ur.updateCalls)
 	}
 }
 
@@ -937,6 +938,110 @@ func TestFinishOIDCLoginRecomputesIsAdminOnEveryBranch(t *testing.T) {
 
 			if !f.ur.gotUpdate.IsAdmin {
 				t.Error("IsAdmin non recalculé à true")
+			}
+		})
+	}
+}
+
+func TestFinishOIDCLoginNeverDemotesWhenTheProviderMapsNoAdminRole(t *testing.T) {
+	t.Parallel()
+
+	role := roleClaimKey
+
+	tests := map[string]func(*fakes){
+		"aucun RoleClaim":  func(*fakes) {},
+		"AdminValues vide": func(f *fakes) { f.opr.provider.RoleClaim = &role },
+	}
+
+	for name, setup := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newFakes()
+			f.ur.user.IsAdmin = true
+			f.ur.adminCount = 12
+			setup(f)
+
+			svc := f.svc(t)
+
+			cookie, state := startCookie(t, f, svc)
+
+			got, err := svc.FinishOIDCLogin(context.Background(), auth.FinishOIDCLoginOpts{
+				Code:             testOIDCCode,
+				State:            state,
+				StateCookieValue: cookie,
+			})
+			if err != nil {
+				t.Fatalf("FinishOIDCLogin: %v", err)
+			}
+
+			if got.Session == nil {
+				t.Fatal("Session nil")
+			}
+
+			if f.ur.updateCalls != 0 {
+				t.Errorf("UsersRepository.Update appelée %d fois, want 0 (%+v)", f.ur.updateCalls, f.ur.gotUpdate)
+			}
+		})
+	}
+}
+
+func TestFinishOIDCLoginKeepsTheLastAdminWhenTheProviderDemotesThem(t *testing.T) {
+	t.Parallel()
+
+	role := roleClaimKey
+
+	tests := map[string]struct {
+		adminCount     int
+		wantUpdate     bool
+		wantWarnLogged bool
+	}{
+		"dernier admin":  {adminCount: 1, wantUpdate: false, wantWarnLogged: true},
+		"un autre admin": {adminCount: 2, wantUpdate: true, wantWarnLogged: false},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newFakes()
+			f.opr.provider.RoleClaim = &role
+			f.opr.provider.AdminValues = []string{adminRole}
+			f.oc.tokenSet.Claims[roleClaimKey] = guestRole
+			f.ur.user.IsAdmin = true
+			f.ur.adminCount = tc.adminCount
+
+			svc := f.svc(t)
+
+			cookie, state := startCookie(t, f, svc)
+
+			got, err := svc.FinishOIDCLogin(context.Background(), auth.FinishOIDCLoginOpts{
+				Code:             testOIDCCode,
+				State:            state,
+				StateCookieValue: cookie,
+			})
+			if err != nil {
+				t.Fatalf("FinishOIDCLogin: %v", err)
+			}
+
+			if got.Session == nil {
+				t.Fatal("Session nil")
+			}
+
+			if tc.wantUpdate {
+				if f.ur.updateCalls != 1 {
+					t.Fatalf("UsersRepository.Update appelée %d fois, want 1", f.ur.updateCalls)
+				}
+
+				if f.ur.gotUpdate.IsAdmin {
+					t.Error("IsAdmin = true, want false : la rétrogradation doit s'appliquer")
+				}
+			} else if f.ur.updateCalls != 0 {
+				t.Errorf("le dernier admin a été rétrogradé (%+v)", f.ur.gotUpdate)
+			}
+
+			if got := strings.Contains(f.logs.String(), "kept the last admin"); got != tc.wantWarnLogged {
+				t.Errorf("log d'avertissement présent = %v, want %v (logs: %s)", got, tc.wantWarnLogged, f.logs)
 			}
 		})
 	}

--- a/api/pkg/core/auth/oidc_login_test.go
+++ b/api/pkg/core/auth/oidc_login_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/users"
 )
 
 const (
@@ -736,12 +737,16 @@ func TestResolveIdentityReusesExistingFederatedIdentity(t *testing.T) {
 	t.Parallel()
 
 	f := newFakes()
+
+	linkedUser := &users.User{ID: uuid.New(), Name: "bob"}
+	f.ur.byID[linkedUser.ID] = linkedUser
+
 	f.fir.getErr = nil
 	f.fir.fi = &federatedidentities.FederatedIdentity{
 		ID:         uuid.New(),
 		Subject:    testSubject,
 		ProviderID: f.opr.provider.ID,
-		UserID:     f.ur.user.ID,
+		UserID:     linkedUser.ID,
 	}
 
 	svc := f.svc(t)
@@ -756,8 +761,20 @@ func TestResolveIdentityReusesExistingFederatedIdentity(t *testing.T) {
 		t.Fatalf("FinishOIDCLogin: %v", err)
 	}
 
-	if f.ss.gotOpts.UserID != f.ur.user.ID {
-		t.Errorf("UserID = %v, want %v", f.ss.gotOpts.UserID, f.ur.user.ID)
+	wantGetOpts := federatedidentities.GetFederatedIdentityOpts{
+		Subject:    testSubject,
+		ProviderID: f.opr.provider.ID,
+	}
+	if f.fir.gotGetOpts != wantGetOpts {
+		t.Errorf("GetFederatedIdentityOpts = %+v, want %+v", f.fir.gotGetOpts, wantGetOpts)
+	}
+
+	if f.ur.gotID != linkedUser.ID {
+		t.Errorf("UsersRepository.GetByID a reçu %v, want %v (fi.UserID)", f.ur.gotID, linkedUser.ID)
+	}
+
+	if f.ss.gotOpts.UserID != linkedUser.ID {
+		t.Errorf("UserID de la session = %v, want %v", f.ss.gotOpts.UserID, linkedUser.ID)
 	}
 
 	if f.ur.byIDCalls != 1 {

--- a/api/pkg/core/auth/oidc_login_test.go
+++ b/api/pkg/core/auth/oidc_login_test.go
@@ -1,0 +1,926 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/federatedidentities"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidc"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+)
+
+const (
+	testOIDCCode     = "the-code"
+	testRedirectPath = "/library"
+	roleClaimKey     = "role"
+	staffRole        = "staff"
+	adminRole        = "admin"
+	guestRole        = "guest"
+)
+
+type fakeOIDCProvidersRepo struct {
+	err      error
+	provider *oidcproviders.OIDCProvider
+	gotID    uuid.UUID
+	calls    int
+}
+
+func (f *fakeOIDCProvidersRepo) GetByID(_ context.Context, id uuid.UUID) (*oidcproviders.OIDCProvider, error) {
+	f.calls++
+	f.gotID = id
+
+	if f.err != nil {
+		return nil, f.err
+	}
+
+	return f.provider, nil
+}
+
+func (f *fakeOIDCProvidersRepo) GetByIssuerURL(context.Context, string) (*oidcproviders.OIDCProvider, error) {
+	panic("GetByIssuerURL n'est pas utilisée par le service auth")
+}
+
+func (f *fakeOIDCProvidersRepo) Create(
+	context.Context,
+	oidcproviders.CreateOIDCProviderOpts,
+) (*oidcproviders.OIDCProvider, error) {
+	panic("Create n'est pas utilisée par le service auth")
+}
+
+func (f *fakeOIDCProvidersRepo) Update(
+	context.Context,
+	uuid.UUID,
+	oidcproviders.UpdateOIDCProviderOpts,
+) (*oidcproviders.OIDCProvider, error) {
+	panic("Update n'est pas utilisée par le service auth")
+}
+
+func (f *fakeOIDCProvidersRepo) DeleteByID(context.Context, uuid.UUID) error {
+	panic("DeleteByID n'est pas utilisée par le service auth")
+}
+
+func (f *fakeOIDCProvidersRepo) GetAll(context.Context) ([]oidcproviders.LightOIDCProvider, error) {
+	panic("GetAll n'est pas utilisée par le service auth")
+}
+
+func (f *fakeOIDCProvidersRepo) GetUsers(context.Context, uuid.UUID) ([]oidcproviders.OIDCProviderUser, error) {
+	panic("GetUsers n'est pas utilisée par le service auth")
+}
+
+type fakeFederatedIdentitiesRepo struct {
+	getErr        error
+	createErr     error
+	updateErr     error
+	fi            *federatedidentities.FederatedIdentity
+	created       *federatedidentities.FederatedIdentity
+	gotUpdateOpts federatedidentities.UpdateFederatedIdentityOpts
+	gotGetOpts    federatedidentities.GetFederatedIdentityOpts
+	gotCreateOpts federatedidentities.CreateFederatedIdentityOpts
+	getCalls      int
+	createCalls   int
+	updateCalls   int
+}
+
+func (f *fakeFederatedIdentitiesRepo) Get(
+	_ context.Context,
+	opts federatedidentities.GetFederatedIdentityOpts,
+) (*federatedidentities.FederatedIdentity, error) {
+	f.getCalls++
+	f.gotGetOpts = opts
+
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+
+	return f.fi, nil
+}
+
+func (f *fakeFederatedIdentitiesRepo) Create(
+	_ context.Context,
+	opts federatedidentities.CreateFederatedIdentityOpts,
+) (*federatedidentities.FederatedIdentity, error) {
+	f.createCalls++
+	f.gotCreateOpts = opts
+
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+
+	if f.created != nil {
+		return f.created, nil
+	}
+
+	return &federatedidentities.FederatedIdentity{
+		ID:         uuid.New(),
+		Subject:    opts.Subject,
+		ProviderID: opts.ProviderID,
+		UserID:     opts.UserID,
+		Claims:     opts.Claims,
+	}, nil
+}
+
+func (f *fakeFederatedIdentitiesRepo) Update(
+	_ context.Context,
+	opts federatedidentities.UpdateFederatedIdentityOpts,
+) error {
+	f.updateCalls++
+	f.gotUpdateOpts = opts
+
+	return f.updateErr
+}
+
+type fakeOIDCClient struct {
+	authCodeErr    error
+	exchangeErr    error
+	tokenSet       *oidcproviders.TokenSet
+	authCodeURL    string
+	gotCode        string
+	gotVerifier    string
+	gotNonce       string
+	gotRedirectURI string
+	gotAuthParams  oidcproviders.AuthCodeParams
+	gotProvider    oidcproviders.OIDCProvider
+	authCodeCalls  int
+	exchangeCalls  int
+}
+
+func (f *fakeOIDCClient) AuthCodeURL(
+	_ context.Context,
+	provider oidcproviders.OIDCProvider,
+	params oidcproviders.AuthCodeParams,
+) (string, error) {
+	f.authCodeCalls++
+	f.gotProvider = provider
+	f.gotAuthParams = params
+
+	if f.authCodeErr != nil {
+		return "", f.authCodeErr
+	}
+
+	return f.authCodeURL, nil
+}
+
+func (f *fakeOIDCClient) Exchange(
+	_ context.Context,
+	provider oidcproviders.OIDCProvider,
+	code, verifier, nonce, redirectURI string,
+) (*oidcproviders.TokenSet, error) {
+	f.exchangeCalls++
+	f.gotProvider = provider
+	f.gotCode = code
+	f.gotVerifier = verifier
+	f.gotNonce = nonce
+	f.gotRedirectURI = redirectURI
+
+	if f.exchangeErr != nil {
+		return nil, f.exchangeErr
+	}
+
+	return f.tokenSet, nil
+}
+
+func TestStartOIDCLoginBuildsAuthCodeURLAndCookie(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+
+	got, err := f.svc(t).StartOIDCLogin(context.Background(), auth.StartOIDCLoginOpts{
+		ProviderID: f.opr.provider.ID,
+		Redirect:   testRedirectPath,
+	})
+	if err != nil {
+		t.Fatalf("StartOIDCLogin: %v", err)
+	}
+
+	if got.AuthCodeURL != f.oc.authCodeURL {
+		t.Errorf("AuthCodeURL = %q, want %q", got.AuthCodeURL, f.oc.authCodeURL)
+	}
+
+	if got.StateCookieValue == "" {
+		t.Fatal("StateCookieValue vide")
+	}
+
+	if !got.ExpiresAt.Equal(f.now.Add(f.cfg.StateCookieTTL)) {
+		t.Errorf("ExpiresAt = %v, want %v", got.ExpiresAt, f.now.Add(f.cfg.StateCookieTTL))
+	}
+
+	if f.oc.gotAuthParams.RedirectURI != oidcRedirectURI {
+		t.Errorf("RedirectURI = %q, want %q", f.oc.gotAuthParams.RedirectURI, oidcRedirectURI)
+	}
+
+	if f.oc.gotAuthParams.State == "" || f.oc.gotAuthParams.Nonce == "" || f.oc.gotAuthParams.Verifier == "" {
+		t.Errorf("AuthCodeParams incomplets: %+v", f.oc.gotAuthParams)
+	}
+}
+
+func TestStartOIDCLoginCookieRoundTripsThroughFinish(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	svc := f.svc(t)
+
+	start, err := svc.StartOIDCLogin(context.Background(), auth.StartOIDCLoginOpts{
+		ProviderID: f.opr.provider.ID,
+		Redirect:   testRedirectPath,
+	})
+	if err != nil {
+		t.Fatalf("StartOIDCLogin: %v", err)
+	}
+
+	got, err := svc.FinishOIDCLogin(context.Background(), auth.FinishOIDCLoginOpts{
+		Code:             testOIDCCode,
+		State:            f.oc.gotAuthParams.State,
+		StateCookieValue: start.StateCookieValue,
+	})
+	if err != nil {
+		t.Fatalf("FinishOIDCLogin: %v", err)
+	}
+
+	if got.Redirect != testRedirectPath {
+		t.Errorf("Redirect = %q, want /library", got.Redirect)
+	}
+
+	if f.oc.gotVerifier != f.oc.gotAuthParams.Verifier {
+		t.Errorf("Exchange a reçu verifier %q, want %q", f.oc.gotVerifier, f.oc.gotAuthParams.Verifier)
+	}
+
+	if f.oc.gotNonce != f.oc.gotAuthParams.Nonce {
+		t.Errorf("Exchange a reçu nonce %q, want %q", f.oc.gotNonce, f.oc.gotAuthParams.Nonce)
+	}
+
+	if f.oc.gotRedirectURI != oidcRedirectURI {
+		t.Errorf("Exchange a reçu redirectURI %q, want %q", f.oc.gotRedirectURI, oidcRedirectURI)
+	}
+}
+
+func TestStartOIDCLoginUnknownProviderIsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	f.opr.err = domain.ErrNotFound
+
+	_, err := f.svc(t).StartOIDCLogin(context.Background(), auth.StartOIDCLoginOpts{ProviderID: uuid.New()})
+	if !errors.Is(err, auth.ErrOIDCUnavailable) {
+		t.Errorf("err = %v, want ErrOIDCUnavailable", err)
+	}
+}
+
+func TestStartOIDCLoginRepositoryFailureIsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	f.opr.err = errors.New("connection refused")
+
+	_, err := f.svc(t).StartOIDCLogin(context.Background(), auth.StartOIDCLoginOpts{ProviderID: uuid.New()})
+	if !errors.Is(err, auth.ErrOIDCUnavailable) {
+		t.Errorf("err = %v, want ErrOIDCUnavailable", err)
+	}
+}
+
+func TestStartOIDCLoginAuthCodeURLFailureIsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	f.oc.authCodeErr = errors.New("discovery unreachable")
+
+	_, err := f.svc(t).StartOIDCLogin(context.Background(), auth.StartOIDCLoginOpts{ProviderID: f.opr.provider.ID})
+	if !errors.Is(err, auth.ErrOIDCUnavailable) {
+		t.Errorf("err = %v, want ErrOIDCUnavailable", err)
+	}
+}
+
+func startCookie(t *testing.T, f *fakes, svc *auth.Service) (string, string) {
+	t.Helper()
+
+	start, err := svc.StartOIDCLogin(context.Background(), auth.StartOIDCLoginOpts{
+		ProviderID: f.opr.provider.ID,
+		Redirect:   testRedirectPath,
+	})
+	if err != nil {
+		t.Fatalf("StartOIDCLogin: %v", err)
+	}
+
+	return start.StateCookieValue, f.oc.gotAuthParams.State
+}
+
+func TestFinishOIDCLoginRejectsMissingCookie(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	svc := f.svc(t)
+
+	_, state := startCookie(t, f, svc)
+
+	_, err := svc.FinishOIDCLogin(context.Background(), auth.FinishOIDCLoginOpts{
+		Code:  testOIDCCode,
+		State: state,
+	})
+	if !errors.Is(err, auth.ErrOIDCState) {
+		t.Errorf("err = %v, want ErrOIDCState", err)
+	}
+}
+
+func TestFinishOIDCLoginRejectsCorruptCookie(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	svc := f.svc(t)
+
+	_, state := startCookie(t, f, svc)
+
+	_, err := svc.FinishOIDCLogin(context.Background(), auth.FinishOIDCLoginOpts{
+		Code:             testOIDCCode,
+		State:            state,
+		StateCookieValue: "not-a-valid-cookie",
+	})
+	if !errors.Is(err, auth.ErrOIDCState) {
+		t.Errorf("err = %v, want ErrOIDCState", err)
+	}
+}
+
+func TestFinishOIDCLoginRejectsStateMismatch(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	svc := f.svc(t)
+
+	cookie, _ := startCookie(t, f, svc)
+
+	_, err := svc.FinishOIDCLogin(context.Background(), auth.FinishOIDCLoginOpts{
+		Code:             testOIDCCode,
+		State:            "not-the-real-state",
+		StateCookieValue: cookie,
+	})
+	if !errors.Is(err, auth.ErrOIDCState) {
+		t.Errorf("err = %v, want ErrOIDCState", err)
+	}
+}
+
+func TestFinishOIDCLoginRejectsExpiredCookie(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	svc := f.svc(t)
+
+	cookie, state := startCookie(t, f, svc)
+
+	f.now = f.now.Add(f.cfg.StateCookieTTL + time.Minute)
+
+	_, err := svc.FinishOIDCLogin(context.Background(), auth.FinishOIDCLoginOpts{
+		Code:             testOIDCCode,
+		State:            state,
+		StateCookieValue: cookie,
+	})
+	if !errors.Is(err, auth.ErrOIDCState) {
+		t.Errorf("err = %v, want ErrOIDCState", err)
+	}
+}
+
+func TestFinishOIDCLoginDenied(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	svc := f.svc(t)
+
+	cookie, state := startCookie(t, f, svc)
+
+	_, err := svc.FinishOIDCLogin(context.Background(), auth.FinishOIDCLoginOpts{
+		State:            state,
+		StateCookieValue: cookie,
+		ErrorParam:       "access_denied",
+	})
+	if !errors.Is(err, auth.ErrOIDCDenied) {
+		t.Errorf("err = %v, want ErrOIDCDenied", err)
+	}
+}
+
+func TestFinishOIDCLoginOtherErrorParamIsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	svc := f.svc(t)
+
+	cookie, state := startCookie(t, f, svc)
+
+	_, err := svc.FinishOIDCLogin(context.Background(), auth.FinishOIDCLoginOpts{
+		State:            state,
+		StateCookieValue: cookie,
+		ErrorParam:       "server_error",
+	})
+	if !errors.Is(err, auth.ErrOIDCUnavailable) {
+		t.Errorf("err = %v, want ErrOIDCUnavailable", err)
+	}
+}
+
+func TestFinishOIDCLoginProviderDeletedMidFlow(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	svc := f.svc(t)
+
+	cookie, state := startCookie(t, f, svc)
+
+	f.opr.err = domain.ErrNotFound
+
+	_, err := svc.FinishOIDCLogin(context.Background(), auth.FinishOIDCLoginOpts{
+		Code:             testOIDCCode,
+		State:            state,
+		StateCookieValue: cookie,
+	})
+	if !errors.Is(err, auth.ErrOIDCUnavailable) {
+		t.Errorf("err = %v, want ErrOIDCUnavailable", err)
+	}
+}
+
+func TestFinishOIDCLoginNonceMismatchIsState(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	svc := f.svc(t)
+
+	cookie, state := startCookie(t, f, svc)
+
+	f.oc.exchangeErr = oidc.ErrNonceMismatch
+
+	_, err := svc.FinishOIDCLogin(context.Background(), auth.FinishOIDCLoginOpts{
+		Code:             testOIDCCode,
+		State:            state,
+		StateCookieValue: cookie,
+	})
+	if !errors.Is(err, auth.ErrOIDCState) {
+		t.Errorf("err = %v, want ErrOIDCState", err)
+	}
+}
+
+func TestFinishOIDCLoginOtherExchangeErrorIsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	svc := f.svc(t)
+
+	cookie, state := startCookie(t, f, svc)
+
+	f.oc.exchangeErr = errors.New("token endpoint down")
+
+	_, err := svc.FinishOIDCLogin(context.Background(), auth.FinishOIDCLoginOpts{
+		Code:             testOIDCCode,
+		State:            state,
+		StateCookieValue: cookie,
+	})
+	if !errors.Is(err, auth.ErrOIDCUnavailable) {
+		t.Errorf("err = %v, want ErrOIDCUnavailable", err)
+	}
+}
+
+func TestFinishOIDCLoginHappyPathIssuesOIDCSession(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	svc := f.svc(t)
+
+	cookie, state := startCookie(t, f, svc)
+
+	got, err := svc.FinishOIDCLogin(context.Background(), auth.FinishOIDCLoginOpts{
+		Code:             testOIDCCode,
+		State:            state,
+		StateCookieValue: cookie,
+	})
+	if err != nil {
+		t.Fatalf("FinishOIDCLogin: %v", err)
+	}
+
+	if got.Session == nil {
+		t.Fatal("Session nil")
+	}
+
+	if f.ss.gotOpts.AuthMethod != sessions.AuthMethodOIDC {
+		t.Errorf("AuthMethod = %v, want AuthMethodOIDC", f.ss.gotOpts.AuthMethod)
+	}
+
+	if f.ss.gotOpts.ProviderID == nil || *f.ss.gotOpts.ProviderID != f.opr.provider.ID {
+		t.Errorf("ProviderID = %v, want %v", f.ss.gotOpts.ProviderID, f.opr.provider.ID)
+	}
+
+	if f.ss.gotOpts.ProviderSID == nil || *f.ss.gotOpts.ProviderSID != f.oc.tokenSet.SID {
+		t.Errorf("ProviderSID = %v, want %v", f.ss.gotOpts.ProviderSID, f.oc.tokenSet.SID)
+	}
+
+	if got.Redirect != testRedirectPath {
+		t.Errorf("Redirect = %q, want /library", got.Redirect)
+	}
+
+	if f.ur.updateCalls != 1 {
+		t.Errorf("UsersRepository.Update appelée %d fois, want 1", f.ur.updateCalls)
+	}
+}
+
+func TestFinishOIDCLoginUnsafeRedirectFallsBackToRoot(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	svc := f.svc(t)
+
+	start, err := svc.StartOIDCLogin(context.Background(), auth.StartOIDCLoginOpts{
+		ProviderID: f.opr.provider.ID,
+		Redirect:   "//evil.example.com",
+	})
+	if err != nil {
+		t.Fatalf("StartOIDCLogin: %v", err)
+	}
+
+	got, err := svc.FinishOIDCLogin(context.Background(), auth.FinishOIDCLoginOpts{
+		Code:             testOIDCCode,
+		State:            f.oc.gotAuthParams.State,
+		StateCookieValue: start.StateCookieValue,
+	})
+	if err != nil {
+		t.Fatalf("FinishOIDCLogin: %v", err)
+	}
+
+	if got.Redirect != "/" {
+		t.Errorf("Redirect = %q, want /", got.Redirect)
+	}
+}
+
+func TestFinishOIDCLoginNotAllowedByClaims(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	role := roleClaimKey
+	f.opr.provider.RoleClaim = &role
+	f.opr.provider.AllowedValues = []string{staffRole}
+	f.oc.tokenSet.Claims[roleClaimKey] = guestRole
+
+	svc := f.svc(t)
+
+	cookie, state := startCookie(t, f, svc)
+
+	_, err := svc.FinishOIDCLogin(context.Background(), auth.FinishOIDCLoginOpts{
+		Code:             testOIDCCode,
+		State:            state,
+		StateCookieValue: cookie,
+	})
+	if !errors.Is(err, auth.ErrOIDCNotAllowed) {
+		t.Errorf("err = %v, want ErrOIDCNotAllowed", err)
+	}
+}
+
+func TestMapClaims(t *testing.T) {
+	t.Parallel()
+
+	role := roleClaimKey
+
+	tests := map[string]struct {
+		claims       map[string]any
+		wantUsername string
+		provider     oidcproviders.OIDCProvider
+		wantIsAdmin  bool
+		wantAllowed  bool
+	}{
+		"RoleClaim nil => jamais admin, toujours autorisé": {
+			provider:     oidcproviders.OIDCProvider{UsernameClaim: usernameClaimKey},
+			claims:       map[string]any{usernameClaimKey: userName},
+			wantUsername: userName,
+			wantIsAdmin:  false,
+			wantAllowed:  true,
+		},
+		"AllowedValues vide => autorisé sans restriction": {
+			provider:     oidcproviders.OIDCProvider{UsernameClaim: usernameClaimKey, RoleClaim: &role},
+			claims:       map[string]any{usernameClaimKey: userName, roleClaimKey: guestRole},
+			wantUsername: userName,
+			wantIsAdmin:  false,
+			wantAllowed:  true,
+		},
+		"AllowedValues non vide et intersecte => autorisé": {
+			provider: oidcproviders.OIDCProvider{
+				UsernameClaim: usernameClaimKey,
+				RoleClaim:     &role,
+				AllowedValues: []string{staffRole, adminRole},
+			},
+			claims:       map[string]any{usernameClaimKey: userName, roleClaimKey: staffRole},
+			wantUsername: userName,
+			wantIsAdmin:  false,
+			wantAllowed:  true,
+		},
+		"AllowedValues non vide et disjoint => refusé": {
+			provider: oidcproviders.OIDCProvider{
+				UsernameClaim: usernameClaimKey,
+				RoleClaim:     &role,
+				AllowedValues: []string{staffRole, adminRole},
+			},
+			claims:       map[string]any{usernameClaimKey: userName, roleClaimKey: guestRole},
+			wantUsername: userName,
+			wantIsAdmin:  false,
+			wantAllowed:  false,
+		},
+		"AdminValues vide => jamais admin": {
+			provider: oidcproviders.OIDCProvider{
+				UsernameClaim: usernameClaimKey,
+				RoleClaim:     &role,
+			},
+			claims:       map[string]any{usernameClaimKey: userName, roleClaimKey: adminRole},
+			wantUsername: userName,
+			wantIsAdmin:  false,
+			wantAllowed:  true,
+		},
+		"AdminValues intersecte => admin": {
+			provider: oidcproviders.OIDCProvider{
+				UsernameClaim: usernameClaimKey,
+				RoleClaim:     &role,
+				AdminValues:   []string{adminRole},
+			},
+			claims:       map[string]any{usernameClaimKey: userName, roleClaimKey: adminRole},
+			wantUsername: userName,
+			wantIsAdmin:  true,
+			wantAllowed:  true,
+		},
+		"AdminValues disjoint => pas admin": {
+			provider: oidcproviders.OIDCProvider{
+				UsernameClaim: usernameClaimKey,
+				RoleClaim:     &role,
+				AdminValues:   []string{adminRole},
+			},
+			claims:       map[string]any{usernameClaimKey: userName, roleClaimKey: staffRole},
+			wantUsername: userName,
+			wantIsAdmin:  false,
+			wantAllowed:  true,
+		},
+		"role en tableau de string": {
+			provider: oidcproviders.OIDCProvider{
+				UsernameClaim: usernameClaimKey,
+				RoleClaim:     &role,
+				AdminValues:   []string{adminRole},
+			},
+			claims:       map[string]any{usernameClaimKey: userName, roleClaimKey: []string{staffRole, adminRole}},
+			wantUsername: userName,
+			wantIsAdmin:  true,
+			wantAllowed:  true,
+		},
+		"role en tableau any": {
+			provider: oidcproviders.OIDCProvider{
+				UsernameClaim: usernameClaimKey,
+				RoleClaim:     &role,
+				AdminValues:   []string{adminRole},
+			},
+			claims:       map[string]any{usernameClaimKey: userName, roleClaimKey: []any{staffRole, adminRole}},
+			wantUsername: userName,
+			wantIsAdmin:  true,
+			wantAllowed:  true,
+		},
+		"UsernameClaim manquant => non autorisé": {
+			provider:     oidcproviders.OIDCProvider{UsernameClaim: usernameClaimKey},
+			claims:       map[string]any{},
+			wantUsername: "",
+			wantIsAdmin:  false,
+			wantAllowed:  false,
+		},
+		"UsernameClaim de mauvais type => non autorisé": {
+			provider:     oidcproviders.OIDCProvider{UsernameClaim: usernameClaimKey},
+			claims:       map[string]any{usernameClaimKey: 42},
+			wantUsername: "",
+			wantIsAdmin:  false,
+			wantAllowed:  false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newFakes()
+			*f.opr.provider = tc.provider
+			f.oc.tokenSet.Claims = tc.claims
+
+			svc := f.svc(t)
+
+			cookie, state := startCookie(t, f, svc)
+
+			_, err := svc.FinishOIDCLogin(context.Background(), auth.FinishOIDCLoginOpts{
+				Code:             testOIDCCode,
+				State:            state,
+				StateCookieValue: cookie,
+			})
+
+			if !tc.wantAllowed {
+				if !errors.Is(err, auth.ErrOIDCNotAllowed) {
+					t.Fatalf("err = %v, want ErrOIDCNotAllowed", err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("FinishOIDCLogin: %v", err)
+			}
+
+			if f.ur.gotUpdate.IsAdmin != tc.wantIsAdmin {
+				t.Errorf("IsAdmin = %v, want %v", f.ur.gotUpdate.IsAdmin, tc.wantIsAdmin)
+			}
+
+			if f.ur.gotName != tc.wantUsername {
+				t.Errorf("username utilisé = %q, want %q", f.ur.gotName, tc.wantUsername)
+			}
+		})
+	}
+}
+
+func TestResolveIdentityReusesExistingFederatedIdentity(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	f.fir.getErr = nil
+	f.fir.fi = &federatedidentities.FederatedIdentity{
+		ID:         uuid.New(),
+		Subject:    testSubject,
+		ProviderID: f.opr.provider.ID,
+		UserID:     f.ur.user.ID,
+	}
+
+	svc := f.svc(t)
+
+	cookie, state := startCookie(t, f, svc)
+
+	if _, err := svc.FinishOIDCLogin(context.Background(), auth.FinishOIDCLoginOpts{
+		Code:             testOIDCCode,
+		State:            state,
+		StateCookieValue: cookie,
+	}); err != nil {
+		t.Fatalf("FinishOIDCLogin: %v", err)
+	}
+
+	if f.ss.gotOpts.UserID != f.ur.user.ID {
+		t.Errorf("UserID = %v, want %v", f.ss.gotOpts.UserID, f.ur.user.ID)
+	}
+
+	if f.ur.byIDCalls != 1 {
+		t.Errorf("UsersRepository.GetByID appelée %d fois, want 1", f.ur.byIDCalls)
+	}
+
+	if f.fir.updateCalls != 1 {
+		t.Errorf("FederatedIdentitiesRepository.Update appelée %d fois, want 1", f.fir.updateCalls)
+	}
+
+	if f.fir.createCalls != 0 {
+		t.Errorf("FederatedIdentitiesRepository.Create appelée %d fois, want 0", f.fir.createCalls)
+	}
+
+	if f.tr.calls != 0 {
+		t.Errorf("WithinTx appelée %d fois, want 0 (pas de provisioning)", f.tr.calls)
+	}
+}
+
+func TestResolveIdentityLinksLocalUsernameMatch(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+
+	svc := f.svc(t)
+
+	cookie, state := startCookie(t, f, svc)
+
+	if _, err := svc.FinishOIDCLogin(context.Background(), auth.FinishOIDCLoginOpts{
+		Code:             testOIDCCode,
+		State:            state,
+		StateCookieValue: cookie,
+	}); err != nil {
+		t.Fatalf("FinishOIDCLogin: %v", err)
+	}
+
+	if f.ss.gotOpts.UserID != f.ur.user.ID {
+		t.Errorf("UserID = %v, want %v", f.ss.gotOpts.UserID, f.ur.user.ID)
+	}
+
+	if f.fir.createCalls != 1 {
+		t.Errorf("FederatedIdentitiesRepository.Create appelée %d fois, want 1", f.fir.createCalls)
+	}
+
+	if f.fir.gotCreateOpts.UserID != f.ur.user.ID || f.fir.gotCreateOpts.Subject != f.oc.tokenSet.Subject {
+		t.Errorf("CreateFederatedIdentityOpts = %+v", f.fir.gotCreateOpts)
+	}
+
+	if f.tr.calls != 0 {
+		t.Errorf("WithinTx appelée %d fois, want 0 (pas de provisioning)", f.tr.calls)
+	}
+}
+
+func TestResolveIdentityAutoProvisionsNewUser(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	f.opr.provider.AutoProvision = true
+	f.ur.byNameErr = domain.ErrNotFound
+
+	svc := f.svc(t)
+
+	cookie, state := startCookie(t, f, svc)
+
+	got, err := svc.FinishOIDCLogin(context.Background(), auth.FinishOIDCLoginOpts{
+		Code:             testOIDCCode,
+		State:            state,
+		StateCookieValue: cookie,
+	})
+	if err != nil {
+		t.Fatalf("FinishOIDCLogin: %v", err)
+	}
+
+	if got.Session == nil {
+		t.Fatal("Session nil")
+	}
+
+	if f.tr.calls != 1 {
+		t.Errorf("WithinTx appelée %d fois, want 1", f.tr.calls)
+	}
+
+	if !f.ur.inTx {
+		t.Error("UsersRepository.Create n'a pas reçu le ctx transactionnel")
+	}
+
+	if f.fir.createCalls != 1 {
+		t.Errorf("FederatedIdentitiesRepository.Create appelée %d fois, want 1", f.fir.createCalls)
+	}
+}
+
+func TestResolveIdentityNoMatchWithoutAutoProvisionRefuses(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	f.opr.provider.AutoProvision = false
+	f.ur.byNameErr = domain.ErrNotFound
+
+	svc := f.svc(t)
+
+	cookie, state := startCookie(t, f, svc)
+
+	_, err := svc.FinishOIDCLogin(context.Background(), auth.FinishOIDCLoginOpts{
+		Code:             testOIDCCode,
+		State:            state,
+		StateCookieValue: cookie,
+	})
+	if !errors.Is(err, auth.ErrOIDCNoAccount) {
+		t.Errorf("err = %v, want ErrOIDCNoAccount", err)
+	}
+
+	if f.tr.calls != 0 {
+		t.Errorf("WithinTx appelée %d fois, want 0", f.tr.calls)
+	}
+}
+
+func TestFinishOIDCLoginRecomputesIsAdminOnEveryBranch(t *testing.T) {
+	t.Parallel()
+
+	role := roleClaimKey
+
+	tests := map[string]func(*fakes){
+		"identité existante": func(f *fakes) {
+			f.fir.fi = &federatedidentities.FederatedIdentity{
+				ID: uuid.New(), Subject: testSubject, ProviderID: f.opr.provider.ID, UserID: f.ur.user.ID,
+			}
+			f.fir.getErr = nil
+		},
+		"lien par username": func(*fakes) {},
+		"auto-provisioning": func(f *fakes) {
+			f.opr.provider.AutoProvision = true
+			f.ur.byNameErr = domain.ErrNotFound
+		},
+	}
+
+	for name, setup := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newFakes()
+			f.opr.provider.RoleClaim = &role
+			f.opr.provider.AdminValues = []string{adminRole}
+			f.oc.tokenSet.Claims[roleClaimKey] = adminRole
+			setup(f)
+
+			svc := f.svc(t)
+
+			cookie, state := startCookie(t, f, svc)
+
+			if _, err := svc.FinishOIDCLogin(context.Background(), auth.FinishOIDCLoginOpts{
+				Code:             testOIDCCode,
+				State:            state,
+				StateCookieValue: cookie,
+			}); err != nil {
+				t.Fatalf("FinishOIDCLogin: %v", err)
+			}
+
+			if f.ur.updateCalls != 1 {
+				t.Fatalf("UsersRepository.Update appelée %d fois, want 1", f.ur.updateCalls)
+			}
+
+			if !f.ur.gotUpdate.IsAdmin {
+				t.Error("IsAdmin non recalculé à true")
+			}
+		})
+	}
+}

--- a/api/pkg/core/auth/oidcproviders/domain.go
+++ b/api/pkg/core/auth/oidcproviders/domain.go
@@ -102,7 +102,7 @@ type Discovery struct {
 
 type Client interface {
 	AuthCodeURL(ctx context.Context, provider OIDCProvider, params AuthCodeParams) (string, error)
-	Exchange(ctx context.Context, provider OIDCProvider, code, verifier, nonce string) (*TokenSet, error)
+	Exchange(ctx context.Context, provider OIDCProvider, code, verifier, nonce, redirectURI string) (*TokenSet, error)
 }
 
 type AuthCodeParams struct {

--- a/api/pkg/core/auth/oidcproviders/domain.go
+++ b/api/pkg/core/auth/oidcproviders/domain.go
@@ -99,3 +99,21 @@ type Discovery struct {
 	UserInfoEndpoint      string
 	EndSessionEndpoint    string
 }
+
+type Client interface {
+	AuthCodeURL(ctx context.Context, provider OIDCProvider, params AuthCodeParams) (string, error)
+	Exchange(ctx context.Context, provider OIDCProvider, code, verifier, nonce string) (*TokenSet, error)
+}
+
+type AuthCodeParams struct {
+	RedirectURI string
+	State       string
+	Nonce       string
+	Verifier    string
+}
+
+type TokenSet struct {
+	Claims  map[string]any
+	Subject string
+	SID     string
+}

--- a/api/pkg/core/auth/oidcproviders/service.go
+++ b/api/pkg/core/auth/oidcproviders/service.go
@@ -19,6 +19,10 @@ type Cipher interface {
 	Seal(plaintext []byte) ([]byte, error)
 }
 
+type CacheEvictor interface {
+	Evict(id uuid.UUID)
+}
+
 type ServiceConfig struct {
 	RedirectURI string
 }
@@ -35,6 +39,7 @@ type ServiceDeps struct {
 	Repository OIDCProvidersRepository
 	Cipher     Cipher
 	Discoverer Discoverer
+	Cache      CacheEvictor
 }
 
 func (deps *ServiceDeps) Validate() error {
@@ -48,6 +53,10 @@ func (deps *ServiceDeps) Validate() error {
 
 	if deps.Discoverer == nil {
 		return errors.New("discoverer is required")
+	}
+
+	if deps.Cache == nil {
+		return errors.New("cache is required")
 	}
 
 	return nil
@@ -183,6 +192,8 @@ func (s *Service) Update(ctx context.Context, id uuid.UUID, opts UpdateOpts) (*O
 		return nil, fmt.Errorf("s.deps.Repository.Update: %w", err)
 	}
 
+	s.deps.Cache.Evict(id)
+
 	return withoutSecret(provider), nil
 }
 
@@ -190,6 +201,8 @@ func (s *Service) Delete(ctx context.Context, id uuid.UUID) error {
 	if err := s.deps.Repository.DeleteByID(ctx, id); err != nil {
 		return fmt.Errorf("s.deps.Repository.DeleteByID: %w", err)
 	}
+
+	s.deps.Cache.Evict(id)
 
 	return nil
 }

--- a/api/pkg/core/auth/oidcproviders/service_test.go
+++ b/api/pkg/core/auth/oidcproviders/service_test.go
@@ -109,17 +109,26 @@ func (f *fakeDiscoverer) Discover(_ context.Context, issuerURL string) (*oidcpro
 	}, nil
 }
 
+type fakeCacheEvictor struct {
+	evicted []uuid.UUID
+}
+
+func (f *fakeCacheEvictor) Evict(id uuid.UUID) {
+	f.evicted = append(f.evicted, id)
+}
+
 func newService(
 	t *testing.T,
 	repo *fakeRepository,
 	cipher *fakeCipher,
 	disco *fakeDiscoverer,
+	cache *fakeCacheEvictor,
 ) *oidcproviders.Service {
 	t.Helper()
 
 	s, err := oidcproviders.NewService(
 		oidcproviders.ServiceConfig{RedirectURI: testRedirect},
-		oidcproviders.ServiceDeps{Repository: repo, Cipher: cipher, Discoverer: disco},
+		oidcproviders.ServiceDeps{Repository: repo, Cipher: cipher, Discoverer: disco, Cache: cache},
 	)
 	if err != nil {
 		t.Fatalf("NewService: %v", err)
@@ -143,7 +152,7 @@ func TestCreateEncryptsTheClientSecret(t *testing.T) {
 	t.Parallel()
 
 	repo := &fakeRepository{provider: &oidcproviders.OIDCProvider{ID: uuid.New()}}
-	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{})
+	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{}, &fakeCacheEvictor{})
 
 	if _, err := s.Create(context.Background(), createOpts()); err != nil {
 		t.Fatalf("Create: %v", err)
@@ -170,7 +179,7 @@ func TestCreateNeverReturnsTheSecret(t *testing.T) {
 		ID:              uuid.New(),
 		ClientSecretEnc: []byte("sealed:s3cr3t"),
 	}}
-	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{})
+	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{}, &fakeCacheEvictor{})
 
 	got, err := s.Create(context.Background(), createOpts())
 	if err != nil {
@@ -186,7 +195,7 @@ func TestCreateRejectsAnIssuerThatFailsDiscovery(t *testing.T) {
 	t.Parallel()
 
 	repo := &fakeRepository{}
-	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{err: errors.New("connection refused")})
+	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{err: errors.New("connection refused")}, &fakeCacheEvictor{})
 
 	_, err := s.Create(context.Background(), createOpts())
 	if !errors.Is(err, oidcproviders.ErrUnreachableIssuer) {
@@ -202,7 +211,8 @@ func TestCreateRejectsAnIncompleteDiscoveryDocument(t *testing.T) {
 	t.Parallel()
 
 	repo := &fakeRepository{}
-	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{err: oidcproviders.ErrIncompleteDiscovery})
+	disco := &fakeDiscoverer{err: oidcproviders.ErrIncompleteDiscovery}
+	s := newService(t, repo, &fakeCipher{}, disco, &fakeCacheEvictor{})
 
 	_, err := s.Create(context.Background(), createOpts())
 	if !errors.Is(err, oidcproviders.ErrIncompleteIssuer) {
@@ -222,7 +232,7 @@ func TestCreatePropagatesADuplicateIssuer(t *testing.T) {
 	t.Parallel()
 
 	repo := &fakeRepository{err: domain.ErrAlreadyExists}
-	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{})
+	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{}, &fakeCacheEvictor{})
 
 	if _, err := s.Create(context.Background(), createOpts()); !errors.Is(err, domain.ErrAlreadyExists) {
 		t.Errorf("Create = %v, want domain.ErrAlreadyExists", err)
@@ -234,7 +244,7 @@ func TestUpdateNeverSealsASecret(t *testing.T) {
 
 	repo := &fakeRepository{provider: &oidcproviders.OIDCProvider{ID: uuid.New()}}
 	cipher := &fakeCipher{}
-	s := newService(t, repo, cipher, &fakeDiscoverer{})
+	s := newService(t, repo, cipher, &fakeDiscoverer{}, &fakeCacheEvictor{})
 
 	_, err := s.Update(context.Background(), uuid.New(), oidcproviders.UpdateOpts{
 		DisplayName:   testDisplayName,
@@ -260,7 +270,7 @@ func TestUpdateRejectsAnIssuerThatFailsDiscovery(t *testing.T) {
 	t.Parallel()
 
 	repo := &fakeRepository{}
-	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{err: errors.New("no such host")})
+	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{err: errors.New("no such host")}, &fakeCacheEvictor{})
 
 	_, err := s.Update(context.Background(), uuid.New(), oidcproviders.UpdateOpts{IssuerURL: testIssuerURL})
 	if !errors.Is(err, oidcproviders.ErrUnreachableIssuer) {
@@ -272,6 +282,23 @@ func TestUpdateRejectsAnIssuerThatFailsDiscovery(t *testing.T) {
 	}
 }
 
+func TestUpdateEvictsTheCache(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepository{provider: &oidcproviders.OIDCProvider{ID: uuid.New()}}
+	cache := &fakeCacheEvictor{}
+	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{}, cache)
+
+	id := uuid.New()
+	if _, err := s.Update(context.Background(), id, oidcproviders.UpdateOpts{IssuerURL: testIssuerURL}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	if len(cache.evicted) != 1 || cache.evicted[0] != id {
+		t.Errorf("evicted = %v, want [%s]", cache.evicted, id)
+	}
+}
+
 func TestListReturnsTheLightShape(t *testing.T) {
 	t.Parallel()
 
@@ -280,7 +307,7 @@ func TestListReturnsTheLightShape(t *testing.T) {
 		{ID: id1, DisplayName: "Authentik"},
 		{ID: id2, DisplayName: testDisplayName},
 	}}
-	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{})
+	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{}, &fakeCacheEvictor{})
 
 	got, err := s.List(context.Background())
 	if err != nil {
@@ -300,7 +327,7 @@ func TestGetByIDNeverReturnsTheSecret(t *testing.T) {
 		DisplayName:     testDisplayName,
 		ClientSecretEnc: []byte("sealed:s3cr3t"),
 	}}
-	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{})
+	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{}, &fakeCacheEvictor{})
 
 	got, err := s.GetByID(context.Background(), uuid.New())
 	if err != nil {
@@ -327,7 +354,7 @@ func TestGetByIDReturnsTheLinkedUsers(t *testing.T) {
 			{ID: userID, Username: "alice", LinkedAt: linkedAt, IsAdmin: true},
 		},
 	}
-	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{})
+	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{}, &fakeCacheEvictor{})
 
 	got, err := s.GetByID(context.Background(), uuid.New())
 	if err != nil {
@@ -347,7 +374,7 @@ func TestGetByIDReturnsTheLinkedUsers(t *testing.T) {
 func TestGetByIDPropagatesNotFound(t *testing.T) {
 	t.Parallel()
 
-	s := newService(t, &fakeRepository{err: domain.ErrNotFound}, &fakeCipher{}, &fakeDiscoverer{})
+	s := newService(t, &fakeRepository{err: domain.ErrNotFound}, &fakeCipher{}, &fakeDiscoverer{}, &fakeCacheEvictor{})
 
 	if _, err := s.GetByID(context.Background(), uuid.New()); !errors.Is(err, domain.ErrNotFound) {
 		t.Errorf("GetByID = %v, want domain.ErrNotFound", err)
@@ -358,7 +385,7 @@ func TestDeleteForwardsTheID(t *testing.T) {
 	t.Parallel()
 
 	repo := &fakeRepository{}
-	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{})
+	s := newService(t, repo, &fakeCipher{}, &fakeDiscoverer{}, &fakeCacheEvictor{})
 
 	id := uuid.New()
 	if err := s.Delete(context.Background(), id); err != nil {
@@ -370,10 +397,26 @@ func TestDeleteForwardsTheID(t *testing.T) {
 	}
 }
 
+func TestDeleteEvictsTheCache(t *testing.T) {
+	t.Parallel()
+
+	cache := &fakeCacheEvictor{}
+	s := newService(t, &fakeRepository{}, &fakeCipher{}, &fakeDiscoverer{}, cache)
+
+	id := uuid.New()
+	if err := s.Delete(context.Background(), id); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if len(cache.evicted) != 1 || cache.evicted[0] != id {
+		t.Errorf("evicted = %v, want [%s]", cache.evicted, id)
+	}
+}
+
 func TestDeletePropagatesNotFound(t *testing.T) {
 	t.Parallel()
 
-	s := newService(t, &fakeRepository{err: domain.ErrNotFound}, &fakeCipher{}, &fakeDiscoverer{})
+	s := newService(t, &fakeRepository{err: domain.ErrNotFound}, &fakeCipher{}, &fakeDiscoverer{}, &fakeCacheEvictor{})
 
 	if err := s.Delete(context.Background(), uuid.New()); !errors.Is(err, domain.ErrNotFound) {
 		t.Errorf("Delete = %v, want domain.ErrNotFound", err)
@@ -390,7 +433,7 @@ func TestProbeReportsTheEndpointsAndTheRedirectURI(t *testing.T) {
 		UserInfoEndpoint:      testIssuerURL + "/userinfo",
 		EndSessionEndpoint:    testIssuerURL + "/logout",
 	}}
-	s := newService(t, &fakeRepository{}, &fakeCipher{}, disco)
+	s := newService(t, &fakeRepository{}, &fakeCipher{}, disco, &fakeCacheEvictor{})
 
 	got, err := s.Probe(context.Background(), testIssuerURL)
 	if err != nil {
@@ -413,7 +456,7 @@ func TestProbeReportsTheEndpointsAndTheRedirectURI(t *testing.T) {
 func TestProbeReportsAProviderWithoutEndSession(t *testing.T) {
 	t.Parallel()
 
-	s := newService(t, &fakeRepository{}, &fakeCipher{}, &fakeDiscoverer{})
+	s := newService(t, &fakeRepository{}, &fakeCipher{}, &fakeDiscoverer{}, &fakeCacheEvictor{})
 
 	got, err := s.Probe(context.Background(), testIssuerURL)
 	if err != nil {
@@ -428,7 +471,7 @@ func TestProbeReportsAProviderWithoutEndSession(t *testing.T) {
 func TestProbeRejectsAnUnreachableIssuer(t *testing.T) {
 	t.Parallel()
 
-	s := newService(t, &fakeRepository{}, &fakeCipher{}, &fakeDiscoverer{err: errors.New("timeout")})
+	s := newService(t, &fakeRepository{}, &fakeCipher{}, &fakeDiscoverer{err: errors.New("timeout")}, &fakeCacheEvictor{})
 
 	if _, err := s.Probe(context.Background(), testIssuerURL); !errors.Is(err, oidcproviders.ErrUnreachableIssuer) {
 		t.Errorf("Probe = %v, want ErrUnreachableIssuer", err)
@@ -438,7 +481,8 @@ func TestProbeRejectsAnUnreachableIssuer(t *testing.T) {
 func TestProbeRejectsAnIncompleteDiscoveryDocument(t *testing.T) {
 	t.Parallel()
 
-	s := newService(t, &fakeRepository{}, &fakeCipher{}, &fakeDiscoverer{err: oidcproviders.ErrIncompleteDiscovery})
+	disco := &fakeDiscoverer{err: oidcproviders.ErrIncompleteDiscovery}
+	s := newService(t, &fakeRepository{}, &fakeCipher{}, disco, &fakeCacheEvictor{})
 
 	if _, err := s.Probe(context.Background(), testIssuerURL); !errors.Is(err, oidcproviders.ErrIncompleteIssuer) {
 		t.Errorf("Probe = %v, want ErrIncompleteIssuer", err)
@@ -474,6 +518,13 @@ func TestNewServiceValidates(t *testing.T) {
 			cfg:     oidcproviders.ServiceConfig{RedirectURI: testRedirect},
 			deps:    oidcproviders.ServiceDeps{Repository: &fakeRepository{}, Cipher: &fakeCipher{}},
 			wantErr: "deps.Validate: discoverer is required",
+		},
+		"no cache": {
+			cfg: oidcproviders.ServiceConfig{RedirectURI: testRedirect},
+			deps: oidcproviders.ServiceDeps{
+				Repository: &fakeRepository{}, Cipher: &fakeCipher{}, Discoverer: &fakeDiscoverer{},
+			},
+			wantErr: "deps.Validate: cache is required",
 		},
 	}
 

--- a/api/pkg/core/auth/service.go
+++ b/api/pkg/core/auth/service.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/federatedidentities"
@@ -37,6 +38,7 @@ type Deps struct {
 	FederatedIdentitiesRepository federatedidentities.FederatedIdentitiesRepository
 	OIDCClient                    oidcproviders.Client
 	StateCipher                   stateCipher
+	Logger                        *slog.Logger
 	Now                           func() time.Time
 }
 
@@ -77,6 +79,10 @@ func (deps *Deps) Validate() error {
 		return errors.New("stateCipher is required")
 	}
 
+	if deps.Logger == nil {
+		return errors.New("logger is required")
+	}
+
 	return nil
 }
 
@@ -114,6 +120,8 @@ func New(cfg Config, deps Deps) (*Service, error) {
 	if deps.Now == nil {
 		deps.Now = time.Now
 	}
+
+	deps.Logger = deps.Logger.With("component", "auth.service")
 
 	return &Service{deps: deps, cfg: cfg}, nil
 }

--- a/api/pkg/core/auth/service.go
+++ b/api/pkg/core/auth/service.go
@@ -6,9 +6,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/federatedidentities"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/hash"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/password"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/users"
@@ -17,12 +20,24 @@ import (
 
 var _ AuthService = (*Service)(nil)
 
+const defaultStateCookieTTL = 10 * time.Minute
+
+type stateCipher interface {
+	Seal(plaintext []byte) ([]byte, error)
+	Open(ciphertext []byte) ([]byte, error)
+}
+
 type Deps struct {
-	HashService     hash.HashService
-	UsersRepository users.UsersRepository
-	PwdRepository   password.PasswordCredsRepository
-	Transactor      transaction.Transactor
-	SessionService  sessions.SessionService
+	HashService                   hash.HashService
+	UsersRepository               users.UsersRepository
+	PwdRepository                 password.PasswordCredsRepository
+	Transactor                    transaction.Transactor
+	SessionService                sessions.SessionService
+	OIDCProvidersRepository       oidcproviders.OIDCProvidersRepository
+	FederatedIdentitiesRepository federatedidentities.FederatedIdentitiesRepository
+	OIDCClient                    oidcproviders.Client
+	StateCipher                   stateCipher
+	Now                           func() time.Time
 }
 
 func (deps *Deps) Validate() error {
@@ -46,19 +61,61 @@ func (deps *Deps) Validate() error {
 		return errors.New("sessionService is required")
 	}
 
+	if deps.OIDCProvidersRepository == nil {
+		return errors.New("oidcProvidersRepository is required")
+	}
+
+	if deps.FederatedIdentitiesRepository == nil {
+		return errors.New("federatedIdentitiesRepository is required")
+	}
+
+	if deps.OIDCClient == nil {
+		return errors.New("oidcClient is required")
+	}
+
+	if deps.StateCipher == nil {
+		return errors.New("stateCipher is required")
+	}
+
+	return nil
+}
+
+type Config struct {
+	RedirectURI    string
+	StateCookieTTL time.Duration
+}
+
+func (cfg *Config) Validate() error {
+	if cfg.RedirectURI == "" {
+		return errors.New("redirectURI is required")
+	}
+
+	if cfg.StateCookieTTL == 0 {
+		cfg.StateCookieTTL = defaultStateCookieTTL
+	}
+
 	return nil
 }
 
 type Service struct {
 	deps Deps
+	cfg  Config
 }
 
-func New(deps Deps) (*Service, error) {
+func New(cfg Config, deps Deps) (*Service, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("cfg.Validate: %w", err)
+	}
+
 	if err := deps.Validate(); err != nil {
 		return nil, fmt.Errorf("deps.Validate: %w", err)
 	}
 
-	return &Service{deps: deps}, nil
+	if deps.Now == nil {
+		deps.Now = time.Now
+	}
+
+	return &Service{deps: deps, cfg: cfg}, nil
 }
 
 func (s *Service) CreateUserWithPwd(ctx context.Context, opts CreateUserWithPwdOpts) (*users.User, error) {

--- a/api/pkg/core/auth/service_test.go
+++ b/api/pkg/core/auth/service_test.go
@@ -6,21 +6,28 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/hash"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/password"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/users"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/crypto"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/transaction"
 )
 
 const (
-	userName = "alice"
-	pwd      = "hunter2hunter2"
-	token    = "letoken"
+	userName         = "alice"
+	pwd              = "hunter2hunter2"
+	token            = "letoken"
+	oidcRedirectURI  = "https://app.example.com/callback"
+	testCipherKey    = "abcdefghijklmnopqrstuvwxyz012345"
+	usernameClaimKey = "preferred_username"
+	testSubject      = "sub-123"
 )
 
 type txCtxKey struct{}
@@ -95,13 +102,19 @@ func (f *fakeHashService) Match(hashed []byte, toCompare []byte) (bool, error) {
 }
 
 type fakeUsersRepository struct {
-	err       error
-	byNameErr error
-	user      *users.User
-	gotName   string
-	gotOpts   users.CreateUserOpts
-	nameCalls int
-	inTx      bool
+	byNameErr   error
+	byIDErr     error
+	updateErr   error
+	err         error
+	user        *users.User
+	gotName     string
+	gotOpts     users.CreateUserOpts
+	nameCalls   int
+	byIDCalls   int
+	updateCalls int
+	gotUpdate   users.UpdateUserOpts
+	gotID       uuid.UUID
+	inTx        bool
 }
 
 func (f *fakeUsersRepository) Create(ctx context.Context, opts users.CreateUserOpts) (*users.User, error) {
@@ -130,12 +143,29 @@ func (f *fakeUsersRepository) CountAdmins(context.Context) (int, error) {
 	panic("CountAdmins n'est pas utilisée par le service auth")
 }
 
-func (f *fakeUsersRepository) GetByID(context.Context, uuid.UUID) (*users.User, error) {
-	panic("GetByID n'est pas utilisée par le service auth")
+func (f *fakeUsersRepository) GetByID(_ context.Context, id uuid.UUID) (*users.User, error) {
+	f.byIDCalls++
+	f.gotID = id
+
+	if f.byIDErr != nil {
+		return nil, f.byIDErr
+	}
+
+	return f.user, nil
 }
 
-func (f *fakeUsersRepository) Update(context.Context, users.UpdateUserOpts) (*users.User, error) {
-	panic("Update n'est pas utilisée par le service auth")
+func (f *fakeUsersRepository) Update(_ context.Context, opts users.UpdateUserOpts) (*users.User, error) {
+	f.updateCalls++
+	f.gotUpdate = opts
+
+	if f.updateErr != nil {
+		return nil, f.updateErr
+	}
+
+	updated := *f.user
+	updated.IsAdmin = opts.IsAdmin
+
+	return &updated, nil
 }
 
 type fakePwdRepository struct {
@@ -223,20 +253,40 @@ func (f *fakeSessionService) RevokeAllForUser(context.Context, uuid.UUID) error 
 }
 
 type fakes struct {
+	now   time.Time
 	clock *clock
 	hs    *fakeHashService
 	ur    *fakeUsersRepository
 	pr    *fakePwdRepository
 	tr    *fakeTransactor
 	ss    *fakeSessionService
+	opr   *fakeOIDCProvidersRepo
+	fir   *fakeFederatedIdentitiesRepo
+	oc    *fakeOIDCClient
+	sc    *crypto.Cipher
+	cfg   auth.Config
 }
 
 func newFakes() *fakes {
 	c := &clock{}
 	user := &users.User{ID: uuid.New(), Name: userName}
+	provider := &oidcproviders.OIDCProvider{
+		ID:            uuid.New(),
+		DisplayName:   "Example IdP",
+		IssuerURL:     "https://idp.example.com",
+		ClientID:      "client-id",
+		UsernameClaim: usernameClaimKey,
+	}
+
+	sc, err := crypto.New(crypto.Config{Key: []byte(testCipherKey)})
+	if err != nil {
+		panic(err)
+	}
 
 	return &fakes{
 		clock: c,
+		cfg:   auth.Config{RedirectURI: oidcRedirectURI, StateCookieTTL: 10 * time.Minute},
+		now:   time.Date(2026, time.August, 10, 12, 0, 0, 0, time.UTC),
 		hs:    &fakeHashService{clock: c, match: true},
 		ur:    &fakeUsersRepository{user: user},
 		pr:    &fakePwdRepository{creds: &password.PasswordCreds{UserID: user.ID, Hash: "hashed:" + pwd}},
@@ -245,18 +295,34 @@ func newFakes() *fakes {
 			Session: sessions.Session{ID: uuid.New(), UserID: user.ID},
 			Token:   token,
 		}},
+		opr: &fakeOIDCProvidersRepo{provider: provider},
+		fir: &fakeFederatedIdentitiesRepo{getErr: domain.ErrNotFound},
+		oc: &fakeOIDCClient{
+			authCodeURL: "https://idp.example.com/authorize?state=letstate",
+			tokenSet: &oidcproviders.TokenSet{
+				Subject: testSubject,
+				SID:     "sid-123",
+				Claims:  map[string]any{usernameClaimKey: userName},
+			},
+		},
+		sc: sc,
 	}
 }
 
 func (f *fakes) svc(t *testing.T) *auth.Service {
 	t.Helper()
 
-	svc, err := auth.New(auth.Deps{
-		HashService:     f.hs,
-		UsersRepository: f.ur,
-		PwdRepository:   f.pr,
-		Transactor:      f.tr,
-		SessionService:  f.ss,
+	svc, err := auth.New(f.cfg, auth.Deps{
+		HashService:                   f.hs,
+		UsersRepository:               f.ur,
+		PwdRepository:                 f.pr,
+		Transactor:                    f.tr,
+		SessionService:                f.ss,
+		OIDCProvidersRepository:       f.opr,
+		FederatedIdentitiesRepository: f.fir,
+		OIDCClient:                    f.oc,
+		StateCipher:                   f.sc,
+		Now:                           func() time.Time { return f.now },
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -270,7 +336,10 @@ func TestNewRequiresTransactor(t *testing.T) {
 
 	f := newFakes()
 
-	svc, err := auth.New(auth.Deps{HashService: f.hs, UsersRepository: f.ur, PwdRepository: f.pr})
+	svc, err := auth.New(
+		auth.Config{RedirectURI: oidcRedirectURI},
+		auth.Deps{HashService: f.hs, UsersRepository: f.ur, PwdRepository: f.pr},
+	)
 	if err == nil {
 		t.Fatal("New sans transactor doit échouer")
 	}

--- a/api/pkg/core/auth/service_test.go
+++ b/api/pkg/core/auth/service_test.go
@@ -107,6 +107,7 @@ type fakeUsersRepository struct {
 	updateErr   error
 	err         error
 	user        *users.User
+	byID        map[uuid.UUID]*users.User
 	gotName     string
 	gotOpts     users.CreateUserOpts
 	nameCalls   int
@@ -151,7 +152,11 @@ func (f *fakeUsersRepository) GetByID(_ context.Context, id uuid.UUID) (*users.U
 		return nil, f.byIDErr
 	}
 
-	return f.user, nil
+	if u, ok := f.byID[id]; ok {
+		return u, nil
+	}
+
+	return nil, domain.ErrNotFound
 }
 
 func (f *fakeUsersRepository) Update(_ context.Context, opts users.UpdateUserOpts) (*users.User, error) {
@@ -288,7 +293,7 @@ func newFakes() *fakes {
 		cfg:   auth.Config{RedirectURI: oidcRedirectURI, StateCookieTTL: 10 * time.Minute},
 		now:   time.Date(2026, time.August, 10, 12, 0, 0, 0, time.UTC),
 		hs:    &fakeHashService{clock: c, match: true},
-		ur:    &fakeUsersRepository{user: user},
+		ur:    &fakeUsersRepository{user: user, byID: map[uuid.UUID]*users.User{user.ID: user}},
 		pr:    &fakePwdRepository{creds: &password.PasswordCreds{UserID: user.ID, Hash: "hashed:" + pwd}},
 		tr:    &fakeTransactor{clock: c},
 		ss: &fakeSessionService{issued: &sessions.IssuedSession{

--- a/api/pkg/core/auth/service_test.go
+++ b/api/pkg/core/auth/service_test.go
@@ -3,8 +3,10 @@
 package auth_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -105,6 +107,7 @@ type fakeUsersRepository struct {
 	byNameErr   error
 	byIDErr     error
 	updateErr   error
+	countErr    error
 	err         error
 	user        *users.User
 	byID        map[uuid.UUID]*users.User
@@ -113,6 +116,8 @@ type fakeUsersRepository struct {
 	nameCalls   int
 	byIDCalls   int
 	updateCalls int
+	adminCount  int
+	countCalls  int
 	gotUpdate   users.UpdateUserOpts
 	gotID       uuid.UUID
 	inTx        bool
@@ -141,7 +146,13 @@ func (f *fakeUsersRepository) GetByUsername(_ context.Context, name string) (*us
 }
 
 func (f *fakeUsersRepository) CountAdmins(context.Context) (int, error) {
-	panic("CountAdmins n'est pas utilisée par le service auth")
+	f.countCalls++
+
+	if f.countErr != nil {
+		return 0, f.countErr
+	}
+
+	return f.adminCount, nil
 }
 
 func (f *fakeUsersRepository) GetByID(_ context.Context, id uuid.UUID) (*users.User, error) {
@@ -269,6 +280,7 @@ type fakes struct {
 	fir   *fakeFederatedIdentitiesRepo
 	oc    *fakeOIDCClient
 	sc    *crypto.Cipher
+	logs  *bytes.Buffer
 	cfg   auth.Config
 }
 
@@ -310,12 +322,15 @@ func newFakes() *fakes {
 				Claims:  map[string]any{usernameClaimKey: userName},
 			},
 		},
-		sc: sc,
+		sc:   sc,
+		logs: &bytes.Buffer{},
 	}
 }
 
 func (f *fakes) svc(t *testing.T) *auth.Service {
 	t.Helper()
+
+	logger := slog.New(slog.NewJSONHandler(f.logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 	svc, err := auth.New(f.cfg, auth.Deps{
 		HashService:                   f.hs,
@@ -327,6 +342,7 @@ func (f *fakes) svc(t *testing.T) *auth.Service {
 		FederatedIdentitiesRepository: f.fir,
 		OIDCClient:                    f.oc,
 		StateCipher:                   f.sc,
+		Logger:                        logger,
 		Now:                           func() time.Time { return f.now },
 	})
 	if err != nil {

--- a/api/pkg/core/auth/service_test.go
+++ b/api/pkg/core/auth/service_test.go
@@ -134,6 +134,10 @@ func (f *fakeUsersRepository) GetByID(context.Context, uuid.UUID) (*users.User, 
 	panic("GetByID n'est pas utilisée par le service auth")
 }
 
+func (f *fakeUsersRepository) Update(context.Context, users.UpdateUserOpts) (*users.User, error) {
+	panic("Update n'est pas utilisée par le service auth")
+}
+
 type fakePwdRepository struct {
 	err       error
 	getErr    error

--- a/api/pkg/core/auth/sessions/domain.go
+++ b/api/pkg/core/auth/sessions/domain.go
@@ -21,11 +21,13 @@ const (
 var ErrInvalidSession = errors.New("invalid session")
 
 type Session struct {
-	CreatedAt  time.Time
-	ExpiresAt  time.Time
-	AuthMethod AuthMethod
-	ID         uuid.UUID
-	UserID     uuid.UUID
+	CreatedAt   time.Time
+	ExpiresAt   time.Time
+	ProviderSID *string
+	ProviderID  *uuid.UUID
+	AuthMethod  AuthMethod
+	ID          uuid.UUID
+	UserID      uuid.UUID
 }
 
 type IssuedSession struct {
@@ -47,8 +49,10 @@ type SessionService interface {
 }
 
 type CreateSessionOpts struct {
-	AuthMethod AuthMethod
-	UserID     uuid.UUID
+	ProviderSID *string
+	ProviderID  *uuid.UUID
+	AuthMethod  AuthMethod
+	UserID      uuid.UUID
 }
 
 type SessionsRepository interface {
@@ -61,8 +65,10 @@ type SessionsRepository interface {
 }
 
 type InsertSessionOpts struct {
-	ExpiresAt  time.Time
-	AuthMethod AuthMethod
-	TokenHash  []byte
-	UserID     uuid.UUID
+	ExpiresAt   time.Time
+	ProviderSID *string
+	ProviderID  *uuid.UUID
+	AuthMethod  AuthMethod
+	TokenHash   []byte
+	UserID      uuid.UUID
 }

--- a/api/pkg/core/auth/sessions/repository/pg/repository.go
+++ b/api/pkg/core/auth/sessions/repository/pg/repository.go
@@ -50,12 +50,14 @@ func (r *PGSessionsRepository) db(ctx context.Context) gorm.Interface[pgmodels.S
 
 func (r *PGSessionsRepository) Insert(ctx context.Context, opts sessions.InsertSessionOpts) (*sessions.Session, error) {
 	model := &pgmodels.Session{
-		ID:         uuid.New(),
-		UserID:     opts.UserID,
-		TokenHash:  opts.TokenHash,
-		AuthMethod: string(opts.AuthMethod),
-		ExpiresAt:  opts.ExpiresAt,
-		CreatedAt:  time.Now(),
+		ID:          uuid.New(),
+		UserID:      opts.UserID,
+		TokenHash:   opts.TokenHash,
+		AuthMethod:  string(opts.AuthMethod),
+		ExpiresAt:   opts.ExpiresAt,
+		CreatedAt:   time.Now(),
+		ProviderID:  opts.ProviderID,
+		ProviderSID: opts.ProviderSID,
 	}
 
 	if err := r.db(ctx).Create(ctx, model); err != nil {
@@ -132,10 +134,12 @@ func (r *PGSessionsRepository) DeleteExpired(ctx context.Context, now time.Time)
 
 func (r *PGSessionsRepository) modelToDomain(model pgmodels.Session) sessions.Session {
 	return sessions.Session{
-		ID:         model.ID,
-		UserID:     model.UserID,
-		AuthMethod: sessions.AuthMethod(model.AuthMethod),
-		CreatedAt:  model.CreatedAt,
-		ExpiresAt:  model.ExpiresAt,
+		ID:          model.ID,
+		UserID:      model.UserID,
+		AuthMethod:  sessions.AuthMethod(model.AuthMethod),
+		CreatedAt:   model.CreatedAt,
+		ExpiresAt:   model.ExpiresAt,
+		ProviderID:  model.ProviderID,
+		ProviderSID: model.ProviderSID,
 	}
 }

--- a/api/pkg/core/auth/sessions/repository/pg/repository_test.go
+++ b/api/pkg/core/auth/sessions/repository/pg/repository_test.go
@@ -170,7 +170,7 @@ func TestInsertAndGetByTokenHashRoundTripProviderIdentity(t *testing.T) {
 				WillReturnRows(
 					sqlmock.NewRows([]string{
 						"id", "user_id", "token_hash", "auth_method", "created_at", "expires_at",
-						"provider_id", "provider_s_id",
+						"provider_id", "provider_sid",
 						"User__id", "User__name", "User__is_admin", "User__created_at", "User__updated_at",
 					}).AddRow(
 						uuid.New(), userID, hash, "password", created, expires,

--- a/api/pkg/core/auth/sessions/repository/pg/repository_test.go
+++ b/api/pkg/core/auth/sessions/repository/pg/repository_test.go
@@ -110,6 +110,112 @@ func TestInsertError(t *testing.T) {
 	}
 }
 
+func TestInsertAndGetByTokenHashRoundTripProviderIdentity(t *testing.T) {
+	t.Parallel()
+
+	providerID := uuid.New()
+	providerSID := "provider-subject"
+
+	tests := map[string]struct {
+		providerID  *uuid.UUID
+		providerSID *string
+	}{
+		"provider identity set":            {providerID: &providerID, providerSID: &providerSID},
+		"plain password session (nil/nil)": {providerID: nil, providerSID: nil},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			r, mock := newRepo(t)
+
+			mock.ExpectBegin()
+			mock.ExpectQuery(`INSERT INTO "sessions"`).
+				WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+			mock.ExpectCommit()
+
+			hash := []byte("0123456789abcdef0123456789abcdef")
+
+			inserted, err := r.Insert(context.Background(), sessions.InsertSessionOpts{
+				UserID:      uuid.New(),
+				AuthMethod:  sessions.AuthMethodPassword,
+				TokenHash:   hash,
+				ExpiresAt:   time.Now().Add(time.Hour).UTC().Truncate(time.Second),
+				ProviderID:  tc.providerID,
+				ProviderSID: tc.providerSID,
+			})
+			if err != nil {
+				t.Fatalf("Insert: %v", err)
+			}
+
+			assertProviderIDEqual(t, "Insert", inserted.ProviderID, tc.providerID)
+			assertProviderSIDEqual(t, "Insert", inserted.ProviderSID, tc.providerSID)
+
+			userID := uuid.New()
+			created := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+			expires := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+
+			var providerIDCol, providerSIDCol any
+			if tc.providerID != nil {
+				providerIDCol = *tc.providerID
+			}
+
+			if tc.providerSID != nil {
+				providerSIDCol = *tc.providerSID
+			}
+
+			mock.ExpectQuery(`SELECT .* FROM "sessions" JOIN "users" "User" ON`).
+				WithArgs(hash, 1).
+				WillReturnRows(
+					sqlmock.NewRows([]string{
+						"id", "user_id", "token_hash", "auth_method", "created_at", "expires_at",
+						"provider_id", "provider_s_id",
+						"User__id", "User__name", "User__is_admin", "User__created_at", "User__updated_at",
+					}).AddRow(
+						uuid.New(), userID, hash, "password", created, expires,
+						providerIDCol, providerSIDCol,
+						userID, "alice", true, created, created,
+					),
+				)
+
+			got, _, err := r.GetByTokenHash(context.Background(), hash)
+			if err != nil {
+				t.Fatalf("GetByTokenHash: %v", err)
+			}
+
+			assertProviderIDEqual(t, "GetByTokenHash", got.ProviderID, tc.providerID)
+			assertProviderSIDEqual(t, "GetByTokenHash", got.ProviderSID, tc.providerSID)
+		})
+	}
+}
+
+func assertProviderIDEqual(t *testing.T, op string, got, want *uuid.UUID) {
+	t.Helper()
+
+	switch {
+	case want == nil:
+		if got != nil {
+			t.Errorf("%s: ProviderID = %v, want nil", op, *got)
+		}
+	case got == nil || *got != *want:
+		t.Errorf("%s: ProviderID = %v, want %v", op, got, *want)
+	}
+}
+
+func assertProviderSIDEqual(t *testing.T, op string, got, want *string) {
+	t.Helper()
+
+	switch {
+	case want == nil:
+		if got != nil {
+			t.Errorf("%s: ProviderSID = %v, want nil", op, *got)
+		}
+	case got == nil || *got != *want:
+		t.Errorf("%s: ProviderSID = %v, want %v", op, got, *want)
+	}
+}
+
 func TestGetByTokenHashJoinsUserInOneQuery(t *testing.T) {
 	t.Parallel()
 

--- a/api/pkg/core/auth/sessions/service.go
+++ b/api/pkg/core/auth/sessions/service.go
@@ -123,10 +123,12 @@ func (s *Service) Create(ctx context.Context, opts CreateSessionOpts) (*IssuedSe
 	sum := sha256.Sum256([]byte(token))
 
 	session, err := s.deps.Repository.Insert(ctx, InsertSessionOpts{
-		UserID:     opts.UserID,
-		AuthMethod: opts.AuthMethod,
-		TokenHash:  sum[:],
-		ExpiresAt:  s.deps.Now().Add(ttl.Idle),
+		UserID:      opts.UserID,
+		AuthMethod:  opts.AuthMethod,
+		TokenHash:   sum[:],
+		ExpiresAt:   s.deps.Now().Add(ttl.Idle),
+		ProviderID:  opts.ProviderID,
+		ProviderSID: opts.ProviderSID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("s.deps.Repository.Insert: %w", err)

--- a/api/pkg/core/auth/sessions/service_test.go
+++ b/api/pkg/core/auth/sessions/service_test.go
@@ -35,14 +35,14 @@ func validConfig() sessions.ServiceConfig {
 }
 
 type fakeRepository struct {
-	session      *sessions.Session
-	user         *users.User
-	gotHash      []byte
 	gotExpiry    time.Time
 	insertErr    error
 	getErr       error
 	updateErr    error
 	deleteErr    error
+	user         *users.User
+	session      *sessions.Session
+	gotHash      []byte
 	gotInsert    sessions.InsertSessionOpts
 	inserts      int
 	gets         int
@@ -306,6 +306,31 @@ func TestCreateAppliesTTLOfAuthMethod(t *testing.T) {
 				t.Errorf("AuthMethod = %v, want %v", repo.gotInsert.AuthMethod, tc.method)
 			}
 		})
+	}
+}
+
+func TestCreateForwardsProviderIdentity(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepository{}
+	providerID := uuid.New()
+	providerSID := "provider-subject"
+
+	if _, err := frozenSvc(t, repo, time.Now()).Create(context.Background(), sessions.CreateSessionOpts{
+		UserID:      uuid.New(),
+		AuthMethod:  sessions.AuthMethodOIDC,
+		ProviderID:  &providerID,
+		ProviderSID: &providerSID,
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if repo.gotInsert.ProviderID == nil || *repo.gotInsert.ProviderID != providerID {
+		t.Errorf("ProviderID = %v, want %v", repo.gotInsert.ProviderID, providerID)
+	}
+
+	if repo.gotInsert.ProviderSID == nil || *repo.gotInsert.ProviderSID != providerSID {
+		t.Errorf("ProviderSID = %v, want %v", repo.gotInsert.ProviderSID, providerSID)
 	}
 }
 

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -130,6 +130,15 @@ func (fakeAuthService) Logout(context.Context, string) error {
 	return errors.New(notImplemented)
 }
 
+func (fakeAuthService) StartOIDCLogin(context.Context, auth.StartOIDCLoginOpts) (*auth.OIDCStart, error) {
+	return nil, errors.New(notImplemented)
+}
+
+//nolint:lll
+func (fakeAuthService) FinishOIDCLogin(context.Context, auth.FinishOIDCLoginOpts) (*auth.OIDCLoginResult, error) {
+	return nil, errors.New(notImplemented)
+}
+
 type fakeOIDCProvidersService struct{}
 
 func (fakeOIDCProvidersService) List(context.Context) ([]oidcproviders.LightOIDCProvider, error) {
@@ -225,6 +234,11 @@ func newTestApp(t *testing.T, db Database, port int) (*App, *health.Registry) {
 		t.Fatalf("NewCookieManager: %v", err)
 	}
 
+	oidcStateCookies, err := sessionshttp.NewCookieManager(sessionshttp.CookieConfig{Name: "oidc_state", Path: "/"})
+	if err != nil {
+		t.Fatalf("NewCookieManager: %v", err)
+	}
+
 	setupCtrl, err := httpsetup.New(
 		httpsetup.Config{Endpoint: "/setup"},
 		httpsetup.Deps{Logger: logger, SetupService: fakeSetupService{}, Cookies: cookies},
@@ -235,7 +249,13 @@ func newTestApp(t *testing.T, db Database, port int) (*App, *health.Registry) {
 
 	authCtrl, err := httpauth.New(
 		httpauth.Config{Endpoint: "/auth"},
-		httpauth.Deps{Logger: logger, AuthService: fakeAuthService{}, Cookies: cookies},
+		httpauth.Deps{
+			Logger:           logger,
+			AuthService:      fakeAuthService{},
+			Cookies:          cookies,
+			OIDCStateCookies: oidcStateCookies,
+			ProvidersLister:  fakeOIDCProvidersService{},
+		},
 	)
 	if err != nil {
 		t.Fatalf("httpauth.New: %v", err)

--- a/api/pkg/core/setup/dosetup_test.go
+++ b/api/pkg/core/setup/dosetup_test.go
@@ -70,6 +70,14 @@ func (f *fakeAuthService) Logout(context.Context, string) error {
 	panic("Logout ne doit pas être appelée par DoSetup")
 }
 
+func (f *fakeAuthService) StartOIDCLogin(context.Context, auth.StartOIDCLoginOpts) (*auth.OIDCStart, error) {
+	panic("StartOIDCLogin ne doit pas être appelée par DoSetup")
+}
+
+func (f *fakeAuthService) FinishOIDCLogin(context.Context, auth.FinishOIDCLoginOpts) (*auth.OIDCLoginResult, error) {
+	panic("FinishOIDCLogin ne doit pas être appelée par DoSetup")
+}
+
 type stubSessionService struct {
 	err     error
 	issued  *sessions.IssuedSession

--- a/api/pkg/core/setup/service_test.go
+++ b/api/pkg/core/setup/service_test.go
@@ -36,6 +36,10 @@ func (f *fakeUsersRepository) GetByUsername(context.Context, string) (*users.Use
 	panic("GetByUsername ne doit pas être appelée par le service setup")
 }
 
+func (f *fakeUsersRepository) Update(context.Context, users.UpdateUserOpts) (*users.User, error) {
+	panic("Update ne doit pas être appelée par le service setup")
+}
+
 func depsFor(repo users.UsersRepository) setup.Deps {
 	return setup.Deps{
 		UsersRepository: repo,

--- a/api/pkg/core/users/domain.go
+++ b/api/pkg/core/users/domain.go
@@ -22,9 +22,15 @@ type UsersRepository interface {
 	GetByID(context.Context, uuid.UUID) (*User, error)
 	GetByUsername(context.Context, string) (*User, error)
 	Create(context.Context, CreateUserOpts) (*User, error)
+	Update(context.Context, UpdateUserOpts) (*User, error)
 }
 
 type CreateUserOpts struct {
 	Name    string
+	IsAdmin bool
+}
+
+type UpdateUserOpts struct {
+	ID      uuid.UUID
 	IsAdmin bool
 }

--- a/api/pkg/core/users/repository/pg/repository.go
+++ b/api/pkg/core/users/repository/pg/repository.go
@@ -110,6 +110,30 @@ func (r *PGUsersRepository) GetByUsername(ctx context.Context, name string) (*us
 	return &ret, nil
 }
 
+func (r *PGUsersRepository) Update(ctx context.Context, opts users.UpdateUserOpts) (*users.User, error) {
+	db := pgtx.From(ctx, r.deps.DB)
+	result := db.Model(&pgmodels.User{}).Where("id = ?", opts.ID).Updates(map[string]interface{}{
+		"is_admin": opts.IsAdmin,
+	})
+
+	if result.Error != nil {
+		return nil, fmt.Errorf("db.Model: %w", result.Error)
+	}
+
+	if result.RowsAffected == 0 {
+		return nil, domain.ErrNotFound
+	}
+
+	user, err := r.db(ctx).Where("id = ?", opts.ID).First(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
+	}
+
+	ret := r.modelToDomain(user)
+
+	return &ret, nil
+}
+
 func (r *PGUsersRepository) modelToDomain(model pgmodels.User) users.User {
 	return users.User{
 		ID:        model.ID,

--- a/api/pkg/core/users/repository/pg/repository.go
+++ b/api/pkg/core/users/repository/pg/repository.go
@@ -111,16 +111,12 @@ func (r *PGUsersRepository) GetByUsername(ctx context.Context, name string) (*us
 }
 
 func (r *PGUsersRepository) Update(ctx context.Context, opts users.UpdateUserOpts) (*users.User, error) {
-	db := pgtx.From(ctx, r.deps.DB)
-	result := db.Model(&pgmodels.User{}).Where("id = ?", opts.ID).Updates(map[string]interface{}{
-		"is_admin": opts.IsAdmin,
-	})
-
-	if result.Error != nil {
-		return nil, fmt.Errorf("db.Model: %w", result.Error)
+	affected, err := r.db(ctx).Where("id = ?", opts.ID).Update(ctx, "is_admin", opts.IsAdmin)
+	if err != nil {
+		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
 	}
 
-	if result.RowsAffected == 0 {
+	if affected == 0 {
 		return nil, domain.ErrNotFound
 	}
 

--- a/api/pkg/core/users/repository/pg/repository_test.go
+++ b/api/pkg/core/users/repository/pg/repository_test.go
@@ -23,6 +23,7 @@ import (
 const (
 	userNameBob   = "bob"
 	userNameAlice = "alice"
+	colName       = "name"
 )
 
 func duplicateKeyErr() error {
@@ -130,7 +131,7 @@ func TestGetByID(t *testing.T) {
 	mock.ExpectQuery(`SELECT \* FROM "users" WHERE id = \$1 ORDER BY "users"\."id" LIMIT \$2`).
 		WithArgs(id, 1).
 		WillReturnRows(
-			sqlmock.NewRows([]string{"id", "name", "is_admin", "created_at", "updated_at"}).
+			sqlmock.NewRows([]string{"id", colName, "is_admin", "created_at", "updated_at"}).
 				AddRow(id, userNameBob, true, created, updated),
 		)
 
@@ -151,7 +152,7 @@ func TestGetByIDNotFound(t *testing.T) {
 	r, mock := newRepo(t)
 
 	mock.ExpectQuery(`SELECT \* FROM "users"`).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}))
+		WillReturnRows(sqlmock.NewRows([]string{"id", colName}))
 
 	got, err := r.GetByID(context.Background(), uuid.New())
 	if !errors.Is(err, domain.ErrNotFound) {
@@ -325,7 +326,7 @@ func TestUpdate(t *testing.T) {
 	mock.ExpectQuery(`SELECT \* FROM "users" WHERE id = \$1 ORDER BY "users"\."id" LIMIT \$2`).
 		WithArgs(id, 1).
 		WillReturnRows(
-			sqlmock.NewRows([]string{"id", "name", "is_admin", "created_at", "updated_at"}).
+			sqlmock.NewRows([]string{"id", colName, "is_admin", "created_at", "updated_at"}).
 				AddRow(id, userNameBob, true, created, updated),
 		)
 

--- a/api/pkg/core/users/repository/pg/repository_test.go
+++ b/api/pkg/core/users/repository/pg/repository_test.go
@@ -306,3 +306,59 @@ func TestCreateError(t *testing.T) {
 		t.Errorf("err = %v, l'erreur d'origine n'est plus atteignable", err)
 	}
 }
+
+func TestUpdate(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newRepo(t)
+
+	id := uuid.New()
+	created := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Second)
+	updated := time.Now().UTC().Truncate(time.Second)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "users" SET "is_admin"=\$1,"updated_at"=\$2 WHERE id = \$3`).
+		WithArgs(true, sqlmock.AnyArg(), id).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	mock.ExpectQuery(`SELECT \* FROM "users" WHERE id = \$1 ORDER BY "users"\."id" LIMIT \$2`).
+		WithArgs(id, 1).
+		WillReturnRows(
+			sqlmock.NewRows([]string{"id", "name", "is_admin", "created_at", "updated_at"}).
+				AddRow(id, userNameBob, true, created, updated),
+		)
+
+	got, err := r.Update(context.Background(), users.UpdateUserOpts{ID: id, IsAdmin: true})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	want := users.User{ID: id, Name: userNameBob, IsAdmin: true, CreatedAt: created, UpdatedAt: updated}
+	if got == nil || *got != want {
+		t.Errorf("Update() = %+v, want %+v", got, want)
+	}
+}
+
+func TestUpdateNotFound(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newRepo(t)
+
+	id := uuid.New()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "users" SET "is_admin"=\$1,"updated_at"=\$2 WHERE id = \$3`).
+		WithArgs(false, sqlmock.AnyArg(), id).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	got, err := r.Update(context.Background(), users.UpdateUserOpts{ID: id, IsAdmin: false})
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("Update = %v, want domain.ErrNotFound", err)
+	}
+
+	if got != nil {
+		t.Errorf("Update a renvoyé %+v en plus de l'erreur", got)
+	}
+}

--- a/api/pkg/repository/pgmodels/session.go
+++ b/api/pkg/repository/pgmodels/session.go
@@ -9,9 +9,9 @@ import (
 )
 
 type Session struct {
-	CreatedAt   time.Time `gorm:"autoCreateTime"`
-	ExpiresAt   time.Time `gorm:"not null;index"`
-	ProviderSID *string
+	CreatedAt   time.Time  `gorm:"autoCreateTime"`
+	ExpiresAt   time.Time  `gorm:"not null;index"`
+	ProviderSID *string    `gorm:"column:provider_sid"`
 	ProviderID  *uuid.UUID `gorm:"type:uuid;index"`
 	AuthMethod  string     `gorm:"type:text;not null"`
 	TokenHash   []byte     `gorm:"type:bytea;not null;uniqueIndex"`

--- a/api/pkg/repository/pgmodels/session.go
+++ b/api/pkg/repository/pgmodels/session.go
@@ -9,13 +9,15 @@ import (
 )
 
 type Session struct {
-	CreatedAt  time.Time `gorm:"autoCreateTime"`
-	ExpiresAt  time.Time `gorm:"not null;index"`
-	AuthMethod string    `gorm:"type:text;not null"`
-	TokenHash  []byte    `gorm:"type:bytea;not null;uniqueIndex"`
-	User       User      `gorm:"foreignKey:UserID"`
-	ID         uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
-	UserID     uuid.UUID `gorm:"type:uuid;not null;index"`
+	CreatedAt   time.Time `gorm:"autoCreateTime"`
+	ExpiresAt   time.Time `gorm:"not null;index"`
+	ProviderSID *string
+	ProviderID  *uuid.UUID `gorm:"type:uuid;index"`
+	AuthMethod  string     `gorm:"type:text;not null"`
+	TokenHash   []byte     `gorm:"type:bytea;not null;uniqueIndex"`
+	User        User       `gorm:"foreignKey:UserID"`
+	ID          uuid.UUID  `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+	UserID      uuid.UUID  `gorm:"type:uuid;not null;index"`
 }
 
 func (Session) TableName() string {

--- a/web/app/composables/layoutPadding.composable.test.ts
+++ b/web/app/composables/layoutPadding.composable.test.ts
@@ -78,4 +78,39 @@ describe('useLayoutPadding', () => {
       expect(leftLayout.value).toBe('var(--navigation-drawer-width)')
     })
   })
+
+  describe('mainStyles', () => {
+    it('omits undefined layout variables so Vuetify defaults stay intact', () => {
+      displayStub.mobile.value = false
+      const store = useLayoutStore()
+      store.setPaginationEnabled(false)
+      store.setNavigationDrawerCompact(false)
+      const { mainStyles } = useLayoutPadding()
+      expect(mainStyles.value).toEqual({
+        '--v-layout-left': 'var(--navigation-drawer-width)',
+      })
+      expect(mainStyles.value).not.toHaveProperty('--v-layout-bottom')
+    })
+
+    it('includes both variables when both apply', () => {
+      displayStub.mobile.value = false
+      const store = useLayoutStore()
+      store.setPaginationEnabled(true)
+      store.setNavigationDrawerCompact(true)
+      const { mainStyles } = useLayoutPadding()
+      expect(mainStyles.value).toEqual({
+        '--v-layout-bottom': 'var(--bottom-pagination-height)',
+        '--v-layout-left': 'var(--navigation-drawer-compact-width)',
+      })
+    })
+
+    it('includes only bottom on mobile', () => {
+      displayStub.mobile.value = true
+      const { mainStyles } = useLayoutPadding()
+      expect(mainStyles.value).toEqual({
+        '--v-layout-bottom': 'var(--bottom-navigation-height)',
+      })
+      expect(mainStyles.value).not.toHaveProperty('--v-layout-left')
+    })
+  })
 })

--- a/web/app/composables/layoutPadding.composable.ts
+++ b/web/app/composables/layoutPadding.composable.ts
@@ -5,6 +5,7 @@ import { useLayoutStore } from '~/stores/layout.store'
 interface LayoutPaddingsComposable {
   bottomLayout: ComputedRef<string | undefined>
   leftLayout: ComputedRef<string | undefined>
+  mainStyles: ComputedRef<Record<string, string>>
 }
 
 export function useLayoutPadding(): LayoutPaddingsComposable {
@@ -33,8 +34,23 @@ export function useLayoutPadding(): LayoutPaddingsComposable {
     return 'var(--navigation-drawer-width)'
   })
 
+  const mainStyles = computed(() => {
+    const styles: Record<string, string> = {}
+
+    if (bottomLayout.value !== undefined) {
+      styles['--v-layout-bottom'] = bottomLayout.value
+    }
+
+    if (leftLayout.value !== undefined) {
+      styles['--v-layout-left'] = leftLayout.value
+    }
+
+    return styles
+  })
+
   return {
     bottomLayout,
     leftLayout,
+    mainStyles,
   }
 }

--- a/web/app/features/auth/components/OidcProviderButtons.test.ts
+++ b/web/app/features/auth/components/OidcProviderButtons.test.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { ProviderSummary } from '~/features/auth/composables/auth.api'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it } from 'vitest'
+import { oidcStartUrl } from '~/features/auth/composables/auth.api'
+import OidcProviderButtons from './OidcProviderButtons.vue'
+
+const providers: ProviderSummary[] = [
+  { id: 'okta', displayName: 'Okta' },
+  { id: 'google', displayName: 'Google' },
+]
+
+describe('authOidcProviderButtons', () => {
+  it('renders nothing when there are no providers', async () => {
+    const wrapper = await mountSuspended(OidcProviderButtons, {
+      props: { providers: [], redirect: '/library' },
+    })
+
+    expect(wrapper.findAll('a')).toHaveLength(0)
+  })
+
+  it('renders one real anchor per provider, linking to the oidc start url', async () => {
+    const wrapper = await mountSuspended(OidcProviderButtons, {
+      props: { providers, redirect: '/library' },
+    })
+
+    for (const provider of providers) {
+      const anchor = wrapper.find(`[data-test="login-oidc-${provider.id}"]`)
+      expect(anchor.exists()).toBe(true)
+      expect(anchor.element.tagName).toBe('A')
+      expect(anchor.attributes('href')).toBe(oidcStartUrl(provider.id, '/library'))
+    }
+  })
+
+  it('renders the provider name in the button text', async () => {
+    const wrapper = await mountSuspended(OidcProviderButtons, {
+      props: { providers, redirect: '/library' },
+    })
+
+    expect(wrapper.text()).toContain('Sign in with Okta')
+    expect(wrapper.text()).toContain('Sign in with Google')
+  })
+})

--- a/web/app/features/auth/components/OidcProviderButtons.vue
+++ b/web/app/features/auth/components/OidcProviderButtons.vue
@@ -1,0 +1,28 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+import type { ProviderSummary } from '~/features/auth/composables/auth.api'
+import { oidcStartUrl } from '~/features/auth/composables/auth.api'
+
+interface Props {
+  providers: ProviderSummary[]
+  redirect: string
+}
+
+defineProps<Props>()
+const { t } = useI18n()
+</script>
+
+<template>
+  <div v-if="providers.length" class="d-flex flex-column ga-2">
+    <VBtn
+      v-for="provider in providers"
+      :key="provider.id"
+      :href="oidcStartUrl(provider.id, redirect)"
+      variant="outlined"
+      size="large"
+      class="w-100"
+      :data-test="`login-oidc-${provider.id}`"
+      :text="t('login.oidc.button', { name: provider.displayName })"
+    />
+  </div>
+</template>

--- a/web/app/features/auth/components/OidcProviderButtons.vue
+++ b/web/app/features/auth/components/OidcProviderButtons.vue
@@ -13,7 +13,7 @@ const { t } = useI18n()
 </script>
 
 <template>
-  <div v-if="providers.length" class="d-flex flex-column ga-2">
+  <div v-if="providers.length" class="d-flex flex-column ga-2 px-4">
     <VBtn
       v-for="provider in providers"
       :key="provider.id"

--- a/web/app/features/auth/composables/auth.api.test.ts
+++ b/web/app/features/auth/composables/auth.api.test.ts
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createAuthApi } from './auth.api'
+import { ApiError } from '~/utils/api'
+import { createAuthApi, oidcStartUrl } from './auth.api'
 
 const call = vi.fn()
 
@@ -40,5 +41,55 @@ describe('createAuthApi().loginWithPwd', () => {
     await expect(createAuthApi().loginWithPwd({ username: 'a', password: 'b' })).resolves.toEqual({
       status: 'unknown-error',
     })
+  })
+})
+
+describe('createAuthApi().getProviders', () => {
+  beforeEach(() => {
+    call.mockReset()
+  })
+
+  const providers = [
+    { id: 'google', displayName: 'Google' },
+    { id: 'okta', displayName: 'Okta' },
+  ]
+
+  it('returns the provider list on success', async () => {
+    call.mockResolvedValue(providers)
+
+    await expect(createAuthApi().getProviders()).resolves.toEqual({
+      success: true,
+      data: providers,
+    })
+  })
+
+  it('returns an ApiError on failure', async () => {
+    call.mockRejectedValue({ statusCode: 500, data: {} })
+
+    const result = await createAuthApi().getProviders()
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(ApiError)
+      expect(result.error.status).toBe(500)
+    }
+  })
+})
+
+describe('oidcStartUrl', () => {
+  it('builds the start URL with an encoded redirect', () => {
+    expect(oidcStartUrl('google', '/library')).toBe('/api/auth/oidc/google/start?redirect=%2Flibrary')
+  })
+
+  it('encodes special characters in the redirect', () => {
+    expect(oidcStartUrl('okta', '/library?tag=sci-fi&sort=asc')).toBe(
+      '/api/auth/oidc/okta/start?redirect=%2Flibrary%3Ftag%3Dsci-fi%26sort%3Dasc',
+    )
+  })
+
+  it('encodes unicode characters in the redirect', () => {
+    expect(oidcStartUrl('okta', '/library/漫画')).toBe(
+      '/api/auth/oidc/okta/start?redirect=%2Flibrary%2F%E6%BC%AB%E7%94%BB',
+    )
   })
 })

--- a/web/app/features/auth/composables/auth.api.ts
+++ b/web/app/features/auth/composables/auth.api.ts
@@ -7,6 +7,12 @@ import { ApiError, initApi } from '~/utils/api'
 export interface AuthApi {
   loginWithPwd: (request: LoginWithPwdRequest) => Promise<LoginWithPwdResult>
   logout: () => Promise<ApiResponse<void>>
+  getProviders: () => Promise<ApiResponse<ProviderSummary[]>>
+}
+
+export interface ProviderSummary {
+  id: string
+  displayName: string
 }
 
 export type LoginWithPwdStatus = 'ok' | 'invalid-credentials' | 'unknown-error'
@@ -50,8 +56,25 @@ export function createAuthApi(): AuthApi {
     }
   }
 
+  async function getProviders(): Promise<ApiResponse<ProviderSummary[]>> {
+    try {
+      const providers = await api<ProviderSummary[]>('/providers')
+
+      return { success: true, data: providers }
+    } catch (error) {
+      return { success: false, error: ApiError.fromFetchError(error) }
+    }
+  }
+
   return {
     loginWithPwd,
     logout,
+    getProviders,
   }
+}
+
+export function oidcStartUrl(providerId: string, redirect: string): string {
+  const params = new URLSearchParams({ redirect })
+
+  return `/api/auth/oidc/${providerId}/start?${params.toString()}`
 }

--- a/web/app/features/auth/composables/oidc-providers.composable.test.ts
+++ b/web/app/features/auth/composables/oidc-providers.composable.test.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useOIDCProviders } from './oidc-providers.composable'
+
+const getProviders = vi.fn()
+
+vi.mock('./auth.api', () => ({ createAuthApi: () => ({ getProviders }) }))
+
+const providers = [
+  { id: 'google', displayName: 'Google' },
+  { id: 'okta', displayName: 'Okta' },
+]
+
+beforeEach(() => {
+  getProviders.mockReset()
+})
+
+describe('useOIDCProviders().fetchProviders', () => {
+  it('populates providers on success', async () => {
+    getProviders.mockResolvedValue({ success: true, data: providers })
+    const oidc = useOIDCProviders()
+
+    await oidc.fetchProviders()
+
+    expect(oidc.providers.value).toEqual(providers)
+  })
+
+  it('empties providers and logs on failure', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    getProviders.mockResolvedValue({ success: false, error: { status: 500 } })
+    const oidc = useOIDCProviders()
+    oidc.providers.value = providers
+
+    await oidc.fetchProviders()
+
+    expect(oidc.providers.value).toEqual([])
+    expect(console.error).toHaveBeenCalled()
+  })
+
+  it('toggles loading around a successful call', async () => {
+    let loadingDuringCall: boolean | undefined
+    const oidc = useOIDCProviders()
+    getProviders.mockImplementation(async () => {
+      loadingDuringCall = oidc.loading.value
+
+      return { success: true, data: providers }
+    })
+
+    await oidc.fetchProviders()
+
+    expect(loadingDuringCall).toBe(true)
+    expect(oidc.loading.value).toBe(false)
+  })
+
+  it('toggles loading around a failed call', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    let loadingDuringCall: boolean | undefined
+    const oidc = useOIDCProviders()
+    getProviders.mockImplementation(async () => {
+      loadingDuringCall = oidc.loading.value
+
+      return { success: false, error: { status: 500 } }
+    })
+
+    await oidc.fetchProviders()
+
+    expect(loadingDuringCall).toBe(true)
+    expect(oidc.loading.value).toBe(false)
+  })
+})

--- a/web/app/features/auth/composables/oidc-providers.composable.ts
+++ b/web/app/features/auth/composables/oidc-providers.composable.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { ProviderSummary } from './auth.api'
+import { createAuthApi } from './auth.api'
+
+export interface OIDCProvidersComposable {
+  providers: Ref<ProviderSummary[]>
+  loading: Ref<boolean>
+  fetchProviders: () => Promise<void>
+}
+
+export function useOIDCProviders(): OIDCProvidersComposable {
+  const api = createAuthApi()
+  const providers = ref<ProviderSummary[]>([])
+  const loading = ref(false)
+
+  async function fetchProviders(): Promise<void> {
+    loading.value = true
+
+    const res = await api.getProviders()
+    providers.value = res.success ? res.data : []
+    if (!res.success) {
+      console.error('useOIDCProviders.fetchProviders', res.error)
+    }
+
+    loading.value = false
+  }
+
+  return { providers, loading, fetchProviders }
+}

--- a/web/app/features/oidc/components/Card/Category/Claims.vue
+++ b/web/app/features/oidc/components/Card/Category/Claims.vue
@@ -17,7 +17,9 @@ async function onSubmit(values: Form): Promise<void> {
     return
   }
 
-  await update({ ...provider.value, ...values })
+  const { users: _, ...data } = provider.value
+
+  await update({ ...data, ...values })
 }
 
 const { field, handleSubmit, reset, isValid } = useForm({

--- a/web/app/features/oidc/components/Card/Category/Informations.vue
+++ b/web/app/features/oidc/components/Card/Category/Informations.vue
@@ -17,7 +17,9 @@ async function onSubmit(values: Form): Promise<void> {
     return
   }
 
-  await update({ ...provider.value, ...values })
+  const { users: _, ...data } = provider.value
+
+  await update({ ...data, ...values })
 }
 
 const { field, handleSubmit, reset, isValid } = useForm({

--- a/web/app/layouts/default.vue
+++ b/web/app/layouts/default.vue
@@ -49,17 +49,12 @@ const bottomNavigationItems = computed((): BottomNavigationItemProps[] => [
   },
 ])
 
-const { bottomLayout, leftLayout } = useLayoutPadding()
+const { mainStyles } = useLayoutPadding()
 </script>
 
 <template>
   <VApp>
-    <VMain
-      :style="{
-        '--v-layout-bottom': bottomLayout,
-        '--v-layout-left': leftLayout,
-      }"
-    >
+    <VMain :style="mainStyles">
       <OrganismNavigationDrawer
         v-if="!mobile"
         :items="navigationDrawerItems"

--- a/web/app/pages/login.vue
+++ b/web/app/pages/login.vue
@@ -14,9 +14,19 @@ definePageMeta({
 const route = useRoute()
 const { t } = useI18n()
 const { login } = useAuth()
+const { providers, fetchProviders } = useOIDCProviders()
+
+const redirect = computed(() => safeRedirect(route.query.redirect))
+
+const oidcErrorCodes = ['oidcState', 'oidcDenied', 'oidcNotAllowed', 'oidcNoAccount', 'oidcUnavailable'] as const
+const initialErrorCode = typeof route.query.error === 'string' && (oidcErrorCodes as readonly string[]).includes(route.query.error)
+  ? route.query.error
+  : undefined
 
 const loading = ref<boolean>(false)
-const error = ref<string>()
+const error = ref<string | undefined>(initialErrorCode ? t(`login.error.${initialErrorCode}`) : undefined)
+
+onMounted(fetchProviders)
 
 async function onSubmit(values: LoginWithPwdRequest): Promise<void> {
   error.value = undefined
@@ -24,7 +34,7 @@ async function onSubmit(values: LoginWithPwdRequest): Promise<void> {
 
   const res = await login(values)
   if (res === 'ok') {
-    await navigateTo(safeRedirect(route.query.redirect))
+    await navigateTo(redirect.value)
 
     return
   }
@@ -67,5 +77,9 @@ const { field, handleSubmit } = useForm({
       v-bind="field('password').props"
       data-test="login-password"
     />
+
+    <template #footer>
+      <AuthOidcProviderButtons :providers :redirect="redirect" />
+    </template>
   </AuthCard>
 </template>

--- a/web/app/pages/login.vue
+++ b/web/app/pages/login.vue
@@ -77,9 +77,14 @@ const { field, handleSubmit } = useForm({
       v-bind="field('password').props"
       data-test="login-password"
     />
-
-    <template #footer>
-      <AuthOidcProviderButtons :providers :redirect="redirect" />
-    </template>
   </AuthCard>
+
+  <template v-if="providers.length">
+    <div class="d-flex ga-4 align-center">
+      <VDivider />
+      <span class="text-uppercase text-medium-emphasis">{{ $t('common.or') }}</span>
+      <VDivider />
+    </div>
+    <AuthOidcProviderButtons :providers :redirect="redirect" />
+  </template>
 </template>

--- a/web/eslint.config.ts
+++ b/web/eslint.config.ts
@@ -7,6 +7,7 @@ import nuxt from './.nuxt/eslint.config.mjs'
 
 const customConfig: TypedFlatConfigItem = {
   rules: {
+    'vue/no-multiple-template-root': 'off',
     'pnpm/yaml-enforce-settings': 'off',
     'unicorn/no-null': 'off',
     'ts/explicit-function-return-type': ['error', { allowExpressions: true }],
@@ -91,4 +92,4 @@ const options: OptionsConfig & Omit<TypedFlatConfigItem, 'files' | 'ignores'> = 
   autoRenamePlugins: true,
 }
 
-export default antfu(options, customConfig, unusedPropertiesConfig).append(nuxt())
+export default nuxt(antfu(options, customConfig, unusedPropertiesConfig))

--- a/web/i18n/locales/en.json
+++ b/web/i18n/locales/en.json
@@ -58,13 +58,21 @@
   "login": {
     "error": {
       "invalid-credentials": "Invalid username/password",
-      "unknown-error": "Unknown error. Please try again."
+      "unknown-error": "Unknown error. Please try again.",
+      "oidcState": "Your sign-in session expired. Please try again.",
+      "oidcDenied": "Sign-in was cancelled.",
+      "oidcNotAllowed": "Your account is not allowed to sign in with this provider.",
+      "oidcNoAccount": "No account is linked to this identity yet. Ask an administrator to enable it.",
+      "oidcUnavailable": "The identity provider is currently unavailable. Please try again later."
     },
     "username": "Username",
     "password": "Password",
     "title": "Welcome back",
     "subtitle": "Sign in to your Uchiyomi server",
-    "submit": "Sign in"
+    "submit": "Sign in",
+    "oidc": {
+      "button": "Sign in with {name}"
+    }
   },
   "auth": {
     "signOut": "Sign out"

--- a/web/i18n/locales/en.json
+++ b/web/i18n/locales/en.json
@@ -199,7 +199,8 @@
     "continue": "Continue"
   },
   "common": {
-    "loading": "Loading..."
+    "loading": "Loading...",
+    "or": "Or"
   },
   "role": {
     "admin": "Admin",

--- a/web/i18n/locales/fr.json
+++ b/web/i18n/locales/fr.json
@@ -199,7 +199,8 @@
     "continue": "Continuer"
   },
   "common": {
-    "loading": "Chargement..."
+    "loading": "Chargement...",
+    "or": "Ou"
   },
   "role": {
     "admin": "Administrateur",

--- a/web/i18n/locales/fr.json
+++ b/web/i18n/locales/fr.json
@@ -58,13 +58,21 @@
   "login": {
     "error": {
       "invalid-credentials": "Nom d'utilisateur/mot de passe invalide",
-      "unknown-error": "Erreur inconnue. \nVeuillez réessayer."
+      "unknown-error": "Erreur inconnue. \nVeuillez réessayer.",
+      "oidcState": "Votre session de connexion a expiré. Veuillez réessayer.",
+      "oidcDenied": "La connexion a été annulée.",
+      "oidcNotAllowed": "Votre compte n'est pas autorisé à se connecter avec ce fournisseur.",
+      "oidcNoAccount": "Aucun compte n'est lié à cette identité. Demandez à un administrateur de l'activer.",
+      "oidcUnavailable": "Le fournisseur d'identité est actuellement indisponible. Veuillez réessayer plus tard."
     },
     "username": "Nom d'utilisateur",
     "password": "Mot de passe",
     "title": "Bienvenue",
     "subtitle": "Connectez-vous à votre serveur Uchiyomi",
-    "submit": "Se connecter"
+    "submit": "Se connecter",
+    "oidc": {
+      "button": "Se connecter avec {name}"
+    }
   },
   "auth": {
     "signOut": "Se déconnecter"


### PR DESCRIPTION
## Summary
- Wire the OIDC login flow end-to-end: protocol client, auth start/callback routes, identity resolution, and session creation with provider metadata.
- Expose the public provider list and render provider buttons on `/login`, with i18n error messages for each failure redirect.
- Keep the last remaining admin when an OIDC login would otherwise demote them.

Closes #5

## Screenshot

<img width="571" height="667" alt="image" src="https://github.com/user-attachments/assets/fc082c51-f82c-4006-8cdb-d9754b21f174" />


## Test plan
- [x] `go build ./...`, `go test ./...`, `golangci-lint run ./...`
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm knip`
- [x] First login with auto-provisioning against a real provider
- [x] Second login reuses the federated identity
- [x] Login links an existing local username
- [x] Login refused via `allowedValues`
- [x] Admin granted via `adminValues`
- [x] Failure paths land on `/login?error=…` with the matching message


Made with [Cursor](https://cursor.com)