### PR TITLE
Back-channel logout from the identity provider

### DIFF
--- a/api/cmd/uchiyomiserver/setup_internal_test.go
+++ b/api/cmd/uchiyomiserver/setup_internal_test.go
@@ -130,6 +130,10 @@ func (f *fixedUserSessionsRepository) DeleteByUserAndProvider(context.Context, u
 	return errors.New("not implemented")
 }
 
+func (f *fixedUserSessionsRepository) DeleteByProviderAndSID(context.Context, uuid.UUID, string) error {
+	return errors.New("not implemented")
+}
+
 func (f *fixedUserSessionsRepository) DeleteExpired(context.Context, time.Time) (int64, error) {
 	return 0, nil
 }

--- a/api/pkg/core/auth/domain.go
+++ b/api/pkg/core/auth/domain.go
@@ -18,6 +18,7 @@ type AuthService interface {
 	Logout(context.Context, LogoutOpts) (*LogoutResult, error)
 	StartOIDCLogin(context.Context, StartOIDCLoginOpts) (*OIDCStart, error)
 	FinishOIDCLogin(context.Context, FinishOIDCLoginOpts) (*OIDCLoginResult, error)
+	BackchannelLogout(context.Context, string) error
 }
 
 type LoginResult struct {
@@ -69,10 +70,11 @@ type OIDCLoginResult struct {
 }
 
 var (
-	ErrInvalidLoginPwd = errors.New("invalid login/password")
-	ErrOIDCState       = errors.New("oidc state is missing, expired or invalid")
-	ErrOIDCDenied      = errors.New("oidc provider denied the request")
-	ErrOIDCNotAllowed  = errors.New("oidc claims do not satisfy the allowed values")
-	ErrOIDCNoAccount   = errors.New("oidc login did not resolve to an account")
-	ErrOIDCUnavailable = errors.New("oidc provider is unavailable")
+	ErrInvalidLoginPwd    = errors.New("invalid login/password")
+	ErrOIDCState          = errors.New("oidc state is missing, expired or invalid")
+	ErrOIDCDenied         = errors.New("oidc provider denied the request")
+	ErrOIDCNotAllowed     = errors.New("oidc claims do not satisfy the allowed values")
+	ErrOIDCNoAccount      = errors.New("oidc login did not resolve to an account")
+	ErrOIDCUnavailable    = errors.New("oidc provider is unavailable")
+	ErrLogoutTokenInvalid = errors.New("logout token is invalid")
 )

--- a/api/pkg/core/auth/gateway/http/controller.go
+++ b/api/pkg/core/auth/gateway/http/controller.go
@@ -119,6 +119,7 @@ func (c *Controller) InitRouter(r chi.Router) {
 		r.Get("/providers", c.listProviders)
 		r.Get("/oidc/{id}/start", c.startOIDCLogin)
 		r.Get("/oidc/callback", c.oidcCallback)
+		r.Post("/oidc/backchannel-logout", c.oidcBackchannelLogout)
 	})
 }
 
