### PR TITLE
Revalidate federated OIDC sessions against the IdP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ docs/design
 
 api/uchiyomiserver
 skills/
+CONTEXT.md

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ docs/design
 **/cursor.md
 
 api/uchiyomiserver
+skills/

--- a/api/cmd/uchiyomiserver/config.go
+++ b/api/cmd/uchiyomiserver/config.go
@@ -15,10 +15,10 @@ import (
 
 type cfg struct {
 	OIDC struct {
-		PublicURL            string        `env:"PUBLIC_URL,required,notEmpty"`
-		EncryptionKeyB64     string        `env:"OIDC_ENCRYPTION_KEY,required,notEmpty"`
-		RevalidationInterval time.Duration `env:"OIDC_REVALIDATION_INTERVAL" envDefault:"15m"`
+		PublicURL            string `env:"PUBLIC_URL,required,notEmpty"`
+		EncryptionKeyB64     string `env:"OIDC_ENCRYPTION_KEY,required,notEmpty"`
 		EncryptionKey        []byte
+		RevalidationInterval time.Duration `env:"OIDC_REVALIDATION_INTERVAL" envDefault:"15m"`
 	}
 	Logger struct {
 		Level logging.LogLevel `env:"LOG_LEVEL" envDefault:"info"`

--- a/api/cmd/uchiyomiserver/config.go
+++ b/api/cmd/uchiyomiserver/config.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/url"
+	"time"
 
 	"github.com/caarlos0/env/v11"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/crypto"
@@ -14,9 +15,10 @@ import (
 
 type cfg struct {
 	OIDC struct {
-		PublicURL        string `env:"PUBLIC_URL,required,notEmpty"`
-		EncryptionKeyB64 string `env:"OIDC_ENCRYPTION_KEY,required,notEmpty"`
-		EncryptionKey    []byte
+		PublicURL            string        `env:"PUBLIC_URL,required,notEmpty"`
+		EncryptionKeyB64     string        `env:"OIDC_ENCRYPTION_KEY,required,notEmpty"`
+		RevalidationInterval time.Duration `env:"OIDC_REVALIDATION_INTERVAL" envDefault:"15m"`
+		EncryptionKey        []byte
 	}
 	Logger struct {
 		Level logging.LogLevel `env:"LOG_LEVEL" envDefault:"info"`

--- a/api/cmd/uchiyomiserver/setup.go
+++ b/api/cmd/uchiyomiserver/setup.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/transaction/pgtx"
 
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/federatedidentities"
 	pgfederatedidentities "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/federatedidentities/repository/pg"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/hash/bcrypthash"
 	pgpwd "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/password/repository/pg"
@@ -64,8 +65,12 @@ func setupApp(cfg *cfg) (*core.App, error) {
 	}
 
 	apps, err := setupApps(appsDeps{
-		Logger:             logger,
-		SessionsRepository: dbr.SessionsRepository,
+		Logger:                        logger,
+		SessionsRepository:            dbr.SessionsRepository,
+		AuthService:                   services.Auth,
+		FederatedIdentitiesRepository: dbr.FederatedIdentitiesRepository,
+		OIDCProvidersRepository:       dbr.OIDCProvidersRepository,
+		RevalidationInterval:          cfg.OIDC.RevalidationInterval,
 	})
 	if err != nil {
 		//nolint:wrapcheck
@@ -101,11 +106,12 @@ func setupApp(cfg *cfg) (*core.App, error) {
 			UsersCtrl:         ctrls.Users,
 			OIDCProvidersCtrl: ctrls.OIDCProviders,
 
-			Health:   registry,
-			Logger:   logger,
-			DB:       dbr.PGDB,
-			Asura:    apps.Asura,
-			Sessions: apps.Sessions,
+			Health:           registry,
+			Logger:           logger,
+			DB:               dbr.PGDB,
+			Asura:            apps.Asura,
+			Sessions:         apps.Sessions,
+			OIDCRevalidation: apps.OIDCRevalidation,
 		})
 	if err != nil {
 		return nil, fmt.Errorf("failed to init main app: %w", err)
@@ -298,13 +304,18 @@ func setupServices(deps servicesDeps) (*services, error) {
 }
 
 type apps struct {
-	Asura    *asura.App
-	Sessions *sessions.App
+	Asura            *asura.App
+	Sessions         *sessions.App
+	OIDCRevalidation *oidc.RevalidationApp
 }
 
 type appsDeps struct {
-	Logger             *slog.Logger
-	SessionsRepository sessions.SessionsRepository
+	Logger                        *slog.Logger
+	SessionsRepository            sessions.SessionsRepository
+	AuthService                   *auth.Service
+	FederatedIdentitiesRepository federatedidentities.FederatedIdentitiesRepository
+	OIDCProvidersRepository       oidcproviders.OIDCProvidersRepository
+	RevalidationInterval          time.Duration
 }
 
 func setupApps(deps appsDeps) (*apps, error) {
@@ -318,14 +329,28 @@ func setupApps(deps appsDeps) (*apps, error) {
 		return nil, fmt.Errorf("failed to init sessions app: %w", err)
 	}
 
+	oidcRevalidation, err := oidc.NewRevalidationApp(
+		oidc.RevalidationConfig{Interval: deps.RevalidationInterval},
+		oidc.RevalidationDeps{
+			Logger:                        deps.Logger,
+			Revalidator:                   deps.AuthService,
+			FederatedIdentitiesRepository: deps.FederatedIdentitiesRepository,
+			OIDCProvidersRepository:       deps.OIDCProvidersRepository,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init oidc revalidation app: %w", err)
+	}
+
 	asura, err := setupAsura(deps.Logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to init asura source: %w", err)
 	}
 
 	a := &apps{
-		Asura:    asura,
-		Sessions: sessionApp,
+		Asura:            asura,
+		Sessions:         sessionApp,
+		OIDCRevalidation: oidcRevalidation,
 	}
 
 	return a, nil

--- a/api/cmd/uchiyomiserver/setup_internal_test.go
+++ b/api/cmd/uchiyomiserver/setup_internal_test.go
@@ -126,6 +126,10 @@ func (f *fixedUserSessionsRepository) DeleteByUserID(context.Context, uuid.UUID)
 	return errors.New("not implemented")
 }
 
+func (f *fixedUserSessionsRepository) DeleteByUserAndProvider(context.Context, uuid.UUID, uuid.UUID) error {
+	return errors.New("not implemented")
+}
+
 func (f *fixedUserSessionsRepository) DeleteExpired(context.Context, time.Time) (int64, error) {
 	return 0, nil
 }

--- a/api/pkg/core/app.go
+++ b/api/pkg/core/app.go
@@ -72,8 +72,9 @@ type Deps struct {
 	Logger *slog.Logger
 	Health *health.Registry
 
-	Asura    *asura.App
-	Sessions *sessions.App
+	Asura            *asura.App
+	Sessions         *sessions.App
+	OIDCRevalidation interface{ Run(context.Context) error }
 }
 
 func (deps *Deps) Validate() error {
@@ -99,6 +100,10 @@ func (deps *Deps) Validate() error {
 
 	if deps.Sessions == nil {
 		return errors.New("sessions is required")
+	}
+
+	if deps.OIDCRevalidation == nil {
+		return errors.New("oidcRevalidation is required")
 	}
 
 	if deps.HealthCtrl == nil {
@@ -173,6 +178,7 @@ func (a *App) startup(ctx context.Context, errG *errgroup.Group) func() error {
 
 		errG.Go(a.runComponent(ctx, componentAsura, a.deps.Asura.Run))
 		errG.Go(a.runComponent(ctx, componentSessions, a.deps.Sessions.Run))
+		errG.Go(a.runComponent(ctx, componentOIDCRevalidation, a.deps.OIDCRevalidation.Run))
 
 		return nil
 	}

--- a/api/pkg/core/app_internal_test.go
+++ b/api/pkg/core/app_internal_test.go
@@ -140,7 +140,10 @@ func TestRunReportsEverythingOKOnceMigrationCompletes(t *testing.T) {
 	})
 
 	body := decodeReadyz(t, raw)
-	for _, name := range []string{componentMigrations, componentAsura, componentSessions, componentOIDCRevalidation, componentDB} {
+	components := []string{
+		componentMigrations, componentAsura, componentSessions, componentOIDCRevalidation, componentDB,
+	}
+	for _, name := range components {
 		if got := body.Components[name].Status; got != string(health.StatusOK) {
 			t.Errorf("%s = %q, want %q", name, got, health.StatusOK)
 		}

--- a/api/pkg/core/app_internal_test.go
+++ b/api/pkg/core/app_internal_test.go
@@ -140,7 +140,7 @@ func TestRunReportsEverythingOKOnceMigrationCompletes(t *testing.T) {
 	})
 
 	body := decodeReadyz(t, raw)
-	for _, name := range []string{componentMigrations, componentAsura, componentSessions, componentDB} {
+	for _, name := range []string{componentMigrations, componentAsura, componentSessions, componentOIDCRevalidation, componentDB} {
 		if got := body.Components[name].Status; got != string(health.StatusOK) {
 			t.Errorf("%s = %q, want %q", name, got, health.StatusOK)
 		}

--- a/api/pkg/core/auth/credentials/federatedidentities/domain.go
+++ b/api/pkg/core/auth/credentials/federatedidentities/domain.go
@@ -20,9 +20,9 @@ type FederatedIdentity struct {
 	LastValidatedAt time.Time
 	LastLoginAt     time.Time
 	CreatedAt       time.Time
-	RefreshTokenEnc []byte
 	Claims          map[string]any
 	Subject         string
+	RefreshTokenEnc []byte
 	ID              uuid.UUID
 	UserID          uuid.UUID
 	ProviderID      uuid.UUID
@@ -30,9 +30,9 @@ type FederatedIdentity struct {
 
 type CreateFederatedIdentityOpts struct {
 	LastValidatedAt time.Time
-	RefreshTokenEnc []byte
 	Claims          map[string]any
 	Subject         string
+	RefreshTokenEnc []byte
 	UserID          uuid.UUID
 	ProviderID      uuid.UUID
 }
@@ -45,9 +45,9 @@ type GetFederatedIdentityOpts struct {
 type UpdateFederatedIdentityOpts struct {
 	LastValidatedAt   time.Time
 	LastLoginAt       time.Time
+	Claims            map[string]any
 	RefreshTokenEnc   []byte
+	ID                uuid.UUID
 	SetRefreshToken   bool
 	ClearRefreshToken bool
-	Claims            map[string]any
-	ID                uuid.UUID
 }

--- a/api/pkg/core/auth/credentials/federatedidentities/domain.go
+++ b/api/pkg/core/auth/credentials/federatedidentities/domain.go
@@ -13,23 +13,28 @@ type FederatedIdentitiesRepository interface {
 	Create(context.Context, CreateFederatedIdentityOpts) (*FederatedIdentity, error)
 	Get(context.Context, GetFederatedIdentityOpts) (*FederatedIdentity, error)
 	Update(context.Context, UpdateFederatedIdentityOpts) error
+	ListDueForRevalidation(context.Context, time.Time) ([]FederatedIdentity, error)
 }
 
 type FederatedIdentity struct {
-	CreatedAt   time.Time
-	LastLoginAt time.Time
-	Claims      map[string]any
-	Subject     string
-	ID          uuid.UUID
-	UserID      uuid.UUID
-	ProviderID  uuid.UUID
+	LastValidatedAt time.Time
+	LastLoginAt     time.Time
+	CreatedAt       time.Time
+	RefreshTokenEnc []byte
+	Claims          map[string]any
+	Subject         string
+	ID              uuid.UUID
+	UserID          uuid.UUID
+	ProviderID      uuid.UUID
 }
 
 type CreateFederatedIdentityOpts struct {
-	Claims     map[string]any
-	Subject    string
-	UserID     uuid.UUID
-	ProviderID uuid.UUID
+	LastValidatedAt time.Time
+	RefreshTokenEnc []byte
+	Claims          map[string]any
+	Subject         string
+	UserID          uuid.UUID
+	ProviderID      uuid.UUID
 }
 
 type GetFederatedIdentityOpts struct {
@@ -38,7 +43,11 @@ type GetFederatedIdentityOpts struct {
 }
 
 type UpdateFederatedIdentityOpts struct {
-	LastLoginAt time.Time
-	Claims      map[string]any
-	ID          uuid.UUID
+	LastValidatedAt   time.Time
+	LastLoginAt       time.Time
+	RefreshTokenEnc   []byte
+	SetRefreshToken   bool
+	ClearRefreshToken bool
+	Claims            map[string]any
+	ID                uuid.UUID
 }

--- a/api/pkg/core/auth/credentials/federatedidentities/repository/pg/repository.go
+++ b/api/pkg/core/auth/credentials/federatedidentities/repository/pg/repository.go
@@ -52,16 +52,16 @@ func (r *PGFederatedIdentitiesRepository) db(ctx context.Context) gorm.Interface
 func (r *PGFederatedIdentitiesRepository) Create(ctx context.Context, opts federatedidentities.CreateFederatedIdentityOpts) (*federatedidentities.FederatedIdentity, error) {
 	now := time.Now()
 	model := &pgmodels.FederatedIdentity{
-		ID:         uuid.New(),
-		UserID:     opts.UserID,
-		ProviderID: opts.ProviderID,
-
-		Subject: opts.Subject,
-		Claims:  opts.Claims,
-
-		LastLoginAt: now,
-		CreatedAt:   now,
-		UpdatedAt:   now,
+		ID:              uuid.New(),
+		UserID:          opts.UserID,
+		ProviderID:      opts.ProviderID,
+		Subject:         opts.Subject,
+		Claims:          opts.Claims,
+		RefreshTokenEnc: opts.RefreshTokenEnc,
+		LastValidatedAt: opts.LastValidatedAt,
+		LastLoginAt:     now,
+		CreatedAt:       now,
+		UpdatedAt:       now,
 	}
 
 	err := r.db(ctx).Create(ctx, model)
@@ -100,10 +100,21 @@ func (r *PGFederatedIdentitiesRepository) Get(ctx context.Context, opts federate
 
 //nolint:lll
 func (r *PGFederatedIdentitiesRepository) Update(ctx context.Context, opts federatedidentities.UpdateFederatedIdentityOpts) error {
-	affectedNb, err := r.db(ctx).Where("id = ?", opts.ID).Updates(ctx, pgmodels.FederatedIdentity{
-		Claims:      opts.Claims,
-		LastLoginAt: opts.LastLoginAt,
-	})
+	updates := pgmodels.FederatedIdentity{
+		Claims:          opts.Claims,
+		LastLoginAt:     opts.LastLoginAt,
+		LastValidatedAt: opts.LastValidatedAt,
+	}
+
+	if opts.SetRefreshToken {
+		updates.RefreshTokenEnc = opts.RefreshTokenEnc
+	}
+
+	if opts.ClearRefreshToken {
+		updates.RefreshTokenEnc = nil
+	}
+
+	affectedNb, err := r.db(ctx).Where("id = ?", opts.ID).Updates(ctx, updates)
 
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -121,14 +132,46 @@ func (r *PGFederatedIdentitiesRepository) Update(ctx context.Context, opts feder
 }
 
 //nolint:lll
+func (r *PGFederatedIdentitiesRepository) ListDueForRevalidation(
+	ctx context.Context,
+	before time.Time,
+) ([]federatedidentities.FederatedIdentity, error) {
+	now := time.Now()
+
+	var models []pgmodels.FederatedIdentity
+
+	err := pgtx.From(ctx, r.deps.DB).
+		Model(&pgmodels.FederatedIdentity{}).
+		Distinct().
+		Joins(`INNER JOIN sessions ON sessions.user_id = federated_identities.user_id
+			AND sessions.provider_id = federated_identities.provider_id`).
+		Where("federated_identities.refresh_token_enc IS NOT NULL").
+		Where("federated_identities.last_validated_at < ?", before).
+		Where("sessions.expires_at > ?", now).
+		Find(&models).Error
+	if err != nil {
+		return nil, fmt.Errorf("db query: %w", err)
+	}
+
+	out := make([]federatedidentities.FederatedIdentity, len(models))
+	for i, model := range models {
+		out[i] = r.modelToDomain(model)
+	}
+
+	return out, nil
+}
+
+//nolint:lll
 func (r *PGFederatedIdentitiesRepository) modelToDomain(model pgmodels.FederatedIdentity) federatedidentities.FederatedIdentity {
 	return federatedidentities.FederatedIdentity{
-		ID:          model.ID,
-		UserID:      model.UserID,
-		ProviderID:  model.ProviderID,
-		Subject:     model.Subject,
-		Claims:      model.Claims,
-		LastLoginAt: model.LastLoginAt,
-		CreatedAt:   model.CreatedAt,
+		ID:              model.ID,
+		UserID:          model.UserID,
+		ProviderID:      model.ProviderID,
+		Subject:         model.Subject,
+		Claims:          model.Claims,
+		RefreshTokenEnc: model.RefreshTokenEnc,
+		LastValidatedAt: model.LastValidatedAt,
+		LastLoginAt:     model.LastLoginAt,
+		CreatedAt:       model.CreatedAt,
 	}
 }

--- a/api/pkg/core/auth/credentials/federatedidentities/repository/pg/repository_test.go
+++ b/api/pkg/core/auth/credentials/federatedidentities/repository/pg/repository_test.go
@@ -307,3 +307,59 @@ func TestUpdateError(t *testing.T) {
 		t.Errorf("err = %v, original error no longer reachable", err)
 	}
 }
+
+func TestListDueForRevalidation(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newRepo(t)
+
+	before := time.Now().Add(-15 * time.Minute)
+	id, userID, providerID := uuid.New(), uuid.New(), uuid.New()
+	lastValidated := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+
+	mock.ExpectQuery(`SELECT DISTINCT "federated_identities"`).
+		WithArgs(before, sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "user_id", "provider_id", "subject", "claims",
+			"refresh_token_enc", "last_validated_at", "created_at", "last_login_at",
+		}).AddRow(
+			id, userID, providerID, testSubject, []byte(`{}`),
+			[]byte("enc"), lastValidated, time.Now(), time.Now(),
+		))
+
+	got, err := r.ListDueForRevalidation(context.Background(), before)
+	if err != nil {
+		t.Fatalf("ListDueForRevalidation: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+
+	if got[0].ID != id || got[0].UserID != userID || got[0].ProviderID != providerID {
+		t.Errorf("ListDueForRevalidation() = %+v", got[0])
+	}
+
+	if !got[0].LastValidatedAt.Equal(lastValidated) {
+		t.Errorf("LastValidatedAt = %v, want %v", got[0].LastValidatedAt, lastValidated)
+	}
+}
+
+func TestUpdateClearsRefreshToken(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newRepo(t)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "federated_identities" SET`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	err := r.Update(context.Background(), federatedidentities.UpdateFederatedIdentityOpts{
+		ID:                uuid.New(),
+		ClearRefreshToken: true,
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+}

--- a/api/pkg/core/auth/credentials/federatedidentities/repository/pg/repository_test.go
+++ b/api/pkg/core/auth/credentials/federatedidentities/repository/pg/repository_test.go
@@ -22,9 +22,10 @@ import (
 )
 
 const (
-	testSubject = "sub-123"
-	testEmail   = "bob@example.com"
-	claimsEmail = "email"
+	testSubject  = "sub-123"
+	testEmail    = "bob@example.com"
+	claimsEmail  = "email"
+	claimsColumn = "claims"
 )
 
 func duplicateKeyErr() error {
@@ -64,7 +65,7 @@ func TestCreateJoinsAmbientTransaction(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectQuery(`INSERT INTO "federated_identities"`).
-		WillReturnRows(sqlmock.NewRows([]string{"claims", "id"}).AddRow(nil, uuid.New()))
+		WillReturnRows(sqlmock.NewRows([]string{claimsColumn, "id"}).AddRow(nil, uuid.New()))
 	mock.ExpectCommit()
 
 	err = tr.WithinTx(context.Background(), transaction.TxOpts{}, func(ctx context.Context) error {
@@ -189,7 +190,7 @@ func TestGet(t *testing.T) {
 	mock.ExpectQuery(`SELECT \* FROM "federated_identities" WHERE provider_id = \$1 AND subject = \$2`).
 		WithArgs(providerID, testSubject, 1).
 		WillReturnRows(
-			sqlmock.NewRows([]string{"id", "user_id", "provider_id", "subject", "claims", "created_at", "last_login_at"}).
+			sqlmock.NewRows([]string{"id", "user_id", "provider_id", "subject", claimsColumn, "created_at", "last_login_at"}).
 				AddRow(id, userID, providerID, testSubject, []byte(`{"email":"bob@example.com"}`), created, lastLogin),
 		)
 
@@ -320,7 +321,7 @@ func TestListDueForRevalidation(t *testing.T) {
 	mock.ExpectQuery(`SELECT DISTINCT "federated_identities"`).
 		WithArgs(before, sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"id", "user_id", "provider_id", "subject", "claims",
+			"id", "user_id", "provider_id", "subject", claimsColumn,
 			"refresh_token_enc", "last_validated_at", "created_at", "last_login_at",
 		}).AddRow(
 			id, userID, providerID, testSubject, []byte(`{}`),

--- a/api/pkg/core/auth/oidc/client.go
+++ b/api/pkg/core/auth/oidc/client.go
@@ -22,6 +22,7 @@ var _ oidcproviders.Client = (*Client)(nil)
 var (
 	ErrClientUnavailable = errors.New("oidc client: provider is unavailable")
 	ErrExchangeFailed    = errors.New("oidc client: token exchange failed")
+	ErrRefreshFailed     = errors.New("oidc client: token refresh failed")
 	ErrIDTokenInvalid    = errors.New("oidc client: id token verification failed")
 	ErrNonceMismatch     = errors.New("oidc client: id token nonce mismatch")
 )
@@ -195,7 +196,84 @@ func (c *Client) Exchange(
 
 	sid, _ := claims[sidClaim].(string)
 
-	return &oidcproviders.TokenSet{Subject: idToken.Subject, SID: sid, Claims: claims}, nil
+	return &oidcproviders.TokenSet{
+		Subject:      idToken.Subject,
+		SID:          sid,
+		Claims:       claims,
+		RefreshToken: token.RefreshToken,
+	}, nil
+}
+
+func (c *Client) Refresh(
+	ctx context.Context,
+	provider oidcproviders.OIDCProvider,
+	refreshToken string,
+) (*oidcproviders.TokenSet, error) {
+	if refreshToken == "" {
+		return nil, fmt.Errorf("%w: refresh token must not be empty", ErrRefreshFailed)
+	}
+
+	p, err := c.providerFor(ctx, provider)
+	if err != nil {
+		return nil, fmt.Errorf("client.providerFor: %w", err)
+	}
+
+	secret, err := c.deps.Cipher.Open(provider.ClientSecretEnc)
+	if err != nil {
+		return nil, fmt.Errorf("cipher.Open: %w", err)
+	}
+
+	cfg := oauth2.Config{
+		ClientID:     provider.ClientID,
+		ClientSecret: string(secret),
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  p.Endpoint().AuthURL,
+			TokenURL: p.Endpoint().TokenURL,
+		},
+		Scopes: dedup(provider.Scopes, openIDScope, offlineAccessScope),
+	}
+
+	refreshCtx := gooidc.ClientContext(ctx, c.deps.HTTPClient)
+
+	token, err := cfg.TokenSource(refreshCtx, &oauth2.Token{RefreshToken: refreshToken}).Token()
+	if err != nil {
+		if retrieveErr, ok := err.(*oauth2.RetrieveError); ok && retrieveErr.ErrorCode == "invalid_grant" {
+			return nil, oidcproviders.ErrInvalidGrant
+		}
+
+		return nil, fmt.Errorf("%w: %w", ErrRefreshFailed, err)
+	}
+
+	rawIDToken, ok := token.Extra("id_token").(string)
+	if !ok || rawIDToken == "" {
+		return nil, fmt.Errorf("%w: token response is missing the id_token", ErrRefreshFailed)
+	}
+
+	idTokenVerifier := p.Verifier(&gooidc.Config{ClientID: provider.ClientID})
+
+	idToken, err := idTokenVerifier.Verify(refreshCtx, rawIDToken)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrIDTokenInvalid, err)
+	}
+
+	var claims map[string]any
+	if err := idToken.Claims(&claims); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrIDTokenInvalid, err)
+	}
+
+	sid, _ := claims[sidClaim].(string)
+
+	rotated := token.RefreshToken
+	if rotated == "" {
+		rotated = refreshToken
+	}
+
+	return &oidcproviders.TokenSet{
+		Subject:      idToken.Subject,
+		SID:          sid,
+		Claims:       claims,
+		RefreshToken: rotated,
+	}, nil
 }
 
 func (c *Client) EndSessionURL(

--- a/api/pkg/core/auth/oidc/client_test.go
+++ b/api/pkg/core/auth/oidc/client_test.go
@@ -114,8 +114,29 @@ func jsonTokenResponse(rawIDToken string) func(w http.ResponseWriter, r *http.Re
 	return func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w,
-			`{"access_token":"test-access-token","token_type":"Bearer","expires_in":3600,"id_token":%q}`,
+			`{"access_token":"test-access-token","token_type":"Bearer","expires_in":3600,"id_token":%q,"refresh_token":"initial-refresh"}`,
 			rawIDToken)
+	}
+}
+
+func jsonRefreshResponse(rawIDToken, refreshToken string) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+
+			return
+		}
+
+		if got := r.PostFormValue("grant_type"); got != "refresh_token" {
+			http.Error(w, "wrong grant_type", http.StatusBadRequest)
+
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w,
+			`{"access_token":"test-access-token","token_type":"Bearer","expires_in":3600,"id_token":%q,"refresh_token":%q}`,
+			rawIDToken, refreshToken)
 	}
 }
 
@@ -371,6 +392,10 @@ func TestExchangeVerifiesTheIDToken(t *testing.T) {
 
 	if ts.Claims["sub"] != testSubject {
 		t.Errorf("Claims[sub] = %v, want %q", ts.Claims["sub"], testSubject)
+	}
+
+	if ts.RefreshToken != "initial-refresh" {
+		t.Errorf("RefreshToken = %q, want %q", ts.RefreshToken, "initial-refresh")
 	}
 }
 
@@ -655,5 +680,66 @@ func TestEndSessionURLPropagatesProviderUnavailable(t *testing.T) {
 	_, _, err := c.EndSessionURL(context.Background(), provider, "https://app.example.com/login")
 	if !errors.Is(err, oidc.ErrClientUnavailable) {
 		t.Errorf("EndSessionURL = %v, want ErrClientUnavailable", err)
+	}
+}
+
+func TestRefreshVerifiesTheIDTokenAndReturnsRotatedRefreshToken(t *testing.T) {
+	t.Parallel()
+
+	idp := newTestIdP(t)
+	provider := testProvider(idp.srv.URL)
+
+	rawIDToken := signClaims(t, idp.key, idp.keyID, baseClaims(idp.srv.URL, provider.ClientID, testNonce))
+	idp.setTokenHandler(jsonRefreshResponse(rawIDToken, "rotated-refresh"))
+
+	c := newTestClient(t)
+
+	ts, err := c.Refresh(context.Background(), provider, "stored-refresh")
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	if ts.Subject != testSubject {
+		t.Errorf("Subject = %q, want %q", ts.Subject, testSubject)
+	}
+
+	if ts.RefreshToken != "rotated-refresh" {
+		t.Errorf("RefreshToken = %q, want %q", ts.RefreshToken, "rotated-refresh")
+	}
+}
+
+func TestRefreshReturnsInvalidGrant(t *testing.T) {
+	t.Parallel()
+
+	idp := newTestIdP(t)
+	provider := testProvider(idp.srv.URL)
+	idp.setTokenHandler(invalidGrantResponse())
+
+	c := newTestClient(t)
+
+	_, err := c.Refresh(context.Background(), provider, "revoked-refresh")
+	if !errors.Is(err, oidcproviders.ErrInvalidGrant) {
+		t.Errorf("Refresh = %v, want ErrInvalidGrant", err)
+	}
+}
+
+func TestRefreshPropagatesTransientFailures(t *testing.T) {
+	t.Parallel()
+
+	idp := newTestIdP(t)
+	provider := testProvider(idp.srv.URL)
+	idp.setTokenHandler(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	})
+
+	c := newTestClient(t)
+
+	_, err := c.Refresh(context.Background(), provider, "stored-refresh")
+	if err == nil {
+		t.Fatal("Refresh = nil, want an error")
+	}
+
+	if errors.Is(err, oidcproviders.ErrInvalidGrant) {
+		t.Errorf("Refresh = %v, must not be ErrInvalidGrant on 5xx", err)
 	}
 }

--- a/api/pkg/core/auth/oidc/client_test.go
+++ b/api/pkg/core/auth/oidc/client_test.go
@@ -111,11 +111,12 @@ func (idp *testIdP) setTokenHandler(h func(w http.ResponseWriter, r *http.Reques
 }
 
 func jsonTokenResponse(rawIDToken string) func(w http.ResponseWriter, r *http.Request) {
+	const tokenBody = `{"access_token":"test-access-token","token_type":"Bearer",` +
+		`"expires_in":3600,"id_token":%q,"refresh_token":"initial-refresh"}`
+
 	return func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w,
-			`{"access_token":"test-access-token","token_type":"Bearer","expires_in":3600,"id_token":%q,"refresh_token":"initial-refresh"}`,
-			rawIDToken)
+		fmt.Fprintf(w, tokenBody, rawIDToken)
 	}
 }
 

--- a/api/pkg/core/auth/oidc/revalidation_app.go
+++ b/api/pkg/core/auth/oidc/revalidation_app.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package oidc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/federatedidentities"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils"
+)
+
+type FederatedRevalidator interface {
+	RevalidateFederatedIdentity(
+		context.Context,
+		oidcproviders.OIDCProvider,
+		federatedidentities.FederatedIdentity,
+	) error
+}
+
+type RevalidationConfig struct {
+	Interval time.Duration
+}
+
+func (cfg *RevalidationConfig) Validate() error {
+	if cfg.Interval < time.Minute {
+		return errors.New("interval must be at least 1 minute")
+	}
+
+	return nil
+}
+
+type RevalidationDeps struct {
+	Revalidator                   FederatedRevalidator
+	FederatedIdentitiesRepository federatedidentities.FederatedIdentitiesRepository
+	OIDCProvidersRepository       oidcproviders.OIDCProvidersRepository
+	Logger                        *slog.Logger
+	Now                           func() time.Time
+}
+
+func (deps *RevalidationDeps) Validate() error {
+	if deps.Revalidator == nil {
+		return errors.New("revalidator is required")
+	}
+
+	if deps.FederatedIdentitiesRepository == nil {
+		return errors.New("federatedIdentitiesRepository is required")
+	}
+
+	if deps.OIDCProvidersRepository == nil {
+		return errors.New("oidcProvidersRepository is required")
+	}
+
+	if deps.Logger == nil {
+		return errors.New("logger is required")
+	}
+
+	return nil
+}
+
+type RevalidationApp struct {
+	deps RevalidationDeps
+	cfg  RevalidationConfig
+}
+
+func NewRevalidationApp(cfg RevalidationConfig, deps RevalidationDeps) (*RevalidationApp, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("cfg.Validate: %w", err)
+	}
+
+	if err := deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	if deps.Now == nil {
+		deps.Now = time.Now
+	}
+
+	deps.Logger = deps.Logger.With("component", "oidc.revalidation")
+
+	return &RevalidationApp{deps: deps, cfg: cfg}, nil
+}
+
+func (a *RevalidationApp) Run(ctx context.Context) error {
+	//nolint:wrapcheck
+	return utils.Loop(ctx, utils.LoopOpts{
+		Interval: a.cfg.Interval,
+		Fn:       a.revalidate,
+	})
+}
+
+func (a *RevalidationApp) revalidate(ctx context.Context) error {
+	before := a.deps.Now().Add(-a.cfg.Interval)
+
+	identities, err := a.deps.FederatedIdentitiesRepository.ListDueForRevalidation(ctx, before)
+	if err != nil {
+		a.deps.Logger.ErrorContext(ctx, "failed to list federated identities for revalidation", "err", err)
+
+		return nil
+	}
+
+	for _, fi := range identities {
+		if err := a.revalidateOne(ctx, fi); err != nil {
+			a.deps.Logger.ErrorContext(ctx, "federated identity revalidation failed",
+				"err", err, "federatedIdentityID", fi.ID, "providerID", fi.ProviderID)
+		}
+	}
+
+	return nil
+}
+
+func (a *RevalidationApp) revalidateOne(ctx context.Context, fi federatedidentities.FederatedIdentity) error {
+	provider, err := a.deps.OIDCProvidersRepository.GetByID(ctx, fi.ProviderID)
+	if err != nil {
+		return fmt.Errorf("a.deps.OIDCProvidersRepository.GetByID: %w", err)
+	}
+
+	if err := a.deps.Revalidator.RevalidateFederatedIdentity(ctx, *provider, fi); err != nil {
+		return fmt.Errorf("a.deps.Revalidator.RevalidateFederatedIdentity: %w", err)
+	}
+
+	return nil
+}

--- a/api/pkg/core/auth/oidc/revalidation_app_test.go
+++ b/api/pkg/core/auth/oidc/revalidation_app_test.go
@@ -16,9 +16,9 @@ import (
 )
 
 type stubRevalidator struct {
+	done  chan struct{}
 	errs  []error
 	calls int
-	done  chan struct{}
 }
 
 func (s *stubRevalidator) RevalidateFederatedIdentity(

--- a/api/pkg/core/auth/oidc/revalidation_app_test.go
+++ b/api/pkg/core/auth/oidc/revalidation_app_test.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package oidc_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/federatedidentities"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidc"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
+)
+
+type stubRevalidator struct {
+	errs  []error
+	calls int
+	done  chan struct{}
+}
+
+func (s *stubRevalidator) RevalidateFederatedIdentity(
+	context.Context,
+	oidcproviders.OIDCProvider,
+	federatedidentities.FederatedIdentity,
+) error {
+	var err error
+
+	if s.calls < len(s.errs) {
+		err = s.errs[s.calls]
+	}
+
+	s.calls++
+
+	if s.done != nil && s.calls == len(s.errs) {
+		close(s.done)
+	}
+
+	return err
+}
+
+type stubFederatedIdentitiesRepo struct {
+	identities []federatedidentities.FederatedIdentity
+}
+
+func (r *stubFederatedIdentitiesRepo) Create(
+	context.Context,
+	federatedidentities.CreateFederatedIdentityOpts,
+) (*federatedidentities.FederatedIdentity, error) {
+	panic("Create is not used by the revalidation app")
+}
+
+func (r *stubFederatedIdentitiesRepo) Get(
+	context.Context,
+	federatedidentities.GetFederatedIdentityOpts,
+) (*federatedidentities.FederatedIdentity, error) {
+	panic("Get is not used by the revalidation app")
+}
+
+func (r *stubFederatedIdentitiesRepo) Update(context.Context, federatedidentities.UpdateFederatedIdentityOpts) error {
+	panic("Update is not used by the revalidation app")
+}
+
+func (r *stubFederatedIdentitiesRepo) ListDueForRevalidation(
+	context.Context,
+	time.Time,
+) ([]federatedidentities.FederatedIdentity, error) {
+	return r.identities, nil
+}
+
+type stubOIDCProvidersRepo struct {
+	providers map[uuid.UUID]*oidcproviders.OIDCProvider
+}
+
+func (r *stubOIDCProvidersRepo) GetByID(_ context.Context, id uuid.UUID) (*oidcproviders.OIDCProvider, error) {
+	p, ok := r.providers[id]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+
+	return p, nil
+}
+
+func (r *stubOIDCProvidersRepo) GetByIssuerURL(context.Context, string) (*oidcproviders.OIDCProvider, error) {
+	panic("GetByIssuerURL is not used by the revalidation app")
+}
+
+func (r *stubOIDCProvidersRepo) Create(
+	context.Context,
+	oidcproviders.CreateOIDCProviderOpts,
+) (*oidcproviders.OIDCProvider, error) {
+	panic("Create is not used by the revalidation app")
+}
+
+func (r *stubOIDCProvidersRepo) Update(
+	context.Context,
+	uuid.UUID,
+	oidcproviders.UpdateOIDCProviderOpts,
+) (*oidcproviders.OIDCProvider, error) {
+	panic("Update is not used by the revalidation app")
+}
+
+func (r *stubOIDCProvidersRepo) DeleteByID(context.Context, uuid.UUID) error {
+	panic("DeleteByID is not used by the revalidation app")
+}
+
+func (r *stubOIDCProvidersRepo) GetAll(context.Context) ([]oidcproviders.LightOIDCProvider, error) {
+	panic("GetAll is not used by the revalidation app")
+}
+
+func (r *stubOIDCProvidersRepo) GetUsers(context.Context, uuid.UUID) ([]oidcproviders.OIDCProviderUser, error) {
+	panic("GetUsers is not used by the revalidation app")
+}
+
+func TestRevalidationAppContinuesAfterOneProviderFails(t *testing.T) {
+	t.Parallel()
+
+	providerA := uuid.New()
+	providerB := uuid.New()
+	revalidated := make(chan struct{})
+	revalidator := &stubRevalidator{
+		errs: []error{
+			errors.New("provider A is down"),
+			nil,
+		},
+		done: revalidated,
+	}
+
+	app, err := oidc.NewRevalidationApp(
+		oidc.RevalidationConfig{Interval: time.Hour},
+		oidc.RevalidationDeps{
+			Logger:      slog.New(slog.DiscardHandler),
+			Revalidator: revalidator,
+			FederatedIdentitiesRepository: &stubFederatedIdentitiesRepo{identities: []federatedidentities.FederatedIdentity{
+				{ID: uuid.New(), ProviderID: providerA, UserID: uuid.New()},
+				{ID: uuid.New(), ProviderID: providerB, UserID: uuid.New()},
+			}},
+			OIDCProvidersRepository: &stubOIDCProvidersRepo{providers: map[uuid.UUID]*oidcproviders.OIDCProvider{
+				providerA: {ID: providerA},
+				providerB: {ID: providerB},
+			}},
+			Now: func() time.Time { return time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC) },
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRevalidationApp: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runDone := make(chan error, 1)
+
+	go func() {
+		runDone <- app.Run(ctx)
+	}()
+
+	<-revalidated
+	cancel()
+
+	if err := <-runDone; !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run = %v, want context.Canceled", err)
+	}
+
+	if revalidator.calls != 2 {
+		t.Errorf("revalidator calls = %d, want 2", revalidator.calls)
+	}
+}

--- a/api/pkg/core/auth/oidc_federated.go
+++ b/api/pkg/core/auth/oidc_federated.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/federatedidentities"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
+)
+
+func (s *Service) sealRefreshToken(refreshToken string) ([]byte, error) {
+	if refreshToken == "" {
+		return nil, nil
+	}
+
+	sealed, err := s.deps.StateCipher.Seal([]byte(refreshToken))
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.StateCipher.Seal: %w", err)
+	}
+
+	return sealed, nil
+}
+
+func (s *Service) federatedIdentityFieldsFromTokenSet(
+	tokenSet *oidcproviders.TokenSet,
+) (refreshTokenEnc []byte, lastValidatedAt time.Time, err error) {
+	refreshTokenEnc, err = s.sealRefreshToken(tokenSet.RefreshToken)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	if len(refreshTokenEnc) > 0 {
+		lastValidatedAt = s.now()
+	}
+
+	return refreshTokenEnc, lastValidatedAt, nil
+}
+
+func (s *Service) createFederatedIdentity(
+	ctx context.Context,
+	opts federatedidentities.CreateFederatedIdentityOpts,
+) error {
+	_, err := s.deps.FederatedIdentitiesRepository.Create(ctx, opts)
+	if err != nil {
+		return fmt.Errorf("s.deps.FederatedIdentitiesRepository.Create: %w", err)
+	}
+
+	return nil
+}

--- a/api/pkg/core/auth/oidc_identity.go
+++ b/api/pkg/core/auth/oidc_identity.go
@@ -58,11 +58,24 @@ func (s *Service) reuseIdentity(
 		return nil, fmt.Errorf("s.deps.UsersRepository.GetByID: %w", err)
 	}
 
-	err = s.deps.FederatedIdentitiesRepository.Update(ctx, federatedidentities.UpdateFederatedIdentityOpts{
+	refreshTokenEnc, lastValidatedAt, err := s.federatedIdentityFieldsFromTokenSet(tokenSet)
+	if err != nil {
+		return nil, err
+	}
+
+	updateOpts := federatedidentities.UpdateFederatedIdentityOpts{
 		ID:          fi.ID,
 		Claims:      tokenSet.Claims,
 		LastLoginAt: s.now(),
-	})
+	}
+
+	if len(refreshTokenEnc) > 0 {
+		updateOpts.RefreshTokenEnc = refreshTokenEnc
+		updateOpts.SetRefreshToken = true
+		updateOpts.LastValidatedAt = lastValidatedAt
+	}
+
+	err = s.deps.FederatedIdentitiesRepository.Update(ctx, updateOpts)
 	if err != nil {
 		return nil, fmt.Errorf("s.deps.FederatedIdentitiesRepository.Update: %w", err)
 	}
@@ -76,14 +89,21 @@ func (s *Service) linkIdentity(
 	tokenSet *oidcproviders.TokenSet,
 	user *users.User,
 ) (*users.User, error) {
-	_, err := s.deps.FederatedIdentitiesRepository.Create(ctx, federatedidentities.CreateFederatedIdentityOpts{
-		Subject:    tokenSet.Subject,
-		ProviderID: provider.ID,
-		UserID:     user.ID,
-		Claims:     tokenSet.Claims,
+	refreshTokenEnc, lastValidatedAt, err := s.federatedIdentityFieldsFromTokenSet(tokenSet)
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.createFederatedIdentity(ctx, federatedidentities.CreateFederatedIdentityOpts{
+		Subject:         tokenSet.Subject,
+		ProviderID:      provider.ID,
+		UserID:          user.ID,
+		Claims:          tokenSet.Claims,
+		RefreshTokenEnc: refreshTokenEnc,
+		LastValidatedAt: lastValidatedAt,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("s.deps.FederatedIdentitiesRepository.Create: %w", err)
+		return nil, err
 	}
 
 	return user, nil
@@ -105,11 +125,18 @@ func (s *Service) provisionIdentity(
 			return fmt.Errorf("s.deps.UsersRepository.Create: %w", err)
 		}
 
+		refreshTokenEnc, lastValidatedAt, err := s.federatedIdentityFieldsFromTokenSet(tokenSet)
+		if err != nil {
+			return err
+		}
+
 		_, err = s.deps.FederatedIdentitiesRepository.Create(ctx, federatedidentities.CreateFederatedIdentityOpts{
-			Subject:    tokenSet.Subject,
-			ProviderID: provider.ID,
-			UserID:     user.ID,
-			Claims:     tokenSet.Claims,
+			Subject:         tokenSet.Subject,
+			ProviderID:      provider.ID,
+			UserID:          user.ID,
+			Claims:          tokenSet.Claims,
+			RefreshTokenEnc: refreshTokenEnc,
+			LastValidatedAt: lastValidatedAt,
 		})
 		if err != nil {
 			return fmt.Errorf("s.deps.FederatedIdentitiesRepository.Create: %w", err)

--- a/api/pkg/core/auth/oidc_login_test.go
+++ b/api/pkg/core/auth/oidc_login_test.go
@@ -139,6 +139,13 @@ func (f *fakeFederatedIdentitiesRepo) Update(
 	return f.updateErr
 }
 
+func (f *fakeFederatedIdentitiesRepo) ListDueForRevalidation(
+	context.Context,
+	time.Time,
+) ([]federatedidentities.FederatedIdentity, error) {
+	panic("ListDueForRevalidation is not used by the auth service")
+}
+
 type fakeOIDCClient struct {
 	authCodeErr           error
 	exchangeErr           error
@@ -208,6 +215,14 @@ func (f *fakeOIDCClient) EndSessionURL(
 	}
 
 	return f.endSessionURL, f.endSessionSupported, nil
+}
+
+func (f *fakeOIDCClient) Refresh(
+	context.Context,
+	oidcproviders.OIDCProvider,
+	string,
+) (*oidcproviders.TokenSet, error) {
+	panic("Refresh is not used by the auth service")
 }
 
 func TestStartOIDCLoginBuildsAuthCodeURLAndCookie(t *testing.T) {

--- a/api/pkg/core/auth/oidc_revalidation.go
+++ b/api/pkg/core/auth/oidc_revalidation.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/federatedidentities"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
+)
+
+func (s *Service) ApplySuccessfulRevalidation(
+	ctx context.Context,
+	provider oidcproviders.OIDCProvider,
+	fi federatedidentities.FederatedIdentity,
+	tokenSet *oidcproviders.TokenSet,
+) error {
+	_, isAdmin, allowed := s.mapClaims(provider, tokenSet)
+	if !allowed {
+		return s.revokeFederatedAccess(ctx, fi)
+	}
+
+	user, err := s.deps.UsersRepository.GetByID(ctx, fi.UserID)
+	if err != nil {
+		return fmt.Errorf("s.deps.UsersRepository.GetByID: %w", err)
+	}
+
+	if err := s.syncIsAdmin(ctx, provider, user, isAdmin); err != nil {
+		return err
+	}
+
+	refreshTokenEnc, lastValidatedAt, err := s.federatedIdentityFieldsFromTokenSet(tokenSet)
+	if err != nil {
+		return err
+	}
+
+	updateOpts := federatedidentities.UpdateFederatedIdentityOpts{
+		ID:              fi.ID,
+		Claims:          tokenSet.Claims,
+		LastValidatedAt: lastValidatedAt,
+	}
+
+	if len(refreshTokenEnc) > 0 {
+		updateOpts.RefreshTokenEnc = refreshTokenEnc
+		updateOpts.SetRefreshToken = true
+	}
+
+	if err := s.deps.FederatedIdentitiesRepository.Update(ctx, updateOpts); err != nil {
+		return fmt.Errorf("s.deps.FederatedIdentitiesRepository.Update: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Service) ApplyInvalidGrant(ctx context.Context, fi federatedidentities.FederatedIdentity) error {
+	return s.revokeFederatedAccess(ctx, fi)
+}
+
+func (s *Service) revokeFederatedAccess(ctx context.Context, fi federatedidentities.FederatedIdentity) error {
+	if err := s.deps.SessionService.RevokeForProvider(ctx, fi.UserID, fi.ProviderID); err != nil {
+		return fmt.Errorf("s.deps.SessionService.RevokeForProvider: %w", err)
+	}
+
+	if err := s.deps.FederatedIdentitiesRepository.Update(ctx, federatedidentities.UpdateFederatedIdentityOpts{
+		ID:                fi.ID,
+		ClearRefreshToken: true,
+	}); err != nil {
+		return fmt.Errorf("s.deps.FederatedIdentitiesRepository.Update: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Service) RevalidateFederatedIdentity(
+	ctx context.Context,
+	provider oidcproviders.OIDCProvider,
+	fi federatedidentities.FederatedIdentity,
+) error {
+	if len(fi.RefreshTokenEnc) == 0 {
+		return nil
+	}
+
+	refreshToken, err := s.deps.StateCipher.Open(fi.RefreshTokenEnc)
+	if err != nil {
+		return fmt.Errorf("s.deps.StateCipher.Open: %w", err)
+	}
+
+	tokenSet, err := s.deps.OIDCClient.Refresh(ctx, provider, string(refreshToken))
+	if err != nil {
+		if errors.Is(err, oidcproviders.ErrInvalidGrant) {
+			return s.ApplyInvalidGrant(ctx, fi)
+		}
+
+		return fmt.Errorf("s.deps.OIDCClient.Refresh: %w", err)
+	}
+
+	return s.ApplySuccessfulRevalidation(ctx, provider, fi, tokenSet)
+}

--- a/api/pkg/core/auth/oidc_revalidation_test.go
+++ b/api/pkg/core/auth/oidc_revalidation_test.go
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/federatedidentities"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
+)
+
+type revalidationSessionService struct {
+	gotUserID     uuid.UUID
+	gotProviderID uuid.UUID
+	calls         int
+	err           error
+}
+
+func (s *revalidationSessionService) Create(
+	context.Context,
+	sessions.CreateSessionOpts,
+) (*sessions.IssuedSession, error) {
+	panic("Create is not used by revalidation")
+}
+
+func (s *revalidationSessionService) Authenticate(context.Context, string) (*sessions.AuthenticatedSession, error) {
+	panic("Authenticate is not used by revalidation")
+}
+
+func (s *revalidationSessionService) Revoke(context.Context, string) error {
+	panic("Revoke is not used by revalidation")
+}
+
+func (s *revalidationSessionService) RevokeAllForUser(context.Context, uuid.UUID) error {
+	panic("RevokeAllForUser is not used by revalidation")
+}
+
+func (s *revalidationSessionService) RevokeForProvider(_ context.Context, userID, providerID uuid.UUID) error {
+	s.calls++
+	s.gotUserID = userID
+	s.gotProviderID = providerID
+
+	return s.err
+}
+
+type revalidationOIDCClient struct {
+	tokenSet *oidcproviders.TokenSet
+	err      error
+}
+
+func (c *revalidationOIDCClient) AuthCodeURL(
+	context.Context,
+	oidcproviders.OIDCProvider,
+	oidcproviders.AuthCodeParams,
+) (string, error) {
+	panic("AuthCodeURL is not used by revalidation")
+}
+
+func (c *revalidationOIDCClient) Exchange(
+	context.Context,
+	oidcproviders.OIDCProvider,
+	string, string, string, string,
+) (*oidcproviders.TokenSet, error) {
+	panic("Exchange is not used by revalidation")
+}
+
+func (c *revalidationOIDCClient) Refresh(
+	context.Context,
+	oidcproviders.OIDCProvider,
+	string,
+) (*oidcproviders.TokenSet, error) {
+	return c.tokenSet, c.err
+}
+
+func (c *revalidationOIDCClient) EndSessionURL(
+	context.Context,
+	oidcproviders.OIDCProvider,
+	string,
+) (string, bool, error) {
+	panic("EndSessionURL is not used by revalidation")
+}
+
+func newRevalidationAuth(t *testing.T, f *fakes, ss sessions.SessionService, oc oidcproviders.Client) *auth.Service {
+	t.Helper()
+
+	s, err := auth.New(f.cfg, auth.Deps{
+		HashService:                   f.hs,
+		UsersRepository:               f.ur,
+		PwdRepository:                 f.pr,
+		Transactor:                    f.tr,
+		SessionService:                ss,
+		OIDCProvidersRepository:       f.opr,
+		FederatedIdentitiesRepository: f.fir,
+		OIDCClient:                    oc,
+		StateCipher:                   f.sc,
+		Logger:                        slog.New(slog.DiscardHandler),
+		Now:                           func() time.Time { return f.now },
+	})
+	if err != nil {
+		t.Fatalf("auth.New: %v", err)
+	}
+
+	return s
+}
+
+func TestRevalidateFederatedIdentityInvalidGrantRevokesProviderSessions(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	ss := &revalidationSessionService{}
+
+	sealed, err := f.sc.Seal([]byte("refresh-token"))
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	fi := federatedidentities.FederatedIdentity{
+		ID:              uuid.New(),
+		UserID:          f.ur.user.ID,
+		ProviderID:      f.opr.provider.ID,
+		RefreshTokenEnc: sealed,
+	}
+
+	s := newRevalidationAuth(t, f, ss, &revalidationOIDCClient{err: oidcproviders.ErrInvalidGrant})
+
+	if err := s.RevalidateFederatedIdentity(context.Background(), *f.opr.provider, fi); err != nil {
+		t.Fatalf("RevalidateFederatedIdentity: %v", err)
+	}
+
+	if ss.calls != 1 {
+		t.Errorf("RevokeForProvider called %d times, want 1", ss.calls)
+	}
+
+	if ss.gotUserID != fi.UserID || ss.gotProviderID != fi.ProviderID {
+		t.Errorf("RevokeForProvider(%v, %v), want (%v, %v)",
+			ss.gotUserID, ss.gotProviderID, fi.UserID, fi.ProviderID)
+	}
+
+	if f.fir.updateCalls != 1 {
+		t.Errorf("Update called %d times, want 1", f.fir.updateCalls)
+	}
+
+	if !f.fir.gotUpdateOpts.ClearRefreshToken {
+		t.Error("ClearRefreshToken = false, want true")
+	}
+}
+
+func TestRevalidateFederatedIdentitySuccessUpdatesClaimsAndAdmin(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	role := adminRole
+	f.opr.provider.RoleClaim = &role
+	f.opr.provider.AdminValues = []string{adminRole}
+
+	sealed, err := f.sc.Seal([]byte("refresh-token"))
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	fi := federatedidentities.FederatedIdentity{
+		ID:              uuid.New(),
+		UserID:          f.ur.user.ID,
+		ProviderID:      f.opr.provider.ID,
+		RefreshTokenEnc: sealed,
+	}
+
+	tokenSet := &oidcproviders.TokenSet{
+		Subject:      "sub-1",
+		RefreshToken: "rotated",
+		Claims: map[string]any{
+			usernameClaimKey: userName,
+			roleClaimKey:     adminRole,
+		},
+	}
+
+	s := newRevalidationAuth(t, f, &revalidationSessionService{}, &revalidationOIDCClient{tokenSet: tokenSet})
+
+	if err := s.RevalidateFederatedIdentity(context.Background(), *f.opr.provider, fi); err != nil {
+		t.Fatalf("RevalidateFederatedIdentity: %v", err)
+	}
+
+	if f.fir.updateCalls != 1 {
+		t.Fatalf("Update called %d times, want 1", f.fir.updateCalls)
+	}
+
+	if !f.fir.gotUpdateOpts.SetRefreshToken {
+		t.Error("SetRefreshToken = false, want true")
+	}
+
+	if f.fir.gotUpdateOpts.Claims[roleClaimKey] != adminRole {
+		t.Errorf("Claims = %v", f.fir.gotUpdateOpts.Claims)
+	}
+}
+
+func TestRevalidateFederatedIdentityTransientFailureDoesNotRevoke(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	ss := &revalidationSessionService{}
+
+	sealed, err := f.sc.Seal([]byte("refresh-token"))
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	fi := federatedidentities.FederatedIdentity{
+		ID:              uuid.New(),
+		UserID:          f.ur.user.ID,
+		ProviderID:      f.opr.provider.ID,
+		RefreshTokenEnc: sealed,
+	}
+
+	sentinel := errors.New("gateway timeout")
+	s := newRevalidationAuth(t, f, ss, &revalidationOIDCClient{err: sentinel})
+
+	err = s.RevalidateFederatedIdentity(context.Background(), *f.opr.provider, fi)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("RevalidateFederatedIdentity = %v, want %v", err, sentinel)
+	}
+
+	if ss.calls != 0 {
+		t.Errorf("RevokeForProvider called %d times, want 0", ss.calls)
+	}
+
+	if f.fir.updateCalls != 0 {
+		t.Errorf("Update called %d times, want 0", f.fir.updateCalls)
+	}
+}
+
+func TestRevalidateFederatedIdentitySkipsMissingRefreshToken(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	ss := &revalidationSessionService{}
+
+	fi := federatedidentities.FederatedIdentity{
+		ID:         uuid.New(),
+		UserID:     f.ur.user.ID,
+		ProviderID: f.opr.provider.ID,
+	}
+
+	s := newRevalidationAuth(t, f, ss, &revalidationOIDCClient{})
+
+	if err := s.RevalidateFederatedIdentity(context.Background(), *f.opr.provider, fi); err != nil {
+		t.Fatalf("RevalidateFederatedIdentity: %v", err)
+	}
+
+	if ss.calls != 0 {
+		t.Errorf("RevokeForProvider called %d times, want 0", ss.calls)
+	}
+}

--- a/api/pkg/core/auth/oidc_revalidation_test.go
+++ b/api/pkg/core/auth/oidc_revalidation_test.go
@@ -17,10 +17,10 @@ import (
 )
 
 type revalidationSessionService struct {
+	err           error
+	calls         int
 	gotUserID     uuid.UUID
 	gotProviderID uuid.UUID
-	calls         int
-	err           error
 }
 
 func (s *revalidationSessionService) Create(

--- a/api/pkg/core/auth/oidcproviders/domain.go
+++ b/api/pkg/core/auth/oidcproviders/domain.go
@@ -88,6 +88,8 @@ type LightOIDCProvider struct {
 
 var ErrIncompleteDiscovery = errors.New("discovery document is incomplete")
 
+var ErrInvalidGrant = errors.New("oidc: refresh token is invalid or revoked")
+
 type Discoverer interface {
 	Discover(ctx context.Context, issuerURL string) (*Discovery, error)
 }
@@ -103,6 +105,7 @@ type Discovery struct {
 type Client interface {
 	AuthCodeURL(ctx context.Context, provider OIDCProvider, params AuthCodeParams) (string, error)
 	Exchange(ctx context.Context, provider OIDCProvider, code, verifier, nonce, redirectURI string) (*TokenSet, error)
+	Refresh(ctx context.Context, provider OIDCProvider, refreshToken string) (*TokenSet, error)
 	EndSessionURL(ctx context.Context, provider OIDCProvider, postLogoutRedirectURI string) (string, bool, error)
 }
 
@@ -114,7 +117,8 @@ type AuthCodeParams struct {
 }
 
 type TokenSet struct {
-	Claims  map[string]any
-	Subject string
-	SID     string
+	Claims       map[string]any
+	RefreshToken string
+	Subject      string
+	SID          string
 }

--- a/api/pkg/core/auth/service_test.go
+++ b/api/pkg/core/auth/service_test.go
@@ -270,6 +270,10 @@ func (f *fakeSessionService) RevokeAllForUser(context.Context, uuid.UUID) error 
 	panic("RevokeAllForUser is not used by the auth service")
 }
 
+func (f *fakeSessionService) RevokeForProvider(context.Context, uuid.UUID, uuid.UUID) error {
+	panic("RevokeForProvider is not used by the auth service")
+}
+
 type fakes struct {
 	now   time.Time
 	clock *clock

--- a/api/pkg/core/auth/sessions/domain.go
+++ b/api/pkg/core/auth/sessions/domain.go
@@ -46,6 +46,7 @@ type SessionService interface {
 	Authenticate(context.Context, string) (*AuthenticatedSession, error)
 	Revoke(context.Context, string) error
 	RevokeAllForUser(context.Context, uuid.UUID) error
+	RevokeForProvider(context.Context, uuid.UUID, uuid.UUID) error
 }
 
 type CreateSessionOpts struct {
@@ -61,6 +62,7 @@ type SessionsRepository interface {
 	UpdateExpiry(context.Context, uuid.UUID, time.Time) error
 	DeleteByTokenHash(context.Context, []byte) error
 	DeleteByUserID(context.Context, uuid.UUID) error
+	DeleteByUserAndProvider(context.Context, uuid.UUID, uuid.UUID) error
 	DeleteExpired(context.Context, time.Time) (int64, error)
 }
 

--- a/api/pkg/core/auth/sessions/repository/pg/repository.go
+++ b/api/pkg/core/auth/sessions/repository/pg/repository.go
@@ -123,6 +123,17 @@ func (r *PGSessionsRepository) DeleteByUserID(ctx context.Context, userID uuid.U
 	return nil
 }
 
+func (r *PGSessionsRepository) DeleteByUserAndProvider(
+	ctx context.Context,
+	userID, providerID uuid.UUID,
+) error {
+	if _, err := r.db(ctx).Where("user_id = ? AND provider_id = ?", userID, providerID).Delete(ctx); err != nil {
+		return fmt.Errorf("r.db(ctx).Delete: %w", err)
+	}
+
+	return nil
+}
+
 func (r *PGSessionsRepository) DeleteExpired(ctx context.Context, now time.Time) (int64, error) {
 	deleted, err := r.db(ctx).Where("expires_at <= ?", now).Delete(ctx)
 	if err != nil {

--- a/api/pkg/core/auth/sessions/repository/pg/repository_test.go
+++ b/api/pkg/core/auth/sessions/repository/pg/repository_test.go
@@ -382,6 +382,24 @@ func TestDeleteByUserID(t *testing.T) {
 	}
 }
 
+func TestDeleteByUserAndProvider(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newRepo(t)
+
+	userID, providerID := uuid.New(), uuid.New()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`DELETE FROM "sessions" WHERE user_id = \$1 AND provider_id = \$2`).
+		WithArgs(userID, providerID).
+		WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectCommit()
+
+	if err := r.DeleteByUserAndProvider(context.Background(), userID, providerID); err != nil {
+		t.Fatalf("DeleteByUserAndProvider: %v", err)
+	}
+}
+
 func TestDeleteExpiredReturnsRowCount(t *testing.T) {
 	t.Parallel()
 

--- a/api/pkg/core/auth/sessions/service.go
+++ b/api/pkg/core/auth/sessions/service.go
@@ -211,3 +211,11 @@ func (s *Service) RevokeAllForUser(ctx context.Context, userID uuid.UUID) error 
 
 	return nil
 }
+
+func (s *Service) RevokeForProvider(ctx context.Context, userID, providerID uuid.UUID) error {
+	if err := s.deps.Repository.DeleteByUserAndProvider(ctx, userID, providerID); err != nil {
+		return fmt.Errorf("s.deps.Repository.DeleteByUserAndProvider: %w", err)
+	}
+
+	return nil
+}

--- a/api/pkg/core/auth/sessions/service_test.go
+++ b/api/pkg/core/auth/sessions/service_test.go
@@ -103,6 +103,13 @@ func (f *fakeRepository) DeleteByUserID(_ context.Context, id uuid.UUID) error {
 	return f.deleteErr
 }
 
+func (f *fakeRepository) DeleteByUserAndProvider(_ context.Context, userID, providerID uuid.UUID) error {
+	f.deleteUsers++
+	f.gotUserID = userID
+
+	return f.deleteErr
+}
+
 func (f *fakeRepository) DeleteExpired(context.Context, time.Time) (int64, error) {
 	panic("DeleteExpired must not be called by the service")
 }
@@ -745,5 +752,23 @@ func TestRevokeAllForUserPropagatesRepositoryError(t *testing.T) {
 	err := frozenSvc(t, repo, time.Now()).RevokeAllForUser(context.Background(), uuid.New())
 	if !errors.Is(err, sentinel) {
 		t.Errorf("err = %v, original error no longer reachable", err)
+	}
+}
+
+func TestRevokeForProviderDeletesByUserAndProvider(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepository{}
+	userID := uuid.New()
+	providerID := uuid.New()
+
+	if err := frozenSvc(t, repo, time.Now()).RevokeForProvider(
+		context.Background(), userID, providerID,
+	); err != nil {
+		t.Fatalf("RevokeForProvider: %v", err)
+	}
+
+	if repo.gotUserID != userID {
+		t.Errorf("DeleteByUserAndProvider user = %v, want %v", repo.gotUserID, userID)
 	}
 }

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -100,6 +100,18 @@ func (fakeSessionsRepository) DeleteByTokenHash(context.Context, []byte) error {
 	return errors.New(notImplemented)
 }
 
+type fakeOIDCRevalidationApp struct{}
+
+func (fakeOIDCRevalidationApp) Run(ctx context.Context) error {
+	<-ctx.Done()
+
+	return ctx.Err()
+}
+
+func (fakeSessionsRepository) DeleteByUserAndProvider(context.Context, uuid.UUID, uuid.UUID) error {
+	return errors.New(notImplemented)
+}
+
 func (fakeSessionsRepository) DeleteByUserID(context.Context, uuid.UUID) error {
 	return errors.New(notImplemented)
 }
@@ -307,6 +319,7 @@ func newTestApp(t *testing.T, db Database, port int) (*App, *health.Registry) {
 			Health:            registry,
 			Asura:             asuraApp,
 			Sessions:          sessionsApp,
+			OIDCRevalidation:  fakeOIDCRevalidationApp{},
 		})
 	if err != nil {
 		t.Fatalf("New: %v", err)

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net"
@@ -105,7 +106,7 @@ type fakeOIDCRevalidationApp struct{}
 func (fakeOIDCRevalidationApp) Run(ctx context.Context) error {
 	<-ctx.Done()
 
-	return ctx.Err()
+	return fmt.Errorf("context done: %w", ctx.Err())
 }
 
 func (fakeSessionsRepository) DeleteByUserAndProvider(context.Context, uuid.UUID, uuid.UUID) error {

--- a/api/pkg/core/health.go
+++ b/api/pkg/core/health.go
@@ -10,16 +10,17 @@ import (
 )
 
 const (
-	componentMigrations = "migrations"
-	componentAsura      = "asura"
-	componentSessions   = "sessions"
-	componentDB         = "db"
+	componentMigrations       = "migrations"
+	componentAsura            = "asura"
+	componentSessions         = "sessions"
+	componentOIDCRevalidation = "oidc-revalidation"
+	componentDB               = "db"
 )
 
 const notReadyMessage = "service is starting"
 
 func NewHealthRegistry(db Database) *health.Registry {
-	reg := health.NewRegistry(componentMigrations, componentAsura, componentSessions)
+	reg := health.NewRegistry(componentMigrations, componentAsura, componentSessions, componentOIDCRevalidation)
 	reg.AddProbe(componentDB, db.Ping)
 
 	return reg

--- a/api/pkg/core/health_internal_test.go
+++ b/api/pkg/core/health_internal_test.go
@@ -41,7 +41,7 @@ func TestNewHealthRegistryDeclaresTheLatchesAndTheDBProbe(t *testing.T) {
 
 	rep := reg.Snapshot(context.Background())
 
-	for _, name := range []string{componentMigrations, componentAsura, componentSessions} {
+	for _, name := range []string{componentMigrations, componentAsura, componentSessions, componentOIDCRevalidation} {
 		c, ok := rep.Components[name]
 		if !ok {
 			t.Errorf("latche %s absente du registre", name)

--- a/api/pkg/core/setup/dosetup_test.go
+++ b/api/pkg/core/setup/dosetup_test.go
@@ -113,6 +113,10 @@ func (s *stubSessionService) RevokeAllForUser(context.Context, uuid.UUID) error 
 	panic("RevokeAllForUser must not be called by DoSetup")
 }
 
+func (s *stubSessionService) RevokeForProvider(context.Context, uuid.UUID, uuid.UUID) error {
+	panic("RevokeForProvider must not be called by DoSetup")
+}
+
 func defaultSessionStub() *stubSessionService {
 	return &stubSessionService{issued: &sessions.IssuedSession{
 		Session: sessions.Session{ID: uuid.New()},

--- a/api/pkg/repository/pgmodels/federatedidentity.go
+++ b/api/pkg/repository/pgmodels/federatedidentity.go
@@ -12,16 +12,18 @@ import (
 )
 
 type FederatedIdentity struct {
-	LastLoginAt time.Time
-	CreatedAt   time.Time    `gorm:"autoCreateTime"`
-	UpdatedAt   time.Time    `gorm:"autoUpdateTime"`
-	Claims      Claims       `gorm:"type:jsonb;not null;default:'{}'"`
-	Subject     string       `gorm:"type:text;not null;uniqueIndex:idx_fedid_provider_subject,priority:2"`
-	Provider    OIDCProvider `gorm:"foreignKey:ProviderID"`
-	User        User         `gorm:"foreignKey:UserID"`
-	ID          uuid.UUID    `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
-	UserID      uuid.UUID    `gorm:"type:uuid;not null;index"`
-	ProviderID  uuid.UUID    `gorm:"type:uuid;not null;uniqueIndex:idx_fedid_provider_subject,priority:1"`
+	LastValidatedAt time.Time
+	LastLoginAt     time.Time
+	CreatedAt       time.Time    `gorm:"autoCreateTime"`
+	UpdatedAt       time.Time    `gorm:"autoUpdateTime"`
+	RefreshTokenEnc []byte       `gorm:"type:bytea"`
+	Claims          Claims       `gorm:"type:jsonb;not null;default:'{}'"`
+	Subject         string       `gorm:"type:text;not null;uniqueIndex:idx_fedid_provider_subject,priority:2"`
+	Provider        OIDCProvider `gorm:"foreignKey:ProviderID"`
+	User            User         `gorm:"foreignKey:UserID"`
+	ID              uuid.UUID    `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+	UserID          uuid.UUID    `gorm:"type:uuid;not null;index"`
+	ProviderID      uuid.UUID    `gorm:"type:uuid;not null;uniqueIndex:idx_fedid_provider_subject,priority:1"`
 }
 
 func (FederatedIdentity) TableName() string {


### PR DESCRIPTION
## Summary

- Persist the OIDC refresh token (encrypted) at login and on every successful rotation, and track `LastValidatedAt` on federated identities.
- Add a background revalidation loop (`OIDC_REVALIDATION_INTERVAL`, default `15m`) that refreshes tokens against the IdP; `invalid_grant` revokes all sessions for that user/provider pair, while transient failures leave sessions intact.
- On a successful refresh, recompute claims and `IsAdmin` from the fresh ID token so group changes at the IdP take effect without re-login.

Closes #7.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Disable an account at a real IdP and confirm its Uchiyomi sessions end within one revalidation interval
- [x] Stop the IdP entirely and confirm existing sessions remain active