@@ -225,6 +226,41 @@ func (c *Controller) startOIDCLogin(w http.ResponseWriter, r *http.Request) {
 
 	c.deps.OIDCStateCookies.Set(w, res.StateCookieValue, res.ExpiresAt, c.deps.Now())
 	http.Redirect(w, r, res.AuthCodeURL, http.StatusFound)
+}
+
+func (c *Controller) oidcBackchannelLogout(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	r.Body = http.MaxBytesReader(w, r.Body, 16*1024)
+
+	if err := r.ParseForm(); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+
+		return
+	}
+
+	raw := r.PostFormValue("logout_token")
+	if raw == "" {
+		w.WriteHeader(http.StatusBadRequest)
+
+		return
+	}
+
+	if err := c.deps.AuthService.BackchannelLogout(ctx, raw); err != nil {
+		if errors.Is(err, auth.ErrLogoutTokenInvalid) {
+			w.WriteHeader(http.StatusBadRequest)
+
+			return
+		}
+
+		c.deps.Logger.ErrorContext(ctx, "failed to process backchannel logout", logging.Err(err))
+		httputils.WriteError(w, c.deps.Logger, http.StatusInternalServerError, "")
+
+		return
+	}
+
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusOK)
 }
 
 func (c *Controller) oidcCallback(w http.ResponseWriter, r *http.Request) {

--- a/api/pkg/core/auth/gateway/http/controller_test.go
+++ b/api/pkg/core/auth/gateway/http/controller_test.go
@@ -26,38 +26,42 @@ import (
 )
 
 const (
-	authEndpoint        = "/auth"
-	loginPath           = "/auth/login"
-	logoutPath          = "/auth/logout"
-	providersPath       = "/auth/providers"
-	oidcCallbackPath    = "/auth/oidc/callback"
-	username            = "alice"
-	password            = "hunter2hunter2"
-	token               = "letoken"
-	sessionCookieName   = "uchiyomi_session"
-	oidcStateCookieName = "uchiyomi_oidc_state"
-	oidcStateCookiePath = "/api/auth/oidc"
-	logLevelWarn        = "WARN"
+	authEndpoint          = "/auth"
+	loginPath             = "/auth/login"
+	logoutPath            = "/auth/logout"
+	providersPath         = "/auth/providers"
+	oidcCallbackPath      = "/auth/oidc/callback"
+	backchannelLogoutPath = "/auth/oidc/backchannel-logout"
+	username              = "alice"
+	password              = "hunter2hunter2"
+	token                 = "letoken"
+	sessionCookieName     = "uchiyomi_session"
+	oidcStateCookieName   = "uchiyomi_oidc_state"
+	oidcStateCookiePath   = "/api/auth/oidc"
+	logLevelWarn          = "WARN"
 )
 
 type stubAuthService struct {
-	err           error
-	finishErr     error
-	startErr      error
-	logoutErr     error
-	logoutResult  *auth.LogoutResult
-	startResult   *auth.OIDCStart
-	result        *auth.LoginResult
-	finishResult  *auth.OIDCLoginResult
-	gotFinishOpts auth.FinishOIDCLoginOpts
-	gotOpts       auth.LoginWithPwdOpts
-	logoutToken   string
-	gotStartOpts  auth.StartOIDCLoginOpts
-	logoutSession sessions.Session
-	calls         int
-	logoutCalls   int
-	startCalls    int
-	finishCalls   int
+	err                       error
+	finishErr                 error
+	startErr                  error
+	logoutErr                 error
+	backchannelLogoutErr      error
+	logoutResult              *auth.LogoutResult
+	startResult               *auth.OIDCStart
+	result                    *auth.LoginResult
+	finishResult              *auth.OIDCLoginResult
+	gotFinishOpts             auth.FinishOIDCLoginOpts
+	gotOpts                   auth.LoginWithPwdOpts
+	logoutToken               string
+	gotBackchannelLogoutToken string
+	gotStartOpts              auth.StartOIDCLoginOpts
+	logoutSession             sessions.Session
+	calls                     int
+	logoutCalls               int
+	startCalls                int
+	finishCalls               int
+	backchannelLogoutCalls    int
 }
 
 func (s *stubAuthService) LoginWithPwd(
@@ -117,6 +121,13 @@ func (s *stubAuthService) FinishOIDCLogin(
 	}
 
 	return s.finishResult, nil
+}
+
+func (s *stubAuthService) BackchannelLogout(_ context.Context, logoutToken string) error {
+	s.backchannelLogoutCalls++
+	s.gotBackchannelLogoutToken = logoutToken
+
+	return s.backchannelLogoutErr
 }
 
 func frozenNow() time.Time {
@@ -1160,6 +1171,102 @@ func TestOIDCCallbackHappyPathRedirectsSetsSessionAndClearsState(t *testing.T) {
 
 	if state.MaxAge != -1 {
 		t.Errorf("state MaxAge = %d, want -1", state.MaxAge)
+	}
+}
+
+func postBackchannelLogout(t *testing.T, r chi.Router, body string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, backchannelLogoutPath, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	r.ServeHTTP(rec, req)
+
+	return rec
+}
+
+func TestBackchannelLogoutReturns200WithNoStore(t *testing.T) {
+	t.Parallel()
+
+	const logoutToken = "eyJhbGciOiJSUzI1NiJ9.valid"
+	svc := &stubAuthService{}
+	r, _ := newTestRouter(t, svc)
+
+	rec := postBackchannelLogout(t, r, "logout_token="+logoutToken)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control = %q, want %q", got, "no-store")
+	}
+
+	if svc.backchannelLogoutCalls != 1 {
+		t.Errorf("BackchannelLogout called %d times, want 1", svc.backchannelLogoutCalls)
+	}
+
+	if svc.gotBackchannelLogoutToken != logoutToken {
+		t.Errorf("logout_token = %q, want %q", svc.gotBackchannelLogoutToken, logoutToken)
+	}
+}
+
+func TestBackchannelLogoutReturns400OnMissingToken(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubAuthService{}
+	r, _ := newTestRouter(t, svc)
+
+	rec := postBackchannelLogout(t, r, "")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+
+	if rec.Body.Len() != 0 {
+		t.Errorf("body = %q, want empty", rec.Body.String())
+	}
+
+	if svc.backchannelLogoutCalls != 0 {
+		t.Errorf("BackchannelLogout called %d times, want 0", svc.backchannelLogoutCalls)
+	}
+}
+
+func TestBackchannelLogoutReturns400OnInvalidToken(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubAuthService{backchannelLogoutErr: auth.ErrLogoutTokenInvalid}
+	r, _ := newTestRouter(t, svc)
+
+	rec := postBackchannelLogout(t, r, "logout_token=invalid")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+
+	if rec.Body.Len() != 0 {
+		t.Errorf("body = %q, want empty", rec.Body.String())
+	}
+
+	if svc.backchannelLogoutCalls != 1 {
+		t.Errorf("BackchannelLogout called %d times, want 1", svc.backchannelLogoutCalls)
+	}
+}
+
+func TestBackchannelLogoutDoesNotRequireSession(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubAuthService{}
+	r, _ := newTestRouter(t, svc)
+
+	rec := postBackchannelLogout(t, r, "logout_token=valid")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	if svc.backchannelLogoutCalls != 1 {
+		t.Errorf("BackchannelLogout called %d times, want 1", svc.backchannelLogoutCalls)
 	}
 }
 

--- a/api/pkg/core/auth/oidc/client.go
+++ b/api/pkg/core/auth/oidc/client.go
@@ -34,6 +34,9 @@ const (
 	openIDScope        = "openid"
 	offlineAccessScope = "offline_access"
 	sidClaim           = "sid"
+
+	logoutTokenEvent   = "http://schemas.openid.net/event/backchannel-logout"
+	logoutTokenIATSkew = 5 * time.Minute
 )
 
 type Decrypter interface {
@@ -309,6 +312,61 @@ func (c *Client) EndSessionURL(
 	u.RawQuery = q.Encode()
 
 	return u.String(), true, nil
+}
+
+func (c *Client) VerifyLogoutToken(
+	ctx context.Context,
+	provider oidcproviders.OIDCProvider,
+	raw string,
+) (*oidcproviders.LogoutToken, error) {
+	p, err := c.providerFor(ctx, provider)
+	if err != nil {
+		return nil, fmt.Errorf("client.providerFor: %w", err)
+	}
+
+	verifier := p.Verifier(&gooidc.Config{
+		ClientID:        provider.ClientID,
+		SkipExpiryCheck: true,
+	})
+
+	token, err := verifier.Verify(ctx, raw)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", oidcproviders.ErrLogoutTokenInvalid, err)
+	}
+
+	var claims map[string]any
+	if err := token.Claims(&claims); err != nil {
+		return nil, fmt.Errorf("%w: %w", oidcproviders.ErrLogoutTokenInvalid, err)
+	}
+
+	if _, hasNonce := claims["nonce"]; hasNonce {
+		return nil, fmt.Errorf("%w: nonce must not be present", oidcproviders.ErrLogoutTokenInvalid)
+	}
+
+	events, _ := claims["events"].(map[string]any)
+	if events == nil {
+		return nil, fmt.Errorf("%w: events claim is missing", oidcproviders.ErrLogoutTokenInvalid)
+	}
+
+	if _, ok := events[logoutTokenEvent]; !ok {
+		return nil, fmt.Errorf("%w: backchannel-logout event is missing", oidcproviders.ErrLogoutTokenInvalid)
+	}
+
+	iat, ok := claims["iat"].(float64)
+	if !ok {
+		return nil, fmt.Errorf("%w: iat is missing or invalid", oidcproviders.ErrLogoutTokenInvalid)
+	}
+
+	iatTime := time.Unix(int64(iat), 0)
+	now := time.Now()
+	if iatTime.Before(now.Add(-logoutTokenIATSkew)) || iatTime.After(now.Add(logoutTokenIATSkew)) {
+		return nil, fmt.Errorf("%w: iat is outside acceptable skew", oidcproviders.ErrLogoutTokenInvalid)
+	}
+
+	sid, _ := claims["sid"].(string)
+	sub, _ := claims["sub"].(string)
+
+	return &oidcproviders.LogoutToken{Subject: sub, SID: sid}, nil
 }
 
 func (c *Client) Evict(id uuid.UUID) {

--- a/api/pkg/core/auth/oidc/client_test.go
+++ b/api/pkg/core/auth/oidc/client_test.go
@@ -31,6 +31,12 @@ const (
 	testState       = "test-state"
 	scopeOpenID     = "openid"
 	scopeProfile    = "profile"
+	algRS256        = "RS256"
+	jwkUseSig       = "sig"
+	claimSub        = "sub"
+	claimIAT        = "iat"
+	claimSID        = "sid"
+	testSessionSID  = "session-abc"
 )
 
 type testIdP struct {
@@ -79,7 +85,7 @@ func newTestIdP(t *testing.T) *testIdP {
 		w.Header().Set("Content-Type", "application/json")
 
 		set := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{
-			{Key: &key.PublicKey, KeyID: idp.keyID, Algorithm: "RS256", Use: "sig"},
+			{Key: &key.PublicKey, KeyID: idp.keyID, Algorithm: algRS256, Use: jwkUseSig},
 		}}
 
 		if err := json.NewEncoder(w).Encode(set); err != nil {
@@ -187,7 +193,7 @@ func signClaims(t *testing.T, key *rsa.PrivateKey, keyID string, claims map[stri
 
 	signer, err := jose.NewSigner(jose.SigningKey{
 		Algorithm: jose.RS256,
-		Key:       jose.JSONWebKey{Key: key, KeyID: keyID, Algorithm: "RS256", Use: "sig"},
+		Key:       jose.JSONWebKey{Key: key, KeyID: keyID, Algorithm: algRS256, Use: jwkUseSig},
 	}, (&jose.SignerOptions{}).WithType("JWT"))
 	if err != nil {
 		t.Fatalf("jose.NewSigner: %v", err)
@@ -215,12 +221,12 @@ func baseClaims(issuer, clientID, nonce string) map[string]any {
 	now := time.Now()
 
 	return map[string]any{
-		"iss":   issuer,
-		"aud":   clientID,
-		"sub":   testSubject,
-		"exp":   now.Add(time.Hour).Unix(),
-		"iat":   now.Unix(),
-		"nonce": nonce,
+		"iss":    issuer,
+		"aud":    clientID,
+		claimSub: testSubject,
+		"exp":    now.Add(time.Hour).Unix(),
+		claimIAT: now.Unix(),
+		"nonce":  nonce,
 	}
 }
 
@@ -512,7 +518,7 @@ func TestExchangeReadsTheSIDClaim(t *testing.T) {
 
 	t.Run("with sid", func(t *testing.T) {
 		claims := baseClaims(idp.srv.URL, provider.ClientID, testNonce)
-		claims["sid"] = "session-abc"
+		claims[claimSID] = testSessionSID
 		idp.setTokenHandler(jsonTokenResponse(signClaims(t, idp.key, idp.keyID, claims)))
 
 		ts, err := c.Exchange(context.Background(), provider, "test-code", "test-verifier", testNonce, testRedirectURI)
@@ -520,8 +526,8 @@ func TestExchangeReadsTheSIDClaim(t *testing.T) {
 			t.Fatalf("Exchange: %v", err)
 		}
 
-		if ts.SID != "session-abc" {
-			t.Errorf("SID = %q, want %q", ts.SID, "session-abc")
+		if ts.SID != testSessionSID {
+			t.Errorf("SID = %q, want %q", ts.SID, testSessionSID)
 		}
 	})
 
@@ -721,6 +727,183 @@ func TestRefreshReturnsInvalidGrant(t *testing.T) {
 	_, err := c.Refresh(context.Background(), provider, "revoked-refresh")
 	if !errors.Is(err, oidcproviders.ErrInvalidGrant) {
 		t.Errorf("Refresh = %v, want ErrInvalidGrant", err)
+	}
+}
+
+func logoutTokenClaims(issuer, clientID string, extra map[string]any) map[string]any {
+	now := time.Now()
+	claims := map[string]any{
+		"iss":    issuer,
+		"aud":    clientID,
+		claimIAT: now.Unix(),
+		"events": map[string]any{
+			"http://schemas.openid.net/event/backchannel-logout": map[string]any{},
+		},
+	}
+
+	for k, v := range extra {
+		claims[k] = v
+	}
+
+	return claims
+}
+
+func signLogoutClaims(t *testing.T, idp *testIdP, claims map[string]any) string {
+	t.Helper()
+
+	signer, err := jose.NewSigner(jose.SigningKey{
+		Algorithm: jose.RS256,
+		Key:       jose.JSONWebKey{Key: idp.key, KeyID: idp.keyID, Algorithm: algRS256, Use: jwkUseSig},
+	}, (&jose.SignerOptions{}).WithType("logout+jwt"))
+	if err != nil {
+		t.Fatalf("jose.NewSigner: %v", err)
+	}
+
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	jws, err := signer.Sign(payload)
+	if err != nil {
+		t.Fatalf("signer.Sign: %v", err)
+	}
+
+	compact, err := jws.CompactSerialize()
+	if err != nil {
+		t.Fatalf("jws.CompactSerialize: %v", err)
+	}
+
+	return compact
+}
+
+func TestVerifyLogoutTokenAcceptsValidTokenWithSID(t *testing.T) {
+	t.Parallel()
+
+	idp := newTestIdP(t)
+	provider := testProvider(idp.srv.URL)
+	c := newTestClient(t)
+
+	claims := logoutTokenClaims(idp.srv.URL, provider.ClientID, map[string]any{
+		claimSID: testSessionSID,
+		claimSub: testSubject,
+	})
+	raw := signLogoutClaims(t, idp, claims)
+
+	got, err := c.VerifyLogoutToken(context.Background(), provider, raw)
+	if err != nil {
+		t.Fatalf("VerifyLogoutToken: %v", err)
+	}
+
+	if got.SID != testSessionSID {
+		t.Errorf("SID = %q, want %q", got.SID, testSessionSID)
+	}
+
+	if got.Subject != testSubject {
+		t.Errorf("Subject = %q, want %q", got.Subject, testSubject)
+	}
+}
+
+func TestVerifyLogoutTokenRejectsBadSignature(t *testing.T) {
+	t.Parallel()
+
+	idp := newTestIdP(t)
+	provider := testProvider(idp.srv.URL)
+	c := newTestClient(t)
+
+	otherKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+
+	claims := logoutTokenClaims(idp.srv.URL, provider.ClientID, map[string]any{
+		claimSID: testSessionSID,
+		claimSub: testSubject,
+	})
+	raw := signClaims(t, otherKey, idp.keyID, claims)
+
+	_, err = c.VerifyLogoutToken(context.Background(), provider, raw)
+	if !errors.Is(err, oidcproviders.ErrLogoutTokenInvalid) {
+		t.Errorf("VerifyLogoutToken = %v, want ErrLogoutTokenInvalid", err)
+	}
+}
+
+func TestVerifyLogoutTokenRejectsWrongAud(t *testing.T) {
+	t.Parallel()
+
+	idp := newTestIdP(t)
+	provider := testProvider(idp.srv.URL)
+	c := newTestClient(t)
+
+	claims := logoutTokenClaims(idp.srv.URL, "wrong", map[string]any{
+		claimSID: testSessionSID,
+		claimSub: testSubject,
+	})
+	raw := signLogoutClaims(t, idp, claims)
+
+	_, err := c.VerifyLogoutToken(context.Background(), provider, raw)
+	if !errors.Is(err, oidcproviders.ErrLogoutTokenInvalid) {
+		t.Errorf("VerifyLogoutToken = %v, want ErrLogoutTokenInvalid", err)
+	}
+}
+
+func TestVerifyLogoutTokenRejectsPresentNonce(t *testing.T) {
+	t.Parallel()
+
+	idp := newTestIdP(t)
+	provider := testProvider(idp.srv.URL)
+	c := newTestClient(t)
+
+	claims := logoutTokenClaims(idp.srv.URL, provider.ClientID, map[string]any{
+		claimSID: testSessionSID,
+		claimSub: testSubject,
+		"nonce":  "n",
+	})
+	raw := signLogoutClaims(t, idp, claims)
+
+	_, err := c.VerifyLogoutToken(context.Background(), provider, raw)
+	if !errors.Is(err, oidcproviders.ErrLogoutTokenInvalid) {
+		t.Errorf("VerifyLogoutToken = %v, want ErrLogoutTokenInvalid", err)
+	}
+}
+
+func TestVerifyLogoutTokenRejectsMissingEventClaim(t *testing.T) {
+	t.Parallel()
+
+	idp := newTestIdP(t)
+	provider := testProvider(idp.srv.URL)
+	c := newTestClient(t)
+
+	claims := logoutTokenClaims(idp.srv.URL, provider.ClientID, map[string]any{
+		claimSID: testSessionSID,
+		claimSub: testSubject,
+	})
+	delete(claims, "events")
+	raw := signLogoutClaims(t, idp, claims)
+
+	_, err := c.VerifyLogoutToken(context.Background(), provider, raw)
+	if !errors.Is(err, oidcproviders.ErrLogoutTokenInvalid) {
+		t.Errorf("VerifyLogoutToken = %v, want ErrLogoutTokenInvalid", err)
+	}
+}
+
+func TestVerifyLogoutTokenRejectsStaleIAT(t *testing.T) {
+	t.Parallel()
+
+	idp := newTestIdP(t)
+	provider := testProvider(idp.srv.URL)
+	c := newTestClient(t)
+
+	claims := logoutTokenClaims(idp.srv.URL, provider.ClientID, map[string]any{
+		claimSID: testSessionSID,
+		claimSub: testSubject,
+		"iat":    time.Now().Add(-10 * time.Minute).Unix(),
+	})
+	raw := signLogoutClaims(t, idp, claims)
+
+	_, err := c.VerifyLogoutToken(context.Background(), provider, raw)
+	if !errors.Is(err, oidcproviders.ErrLogoutTokenInvalid) {
+		t.Errorf("VerifyLogoutToken = %v, want ErrLogoutTokenInvalid", err)
 	}
 }
 

--- a/api/pkg/core/auth/oidc_backchannel_logout.go
+++ b/api/pkg/core/auth/oidc_backchannel_logout.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package auth
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/federatedidentities"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidc"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/logging"
+)
+
+type verifiedLogoutToken struct {
+	*oidcproviders.LogoutToken
+	provider oidcproviders.OIDCProvider
+}
+
+func (s *Service) BackchannelLogout(ctx context.Context, rawToken string) error {
+	logoutToken, err := s.verifyLogoutToken(ctx, rawToken)
+	if err != nil {
+		return err
+	}
+
+	provider := logoutToken.provider
+
+	switch {
+	case logoutToken.SID != "":
+		if err := s.deps.SessionService.RevokeByProviderAndSID(ctx, provider.ID, logoutToken.SID); err != nil {
+			s.deps.Logger.WarnContext(ctx, "failed to revoke sessions by sid during backchannel logout", logging.Err(err))
+		}
+
+		if logoutToken.Subject != "" {
+			if err := s.clearFederatedRefreshToken(ctx, provider.ID, logoutToken.Subject); err != nil {
+				s.deps.Logger.WarnContext(ctx, "failed to clear refresh token during backchannel logout", logging.Err(err))
+			}
+		}
+	case logoutToken.Subject != "":
+		fi, err := s.deps.FederatedIdentitiesRepository.Get(ctx, federatedidentities.GetFederatedIdentityOpts{
+			ProviderID: provider.ID,
+			Subject:    logoutToken.Subject,
+		})
+		if err != nil {
+			if errors.Is(err, domain.ErrNotFound) {
+				return nil
+			}
+
+			s.deps.Logger.WarnContext(ctx, "failed to load federated identity during backchannel logout", logging.Err(err))
+
+			return nil
+		}
+
+		if err := s.revokeFederatedAccess(ctx, *fi); err != nil {
+			s.deps.Logger.WarnContext(ctx, "failed to revoke federated access during backchannel logout", logging.Err(err))
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) verifyLogoutToken(ctx context.Context, rawToken string) (*verifiedLogoutToken, error) {
+	iss, err := parseUnverifiedIssuer(rawToken)
+	if err != nil {
+		return nil, ErrLogoutTokenInvalid
+	}
+
+	provider, err := s.deps.OIDCProvidersRepository.GetByIssuerURL(ctx, iss)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil, ErrLogoutTokenInvalid
+		}
+
+		return nil, fmt.Errorf("s.deps.OIDCProvidersRepository.GetByIssuerURL: %w", err)
+	}
+
+	token, err := s.deps.OIDCClient.VerifyLogoutToken(ctx, *provider, rawToken)
+	if err != nil {
+		if errors.Is(err, oidcproviders.ErrLogoutTokenInvalid) || errors.Is(err, oidc.ErrClientUnavailable) {
+			return nil, ErrLogoutTokenInvalid
+		}
+
+		return nil, fmt.Errorf("s.deps.OIDCClient.VerifyLogoutToken: %w", err)
+	}
+
+	return &verifiedLogoutToken{provider: *provider, LogoutToken: token}, nil
+}
+
+func parseUnverifiedIssuer(raw string) (string, error) {
+	parts := strings.Split(raw, ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("invalid JWT format")
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("decode JWT payload: %w", err)
+	}
+
+	var claims struct {
+		Iss string `json:"iss"`
+	}
+
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", fmt.Errorf("unmarshal JWT payload: %w", err)
+	}
+
+	if claims.Iss == "" {
+		return "", fmt.Errorf("iss claim is missing")
+	}
+
+	return claims.Iss, nil
+}
+
+func (s *Service) clearFederatedRefreshToken(ctx context.Context, providerID uuid.UUID, subject string) error {
+	fi, err := s.deps.FederatedIdentitiesRepository.Get(ctx, federatedidentities.GetFederatedIdentityOpts{
+		ProviderID: providerID,
+		Subject:    subject,
+	})
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil
+		}
+
+		return fmt.Errorf("s.deps.FederatedIdentitiesRepository.Get: %w", err)
+	}
+
+	if err := s.deps.FederatedIdentitiesRepository.Update(ctx, federatedidentities.UpdateFederatedIdentityOpts{
+		ID:                fi.ID,
+		ClearRefreshToken: true,
+	}); err != nil {
+		return fmt.Errorf("s.deps.FederatedIdentitiesRepository.Update: %w", err)
+	}
+
+	return nil
+}

--- a/api/pkg/core/auth/oidc_backchannel_logout_test.go
+++ b/api/pkg/core/auth/oidc_backchannel_logout_test.go
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package auth_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/federatedidentities"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidc"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+)
+
+const testLogoutSubject = "sub1"
+
+func fakeLogoutTokenJWT(iss string) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	payload, _ := json.Marshal(map[string]string{"iss": iss})
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payload)
+
+	return header + "." + payloadB64 + ".signature"
+}
+
+func TestBackchannelLogoutRevokesBySIDAndClearsRefreshToken(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	fiID := uuid.New()
+	f.fir.fi = &federatedidentities.FederatedIdentity{
+		ID:         fiID,
+		Subject:    testLogoutSubject,
+		ProviderID: f.opr.provider.ID,
+		UserID:     f.ur.user.ID,
+	}
+	f.fir.getErr = nil
+	f.oc.logoutToken = &oidcproviders.LogoutToken{SID: "s1", Subject: testLogoutSubject}
+
+	raw := fakeLogoutTokenJWT(f.opr.provider.IssuerURL)
+
+	if err := f.svc(t).BackchannelLogout(context.Background(), raw); err != nil {
+		t.Fatalf("BackchannelLogout: %v", err)
+	}
+
+	if f.ss.revokeBySIDCalls != 1 {
+		t.Errorf("RevokeByProviderAndSID called %d times, want 1", f.ss.revokeBySIDCalls)
+	}
+
+	if f.ss.gotRevokeBySIDProvider != f.opr.provider.ID || f.ss.gotRevokeBySID != "s1" {
+		t.Errorf("RevokeByProviderAndSID(%v, %q), want (%v, %q)",
+			f.ss.gotRevokeBySIDProvider, f.ss.gotRevokeBySID, f.opr.provider.ID, "s1")
+	}
+
+	if f.fir.updateCalls != 1 {
+		t.Errorf("FederatedIdentitiesRepository.Update called %d times, want 1", f.fir.updateCalls)
+	}
+
+	if !f.fir.gotUpdateOpts.ClearRefreshToken {
+		t.Error("ClearRefreshToken = false, want true")
+	}
+
+	if f.ss.revokeForProviderCalls != 0 {
+		t.Errorf("RevokeForProvider called %d times, want 0", f.ss.revokeForProviderCalls)
+	}
+}
+
+func TestBackchannelLogoutRevokesBySubjectOnly(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	fiID := uuid.New()
+	f.fir.fi = &federatedidentities.FederatedIdentity{
+		ID:         fiID,
+		Subject:    testLogoutSubject,
+		ProviderID: f.opr.provider.ID,
+		UserID:     f.ur.user.ID,
+	}
+	f.fir.getErr = nil
+	f.oc.logoutToken = &oidcproviders.LogoutToken{Subject: testLogoutSubject}
+
+	raw := fakeLogoutTokenJWT(f.opr.provider.IssuerURL)
+
+	if err := f.svc(t).BackchannelLogout(context.Background(), raw); err != nil {
+		t.Fatalf("BackchannelLogout: %v", err)
+	}
+
+	if f.ss.revokeForProviderCalls != 1 {
+		t.Errorf("RevokeForProvider called %d times, want 1", f.ss.revokeForProviderCalls)
+	}
+
+	if f.ss.gotRevokeUserID != f.ur.user.ID || f.ss.gotRevokeProviderID != f.opr.provider.ID {
+		t.Errorf("RevokeForProvider(%v, %v), want (%v, %v)",
+			f.ss.gotRevokeUserID, f.ss.gotRevokeProviderID, f.ur.user.ID, f.opr.provider.ID)
+	}
+
+	if f.fir.updateCalls != 1 {
+		t.Errorf("FederatedIdentitiesRepository.Update called %d times, want 1", f.fir.updateCalls)
+	}
+
+	if !f.fir.gotUpdateOpts.ClearRefreshToken {
+		t.Error("ClearRefreshToken = false, want true")
+	}
+
+	if f.ss.revokeBySIDCalls != 0 {
+		t.Errorf("RevokeByProviderAndSID called %d times, want 0", f.ss.revokeBySIDCalls)
+	}
+}
+
+func TestBackchannelLogoutNoMatchStillSucceeds(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	f.fir.getErr = domain.ErrNotFound
+	f.oc.logoutToken = &oidcproviders.LogoutToken{Subject: "unknown-sub"}
+
+	raw := fakeLogoutTokenJWT(f.opr.provider.IssuerURL)
+
+	if err := f.svc(t).BackchannelLogout(context.Background(), raw); err != nil {
+		t.Fatalf("BackchannelLogout: %v", err)
+	}
+
+	if f.ss.revokeForProviderCalls != 0 {
+		t.Errorf("RevokeForProvider called %d times, want 0", f.ss.revokeForProviderCalls)
+	}
+
+	if f.ss.revokeBySIDCalls != 0 {
+		t.Errorf("RevokeByProviderAndSID called %d times, want 0", f.ss.revokeBySIDCalls)
+	}
+
+	if f.fir.updateCalls != 0 {
+		t.Errorf("FederatedIdentitiesRepository.Update called %d times, want 0", f.fir.updateCalls)
+	}
+}
+
+func TestBackchannelLogoutUnknownIssuer(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	f.opr.issuerErr = domain.ErrNotFound
+
+	raw := fakeLogoutTokenJWT("https://unknown.example.com")
+
+	err := f.svc(t).BackchannelLogout(context.Background(), raw)
+	if !errors.Is(err, auth.ErrLogoutTokenInvalid) {
+		t.Errorf("BackchannelLogout = %v, want ErrLogoutTokenInvalid", err)
+	}
+
+	if f.oc.verifyLogoutCalls != 0 {
+		t.Errorf("VerifyLogoutToken called %d times, want 0", f.oc.verifyLogoutCalls)
+	}
+}
+
+func TestBackchannelLogoutSIDOnlyRevokesSessionsNotRefresh(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	f.oc.logoutToken = &oidcproviders.LogoutToken{SID: "s1"}
+
+	raw := fakeLogoutTokenJWT(f.opr.provider.IssuerURL)
+
+	if err := f.svc(t).BackchannelLogout(context.Background(), raw); err != nil {
+		t.Fatalf("BackchannelLogout: %v", err)
+	}
+
+	if f.ss.revokeBySIDCalls != 1 {
+		t.Errorf("RevokeByProviderAndSID called %d times, want 1", f.ss.revokeBySIDCalls)
+	}
+
+	if f.ss.gotRevokeBySIDProvider != f.opr.provider.ID || f.ss.gotRevokeBySID != "s1" {
+		t.Errorf("RevokeByProviderAndSID(%v, %q), want (%v, %q)",
+			f.ss.gotRevokeBySIDProvider, f.ss.gotRevokeBySID, f.opr.provider.ID, "s1")
+	}
+
+	if f.fir.updateCalls != 0 {
+		t.Errorf("FederatedIdentitiesRepository.Update called %d times, want 0", f.fir.updateCalls)
+	}
+
+	if f.fir.getCalls != 0 {
+		t.Errorf("FederatedIdentitiesRepository.Get called %d times, want 0", f.fir.getCalls)
+	}
+}
+
+func TestBackchannelLogoutNeitherSIDNorSub(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	f.oc.logoutToken = &oidcproviders.LogoutToken{}
+
+	raw := fakeLogoutTokenJWT(f.opr.provider.IssuerURL)
+
+	if err := f.svc(t).BackchannelLogout(context.Background(), raw); err != nil {
+		t.Fatalf("BackchannelLogout: %v", err)
+	}
+
+	if f.ss.revokeBySIDCalls != 0 {
+		t.Errorf("RevokeByProviderAndSID called %d times, want 0", f.ss.revokeBySIDCalls)
+	}
+
+	if f.ss.revokeForProviderCalls != 0 {
+		t.Errorf("RevokeForProvider called %d times, want 0", f.ss.revokeForProviderCalls)
+	}
+
+	if f.fir.getCalls != 0 {
+		t.Errorf("FederatedIdentitiesRepository.Get called %d times, want 0", f.fir.getCalls)
+	}
+
+	if f.fir.updateCalls != 0 {
+		t.Errorf("FederatedIdentitiesRepository.Update called %d times, want 0", f.fir.updateCalls)
+	}
+}
+
+func TestBackchannelLogoutRevokeBySIDFailureStillSucceeds(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	f.ss.revokeBySIDErr = fmt.Errorf("db down")
+	f.oc.logoutToken = &oidcproviders.LogoutToken{SID: "s1"}
+
+	raw := fakeLogoutTokenJWT(f.opr.provider.IssuerURL)
+
+	if err := f.svc(t).BackchannelLogout(context.Background(), raw); err != nil {
+		t.Fatalf("BackchannelLogout: %v, want nil", err)
+	}
+
+	if f.ss.revokeBySIDCalls != 1 {
+		t.Errorf("RevokeByProviderAndSID called %d times, want 1", f.ss.revokeBySIDCalls)
+	}
+}
+
+func TestBackchannelLogoutClientUnavailable(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	f.oc.verifyLogoutErr = oidc.ErrClientUnavailable
+
+	raw := fakeLogoutTokenJWT(f.opr.provider.IssuerURL)
+
+	err := f.svc(t).BackchannelLogout(context.Background(), raw)
+	if !errors.Is(err, auth.ErrLogoutTokenInvalid) {
+		t.Errorf("BackchannelLogout = %v, want ErrLogoutTokenInvalid", err)
+	}
+}
+
+func TestBackchannelLogoutInvalidToken(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	f.oc.verifyLogoutErr = oidcproviders.ErrLogoutTokenInvalid
+
+	raw := fakeLogoutTokenJWT(f.opr.provider.IssuerURL)
+
+	err := f.svc(t).BackchannelLogout(context.Background(), raw)
+	if !errors.Is(err, auth.ErrLogoutTokenInvalid) {
+		t.Errorf("BackchannelLogout = %v, want ErrLogoutTokenInvalid", err)
+	}
+}
+
+func TestBackchannelLogoutReplay(t *testing.T) {
+	t.Parallel()
+
+	f := newFakes()
+	f.fir.fi = &federatedidentities.FederatedIdentity{
+		ID:         uuid.New(),
+		Subject:    testLogoutSubject,
+		ProviderID: f.opr.provider.ID,
+		UserID:     f.ur.user.ID,
+	}
+	f.fir.getErr = nil
+	f.oc.logoutToken = &oidcproviders.LogoutToken{SID: "s1", Subject: testLogoutSubject}
+
+	raw := fakeLogoutTokenJWT(f.opr.provider.IssuerURL)
+	svc := f.svc(t)
+
+	for range 2 {
+		if err := svc.BackchannelLogout(context.Background(), raw); err != nil {
+			t.Fatalf("BackchannelLogout: %v", err)
+		}
+	}
+
+	if f.oc.verifyLogoutCalls != 2 {
+		t.Errorf("VerifyLogoutToken called %d times, want 2", f.oc.verifyLogoutCalls)
+	}
+
+	if f.ss.revokeBySIDCalls != 2 {
+		t.Errorf("RevokeByProviderAndSID called %d times, want 2", f.ss.revokeBySIDCalls)
+	}
+}

--- a/api/pkg/core/auth/oidc_login_test.go
+++ b/api/pkg/core/auth/oidc_login_test.go
@@ -29,10 +29,13 @@ const (
 )
 
 type fakeOIDCProvidersRepo struct {
-	err      error
-	provider *oidcproviders.OIDCProvider
-	gotID    uuid.UUID
-	calls    int
+	provider     *oidcproviders.OIDCProvider
+	err          error
+	issuerErr    error
+	gotIssuerURL string
+	gotID        uuid.UUID
+	calls        int
+	issuerCalls  int
 }
 
 func (f *fakeOIDCProvidersRepo) GetByID(_ context.Context, id uuid.UUID) (*oidcproviders.OIDCProvider, error) {
@@ -46,8 +49,22 @@ func (f *fakeOIDCProvidersRepo) GetByID(_ context.Context, id uuid.UUID) (*oidcp
 	return f.provider, nil
 }
 
-func (f *fakeOIDCProvidersRepo) GetByIssuerURL(context.Context, string) (*oidcproviders.OIDCProvider, error) {
-	panic("GetByIssuerURL is not used by the auth service")
+func (f *fakeOIDCProvidersRepo) GetByIssuerURL(
+	_ context.Context,
+	issuerURL string,
+) (*oidcproviders.OIDCProvider, error) {
+	f.issuerCalls++
+	f.gotIssuerURL = issuerURL
+
+	if f.issuerErr != nil {
+		return nil, f.issuerErr
+	}
+
+	if f.provider != nil && f.provider.IssuerURL == issuerURL {
+		return f.provider, nil
+	}
+
+	return nil, domain.ErrNotFound
 }
 
 func (f *fakeOIDCProvidersRepo) Create(
@@ -150,7 +167,9 @@ type fakeOIDCClient struct {
 	authCodeErr           error
 	exchangeErr           error
 	endSessionErr         error
+	verifyLogoutErr       error
 	tokenSet              *oidcproviders.TokenSet
+	logoutToken           *oidcproviders.LogoutToken
 	authCodeURL           string
 	endSessionURL         string
 	gotCode               string
@@ -158,11 +177,13 @@ type fakeOIDCClient struct {
 	gotNonce              string
 	gotRedirectURI        string
 	gotPostLogoutRedirect string
+	gotLogoutRaw          string
 	gotAuthParams         oidcproviders.AuthCodeParams
 	gotProvider           oidcproviders.OIDCProvider
 	authCodeCalls         int
 	exchangeCalls         int
 	endSessionCalls       int
+	verifyLogoutCalls     int
 	endSessionSupported   bool
 }
 
@@ -223,6 +244,22 @@ func (f *fakeOIDCClient) Refresh(
 	string,
 ) (*oidcproviders.TokenSet, error) {
 	panic("Refresh is not used by the auth service")
+}
+
+func (f *fakeOIDCClient) VerifyLogoutToken(
+	_ context.Context,
+	provider oidcproviders.OIDCProvider,
+	raw string,
+) (*oidcproviders.LogoutToken, error) {
+	f.verifyLogoutCalls++
+	f.gotProvider = provider
+	f.gotLogoutRaw = raw
+
+	if f.verifyLogoutErr != nil {
+		return nil, f.verifyLogoutErr
+	}
+
+	return f.logoutToken, nil
 }
 
 func TestStartOIDCLoginBuildsAuthCodeURLAndCookie(t *testing.T) {

--- a/api/pkg/core/auth/oidc_revalidation.go
+++ b/api/pkg/core/auth/oidc_revalidation.go
@@ -63,14 +63,7 @@ func (s *Service) revokeFederatedAccess(ctx context.Context, fi federatedidentit
 		return fmt.Errorf("s.deps.SessionService.RevokeForProvider: %w", err)
 	}
 
-	if err := s.deps.FederatedIdentitiesRepository.Update(ctx, federatedidentities.UpdateFederatedIdentityOpts{
-		ID:                fi.ID,
-		ClearRefreshToken: true,
-	}); err != nil {
-		return fmt.Errorf("s.deps.FederatedIdentitiesRepository.Update: %w", err)
-	}
-
-	return nil
+	return s.clearFederatedRefreshToken(ctx, fi.ProviderID, fi.Subject)
 }
 
 func (s *Service) RevalidateFederatedIdentity(

--- a/api/pkg/core/auth/oidc_revalidation_test.go
+++ b/api/pkg/core/auth/oidc_revalidation_test.go
@@ -50,6 +50,10 @@ func (s *revalidationSessionService) RevokeForProvider(_ context.Context, userID
 	return s.err
 }
 
+func (s *revalidationSessionService) RevokeByProviderAndSID(context.Context, uuid.UUID, string) error {
+	panic("RevokeByProviderAndSID is not used by revalidation")
+}
+
 type revalidationOIDCClient struct {
 	tokenSet *oidcproviders.TokenSet
 	err      error
@@ -85,6 +89,14 @@ func (c *revalidationOIDCClient) EndSessionURL(
 	string,
 ) (string, bool, error) {
 	panic("EndSessionURL is not used by revalidation")
+}
+
+func (c *revalidationOIDCClient) VerifyLogoutToken(
+	context.Context,
+	oidcproviders.OIDCProvider,
+	string,
+) (*oidcproviders.LogoutToken, error) {
+	panic("VerifyLogoutToken is not used by revalidation")
 }
 
 func newRevalidationAuth(t *testing.T, f *fakes, ss sessions.SessionService, oc oidcproviders.Client) *auth.Service {
@@ -125,8 +137,11 @@ func TestRevalidateFederatedIdentityInvalidGrantRevokesProviderSessions(t *testi
 		ID:              uuid.New(),
 		UserID:          f.ur.user.ID,
 		ProviderID:      f.opr.provider.ID,
+		Subject:         testSubject,
 		RefreshTokenEnc: sealed,
 	}
+	f.fir.getErr = nil
+	f.fir.fi = &fi
 
 	s := newRevalidationAuth(t, f, ss, &revalidationOIDCClient{err: oidcproviders.ErrInvalidGrant})
 

--- a/api/pkg/core/auth/oidcproviders/domain.go
+++ b/api/pkg/core/auth/oidcproviders/domain.go
@@ -107,6 +107,7 @@ type Client interface {
 	Exchange(ctx context.Context, provider OIDCProvider, code, verifier, nonce, redirectURI string) (*TokenSet, error)
 	Refresh(ctx context.Context, provider OIDCProvider, refreshToken string) (*TokenSet, error)
 	EndSessionURL(ctx context.Context, provider OIDCProvider, postLogoutRedirectURI string) (string, bool, error)
+	VerifyLogoutToken(ctx context.Context, provider OIDCProvider, raw string) (*LogoutToken, error)
 }
 
 type AuthCodeParams struct {
@@ -122,3 +123,10 @@ type TokenSet struct {
 	Subject      string
 	SID          string
 }
+
+type LogoutToken struct {
+	Subject string
+	SID     string
+}
+
+var ErrLogoutTokenInvalid = errors.New("oidc: logout token is invalid")

--- a/api/pkg/core/auth/service_test.go
+++ b/api/pkg/core/auth/service_test.go
@@ -228,13 +228,21 @@ func (f *fakePwdRepository) UpdateByUserID(context.Context, password.UpsertPassw
 }
 
 type fakeSessionService struct {
-	err         error
-	revokeErr   error
-	issued      *sessions.IssuedSession
-	gotToken    string
-	gotOpts     sessions.CreateSessionOpts
-	calls       int
-	revokeCalls int
+	err                    error
+	revokeErr              error
+	revokeForProviderErr   error
+	revokeBySIDErr         error
+	issued                 *sessions.IssuedSession
+	gotRevokeBySID         string
+	gotToken               string
+	gotOpts                sessions.CreateSessionOpts
+	calls                  int
+	revokeCalls            int
+	revokeForProviderCalls int
+	revokeBySIDCalls       int
+	gotRevokeUserID        uuid.UUID
+	gotRevokeProviderID    uuid.UUID
+	gotRevokeBySIDProvider uuid.UUID
 }
 
 func (f *fakeSessionService) Create(
@@ -270,8 +278,28 @@ func (f *fakeSessionService) RevokeAllForUser(context.Context, uuid.UUID) error 
 	panic("RevokeAllForUser is not used by the auth service")
 }
 
-func (f *fakeSessionService) RevokeForProvider(context.Context, uuid.UUID, uuid.UUID) error {
-	panic("RevokeForProvider is not used by the auth service")
+func (f *fakeSessionService) RevokeForProvider(_ context.Context, userID, providerID uuid.UUID) error {
+	f.revokeForProviderCalls++
+	f.gotRevokeUserID = userID
+	f.gotRevokeProviderID = providerID
+
+	if f.revokeForProviderErr != nil {
+		return f.revokeForProviderErr
+	}
+
+	return nil
+}
+
+func (f *fakeSessionService) RevokeByProviderAndSID(_ context.Context, providerID uuid.UUID, sid string) error {
+	f.revokeBySIDCalls++
+	f.gotRevokeBySIDProvider = providerID
+	f.gotRevokeBySID = sid
+
+	if f.revokeBySIDErr != nil {
+		return f.revokeBySIDErr
+	}
+
+	return nil
 }
 
 type fakes struct {

--- a/api/pkg/core/auth/sessions/domain.go
+++ b/api/pkg/core/auth/sessions/domain.go
@@ -47,6 +47,7 @@ type SessionService interface {
 	Revoke(context.Context, string) error
 	RevokeAllForUser(context.Context, uuid.UUID) error
 	RevokeForProvider(context.Context, uuid.UUID, uuid.UUID) error
+	RevokeByProviderAndSID(context.Context, uuid.UUID, string) error
 }
 
 type CreateSessionOpts struct {
@@ -63,6 +64,7 @@ type SessionsRepository interface {
 	DeleteByTokenHash(context.Context, []byte) error
 	DeleteByUserID(context.Context, uuid.UUID) error
 	DeleteByUserAndProvider(context.Context, uuid.UUID, uuid.UUID) error
+	DeleteByProviderAndSID(context.Context, uuid.UUID, string) error
 	DeleteExpired(context.Context, time.Time) (int64, error)
 }
 

--- a/api/pkg/core/auth/sessions/repository/pg/repository.go
+++ b/api/pkg/core/auth/sessions/repository/pg/repository.go
@@ -134,6 +134,14 @@ func (r *PGSessionsRepository) DeleteByUserAndProvider(
 	return nil
 }
 
+func (r *PGSessionsRepository) DeleteByProviderAndSID(ctx context.Context, providerID uuid.UUID, sid string) error {
+	if _, err := r.db(ctx).Where("provider_id = ? AND provider_sid = ?", providerID, sid).Delete(ctx); err != nil {
+		return fmt.Errorf("r.db(ctx).Delete: %w", err)
+	}
+
+	return nil
+}
+
 func (r *PGSessionsRepository) DeleteExpired(ctx context.Context, now time.Time) (int64, error) {
 	deleted, err := r.db(ctx).Where("expires_at <= ?", now).Delete(ctx)
 	if err != nil {

--- a/api/pkg/core/auth/sessions/repository/pg/repository_test.go
+++ b/api/pkg/core/auth/sessions/repository/pg/repository_test.go
@@ -400,6 +400,24 @@ func TestDeleteByUserAndProvider(t *testing.T) {
 	}
 }
 
+func TestDeleteByProviderAndSID(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newRepo(t)
+	providerID := uuid.New()
+	sid := "session-abc"
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`DELETE FROM "sessions" WHERE provider_id = \$1 AND provider_sid = \$2`).
+		WithArgs(providerID, sid).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	if err := r.DeleteByProviderAndSID(context.Background(), providerID, sid); err != nil {
+		t.Fatalf("DeleteByProviderAndSID: %v", err)
+	}
+}
+
 func TestDeleteExpiredReturnsRowCount(t *testing.T) {
 	t.Parallel()
 

--- a/api/pkg/core/auth/sessions/service.go
+++ b/api/pkg/core/auth/sessions/service.go
@@ -219,3 +219,11 @@ func (s *Service) RevokeForProvider(ctx context.Context, userID, providerID uuid
 
 	return nil
 }
+
+func (s *Service) RevokeByProviderAndSID(ctx context.Context, providerID uuid.UUID, sid string) error {
+	if err := s.deps.Repository.DeleteByProviderAndSID(ctx, providerID, sid); err != nil {
+		return fmt.Errorf("s.deps.Repository.DeleteByProviderAndSID: %w", err)
+	}
+
+	return nil
+}

--- a/api/pkg/core/auth/sessions/service_test.go
+++ b/api/pkg/core/auth/sessions/service_test.go
@@ -35,22 +35,25 @@ func validConfig() sessions.ServiceConfig {
 }
 
 type fakeRepository struct {
-	gotExpiry    time.Time
-	insertErr    error
-	getErr       error
-	updateErr    error
-	deleteErr    error
-	user         *users.User
-	session      *sessions.Session
-	gotHash      []byte
-	gotInsert    sessions.InsertSessionOpts
-	inserts      int
-	gets         int
-	updates      int
-	deleteHashes int
-	deleteUsers  int
-	gotUserID    uuid.UUID
-	gotID        uuid.UUID
+	gotExpiry     time.Time
+	insertErr     error
+	getErr        error
+	updateErr     error
+	deleteErr     error
+	session       *sessions.Session
+	user          *users.User
+	gotSID        string
+	gotHash       []byte
+	gotInsert     sessions.InsertSessionOpts
+	inserts       int
+	gets          int
+	updates       int
+	deleteHashes  int
+	deleteUsers   int
+	deleteBySID   int
+	gotProviderID uuid.UUID
+	gotUserID     uuid.UUID
+	gotID         uuid.UUID
 }
 
 func (f *fakeRepository) Insert(_ context.Context, opts sessions.InsertSessionOpts) (*sessions.Session, error) {
@@ -106,6 +109,15 @@ func (f *fakeRepository) DeleteByUserID(_ context.Context, id uuid.UUID) error {
 func (f *fakeRepository) DeleteByUserAndProvider(_ context.Context, userID, providerID uuid.UUID) error {
 	f.deleteUsers++
 	f.gotUserID = userID
+	f.gotProviderID = providerID
+
+	return f.deleteErr
+}
+
+func (f *fakeRepository) DeleteByProviderAndSID(_ context.Context, providerID uuid.UUID, sid string) error {
+	f.deleteBySID++
+	f.gotProviderID = providerID
+	f.gotSID = sid
 
 	return f.deleteErr
 }
@@ -770,5 +782,41 @@ func TestRevokeForProviderDeletesByUserAndProvider(t *testing.T) {
 
 	if repo.gotUserID != userID {
 		t.Errorf("DeleteByUserAndProvider user = %v, want %v", repo.gotUserID, userID)
+	}
+}
+
+func TestRevokeByProviderAndSIDDeletesByProviderAndSID(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepository{}
+	providerID := uuid.New()
+	sid := "session-abc"
+
+	if err := frozenSvc(t, repo, time.Now()).RevokeByProviderAndSID(
+		context.Background(), providerID, sid,
+	); err != nil {
+		t.Fatalf("RevokeByProviderAndSID: %v", err)
+	}
+
+	if repo.gotProviderID != providerID {
+		t.Errorf("DeleteByProviderAndSID provider = %v, want %v", repo.gotProviderID, providerID)
+	}
+
+	if repo.gotSID != sid {
+		t.Errorf("DeleteByProviderAndSID sid = %q, want %q", repo.gotSID, sid)
+	}
+}
+
+func TestRevokeByProviderAndSIDPropagatesRepositoryError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("connection reset")
+	repo := &fakeRepository{deleteErr: sentinel}
+
+	err := frozenSvc(t, repo, time.Now()).RevokeByProviderAndSID(
+		context.Background(), uuid.New(), "session-abc",
+	)
+	if !errors.Is(err, sentinel) {
+		t.Errorf("err = %v, original error no longer reachable", err)
 	}
 }

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -113,6 +113,10 @@ func (fakeSessionsRepository) DeleteByUserAndProvider(context.Context, uuid.UUID
 	return errors.New(notImplemented)
 }
 
+func (fakeSessionsRepository) DeleteByProviderAndSID(context.Context, uuid.UUID, string) error {
+	return errors.New(notImplemented)
+}
+
 func (fakeSessionsRepository) DeleteByUserID(context.Context, uuid.UUID) error {
 	return errors.New(notImplemented)
 }
@@ -150,6 +154,10 @@ func (fakeAuthService) StartOIDCLogin(context.Context, auth.StartOIDCLoginOpts) 
 //nolint:lll
 func (fakeAuthService) FinishOIDCLogin(context.Context, auth.FinishOIDCLoginOpts) (*auth.OIDCLoginResult, error) {
 	return nil, errors.New(notImplemented)
+}
+
+func (fakeAuthService) BackchannelLogout(context.Context, string) error {
+	return errors.New(notImplemented)
 }
 
 type fakeOIDCProvidersService struct{}

--- a/api/pkg/core/setup/dosetup_test.go
+++ b/api/pkg/core/setup/dosetup_test.go
@@ -78,6 +78,10 @@ func (f *fakeAuthService) FinishOIDCLogin(context.Context, auth.FinishOIDCLoginO
 	panic("FinishOIDCLogin must not be called by DoSetup")
 }
 
+func (f *fakeAuthService) BackchannelLogout(context.Context, string) error {
+	panic("BackchannelLogout must not be called by DoSetup")
+}
+
 type stubSessionService struct {
 	err     error
 	issued  *sessions.IssuedSession
@@ -115,6 +119,10 @@ func (s *stubSessionService) RevokeAllForUser(context.Context, uuid.UUID) error 
 
 func (s *stubSessionService) RevokeForProvider(context.Context, uuid.UUID, uuid.UUID) error {
 	panic("RevokeForProvider must not be called by DoSetup")
+}
+
+func (s *stubSessionService) RevokeByProviderAndSID(context.Context, uuid.UUID, string) error {
+	panic("RevokeByProviderAndSID must not be called by DoSetup")
 }
 
 func defaultSessionStub() *stubSessionService {


### PR DESCRIPTION
## Summary

- Add `POST /api/auth/oidc/backchannel-logout` as a public endpoint that accepts a signed `logout_token` from the IdP
- Verify the JWT against the provider JWKS (signature, `iss`, `aud`, `iat`, back-channel `events` claim, no `nonce`)
- Revoke sessions by `(providerID, sid)` or by federated identity `sub`, with refresh-token cleanup (Option B)
- Always return `200` with `Cache-Control: no-store` on valid tokens, including when no session matches (anti-probing)

## Test plan

- [x] `go build ./...`, `go test ./...`, `golangci-lint run ./...` green
- [x] Unit tests: valid token with `sid`, valid token with `sub` only, no match, bad signature, wrong `aud`, present `nonce`, missing event claim, unknown issuer, replay
- [x] Manual: configure IdP back-channel logout URL to `{PUBLIC_URL}/api/auth/oidc/backchannel-logout`, sign out from another SSO app, confirm Uchiyomi session ends

Closes #8