### PR TITLE
Comic and library entry data model

### DIFF
--- a/api/pkg/core/comics/domain.go
+++ b/api/pkg/core/comics/domain.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package comics
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Comic struct {
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+	Artist           string
+	Type             string
+	Description      string
+	LocalCoverPath   string
+	ExternalCoverURL string
+	SourceURL        string
+	Source           string
+	Author           string
+	Status           string
+	Slug             string
+	Title            string
+	Genres           []string
+	AltTitles        []string
+	ChapterCount     int
+	ReleaseYear      int
+	Rating           float64
+	ID               uuid.UUID
+}
+
+type SourceSlugKey struct {
+	Source string
+	Slug   string
+}
+
+type ComicsRepository interface {
+	GetByID(context.Context, uuid.UUID) (*Comic, error)
+	GetBySourceSlug(context.Context, SourceSlugKey) (*Comic, error)
+	Create(context.Context, CreateComicOpts) (*Comic, error)
+}
+
+type CreateComicOpts struct {
+	Status           string
+	Type             string
+	Description      string
+	LocalCoverPath   string
+	ExternalCoverURL string
+	SourceURL        string
+	Source           string
+	Artist           string
+	Slug             string
+	Author           string
+	Title            string
+	AltTitles        []string
+	Genres           []string
+	ChapterCount     int
+	ReleaseYear      int
+	Rating           float64
+}

--- a/api/pkg/core/comics/repository/pg/repository.go
+++ b/api/pkg/core/comics/repository/pg/repository.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package pg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/repository/pgmodels"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/transaction/pgtx"
+	"github.com/lib/pq"
+	"gorm.io/gorm"
+)
+
+var _ comics.ComicsRepository = (*PGComicsRepository)(nil)
+
+type Deps struct {
+	DB *gorm.DB
+}
+
+func (deps *Deps) Validate() error {
+	if deps.DB == nil {
+		return errors.New("db is required")
+	}
+
+	return nil
+}
+
+type PGComicsRepository struct {
+	deps Deps
+}
+
+func New(deps Deps) (*PGComicsRepository, error) {
+	if err := deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	r := &PGComicsRepository{deps: deps}
+
+	return r, nil
+}
+
+func (r *PGComicsRepository) db(ctx context.Context) gorm.Interface[pgmodels.Comic] {
+	return gorm.G[pgmodels.Comic](pgtx.From(ctx, r.deps.DB))
+}
+
+func (r *PGComicsRepository) GetByID(ctx context.Context, id uuid.UUID) (*comics.Comic, error) {
+	model, err := r.db(ctx).Where("id = ?", id).First(ctx)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrNotFound
+		}
+
+		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
+	}
+
+	ret := r.modelToDomain(model)
+
+	return &ret, nil
+}
+
+func (r *PGComicsRepository) GetBySourceSlug(ctx context.Context, key comics.SourceSlugKey) (*comics.Comic, error) {
+	model, err := r.db(ctx).Where("source = ? AND slug = ?", key.Source, key.Slug).First(ctx)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrNotFound
+		}
+
+		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
+	}
+
+	ret := r.modelToDomain(model)
+
+	return &ret, nil
+}
+
+func (r *PGComicsRepository) Create(ctx context.Context, opts comics.CreateComicOpts) (*comics.Comic, error) {
+	now := time.Now()
+
+	model := &pgmodels.Comic{
+		ID:               uuid.New(),
+		Source:           opts.Source,
+		Slug:             opts.Slug,
+		Title:            opts.Title,
+		Status:           opts.Status,
+		ComicType:        opts.Type,
+		Genres:           pq.StringArray(opts.Genres),
+		ChapterCount:     opts.ChapterCount,
+		Author:           opts.Author,
+		Artist:           opts.Artist,
+		Description:      opts.Description,
+		AltTitles:        pq.StringArray(opts.AltTitles),
+		Rating:           opts.Rating,
+		ReleaseYear:      opts.ReleaseYear,
+		SourceURL:        opts.SourceURL,
+		ExternalCoverURL: opts.ExternalCoverURL,
+		LocalCoverPath:   opts.LocalCoverPath,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	err := r.db(ctx).Create(ctx, model)
+	if err != nil {
+		if errors.Is(err, gorm.ErrDuplicatedKey) {
+			return nil, domain.ErrAlreadyExists
+		}
+
+		return nil, fmt.Errorf("r.db(ctx).Create: %w", err)
+	}
+
+	ret := r.modelToDomain(*model)
+
+	return &ret, nil
+}
+
+func (r *PGComicsRepository) modelToDomain(model pgmodels.Comic) comics.Comic {
+	return comics.Comic{
+		ID:               model.ID,
+		Source:           model.Source,
+		Slug:             model.Slug,
+		Title:            model.Title,
+		Status:           model.Status,
+		Type:             model.ComicType,
+		Genres:           model.Genres,
+		ChapterCount:     model.ChapterCount,
+		Author:           model.Author,
+		Artist:           model.Artist,
+		Description:      model.Description,
+		AltTitles:        model.AltTitles,
+		Rating:           model.Rating,
+		ReleaseYear:      model.ReleaseYear,
+		SourceURL:        model.SourceURL,
+		ExternalCoverURL: model.ExternalCoverURL,
+		LocalCoverPath:   model.LocalCoverPath,
+		CreatedAt:        model.CreatedAt,
+		UpdatedAt:        model.UpdatedAt,
+	}
+}

--- a/api/pkg/core/comics/repository/pg/repository_test.go
+++ b/api/pkg/core/comics/repository/pg/repository_test.go
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package pg_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics/repository/pg"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/repository/pgtest"
+)
+
+const (
+	comicSource = "asurascans"
+	comicSlug   = "solo-leveling"
+	comicTitle  = "Solo Leveling"
+	comicStatus = "completed"
+	comicType   = "manhwa"
+)
+
+func duplicateComicKeyErr() error {
+	return &pgconn.PgError{
+		Code:    "23505",
+		Message: `duplicate key value violates unique constraint "idx_comic_source_slug"`,
+	}
+}
+
+func newComicsRepo(t *testing.T) (*pg.PGComicsRepository, sqlmock.Sqlmock) {
+	t.Helper()
+
+	db, mock := pgtest.New(t)
+
+	r, err := pg.New(pg.Deps{DB: db})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	return r, mock
+}
+
+func TestNewValidatesDeps(t *testing.T) {
+	t.Parallel()
+
+	r, err := pg.New(pg.Deps{})
+	if err == nil {
+		t.Fatal("New without DB must fail")
+	}
+
+	if r != nil {
+		t.Error("New returned a repository in addition to the error")
+	}
+
+	if want := "deps.Validate: db is required"; err.Error() != want {
+		t.Errorf("err = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestGetByID(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newComicsRepo(t)
+
+	id := uuid.New()
+	created := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	updated := time.Now().UTC().Truncate(time.Second)
+
+	mock.ExpectQuery(`SELECT \* FROM "comics" WHERE id = \$1`).
+		WithArgs(id, 1).
+		WillReturnRows(
+			sqlmock.NewRows([]string{
+				"id", "source", "slug", "title", "status", "comic_type",
+				"chapter_count", "author", "artist", "description", "rating", "release_year",
+				"source_url", "external_cover_url", "local_cover_path", "created_at", "updated_at",
+			}).AddRow(
+				id, comicSource, comicSlug, comicTitle, comicStatus, comicType,
+				200, "Chugong", "Dubu", "desc", 9.5, 2018,
+				"https://api.asurascans.com/series/solo-leveling", "https://cover.example/cover.webp",
+				"covers/solo-leveling.webp", created, updated,
+			),
+		)
+
+	got, err := r.GetByID(context.Background(), id)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+
+	if got.ID != id || got.Source != comicSource || got.Slug != comicSlug || got.Title != comicTitle {
+		t.Errorf("GetByID() = %+v", got)
+	}
+}
+
+func TestGetByIDNotFound(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newComicsRepo(t)
+
+	mock.ExpectQuery(`SELECT \* FROM "comics"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	got, err := r.GetByID(context.Background(), uuid.New())
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("GetByID = %v, want domain.ErrNotFound", err)
+	}
+
+	if got != nil {
+		t.Errorf("GetByID returned %+v in addition to the error", got)
+	}
+}
+
+func TestGetBySourceSlug(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newComicsRepo(t)
+
+	id := uuid.New()
+	created := time.Now().UTC().Truncate(time.Second)
+	updated := created
+
+	mock.ExpectQuery(`SELECT \* FROM "comics" WHERE source = \$1 AND slug = \$2`).
+		WithArgs(comicSource, comicSlug, 1).
+		WillReturnRows(
+			sqlmock.NewRows([]string{
+				"id", "source", "slug", "title", "status", "comic_type",
+				"chapter_count", "author", "artist", "description", "rating", "release_year",
+				"source_url", "external_cover_url", "local_cover_path", "created_at", "updated_at",
+			}).AddRow(
+				id, comicSource, comicSlug, comicTitle, comicStatus, comicType,
+				200, "Chugong", "Dubu", "desc", 9.5, 2018,
+				"", "", "", created, updated,
+			),
+		)
+
+	got, err := r.GetBySourceSlug(context.Background(), comics.SourceSlugKey{
+		Source: comicSource,
+		Slug:   comicSlug,
+	})
+	if err != nil {
+		t.Fatalf("GetBySourceSlug: %v", err)
+	}
+
+	if got.Slug != comicSlug {
+		t.Errorf("GetBySourceSlug() slug = %q, want %q", got.Slug, comicSlug)
+	}
+}
+
+func TestCreate(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newComicsRepo(t)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`INSERT INTO "comics"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+	mock.ExpectCommit()
+
+	before := time.Now()
+
+	got, err := r.Create(context.Background(), comics.CreateComicOpts{
+		Source:       comicSource,
+		Slug:         comicSlug,
+		Title:        comicTitle,
+		Status:       comicStatus,
+		Type:         comicType,
+		Genres:       []string{"action", "fantasy"},
+		ChapterCount: 200,
+		Author:       "Chugong",
+		Artist:       "Dubu",
+		Description:  "desc",
+		AltTitles:    []string{"Na Honjaman Level Up"},
+		Rating:       9.5,
+		ReleaseYear:  2018,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if got.Slug != comicSlug || got.Type != comicType {
+		t.Errorf("Create() = %+v", got)
+	}
+
+	if got.ID == uuid.Nil {
+		t.Error("Create did not generate ID")
+	}
+
+	if got.CreatedAt.Before(before) || got.UpdatedAt.Before(before) {
+		t.Errorf("timestamps not set: created=%v updated=%v", got.CreatedAt, got.UpdatedAt)
+	}
+}
+
+func TestCreateDuplicateKey(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newComicsRepo(t)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`INSERT INTO "comics"`).WillReturnError(duplicateComicKeyErr())
+	mock.ExpectRollback()
+
+	got, err := r.Create(context.Background(), comics.CreateComicOpts{
+		Source: comicSource,
+		Slug:   comicSlug,
+		Title:  comicTitle,
+	})
+	if !errors.Is(err, domain.ErrAlreadyExists) {
+		t.Errorf("Create = %v, want domain.ErrAlreadyExists", err)
+	}
+
+	if got != nil {
+		t.Errorf("Create returned %+v in addition to the error", got)
+	}
+}

--- a/api/pkg/core/library/domain.go
+++ b/api/pkg/core/library/domain.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package library
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
+)
+
+type Entry struct {
+	AddedAt time.Time
+	ID      uuid.UUID
+	UserID  uuid.UUID
+	ComicID uuid.UUID
+}
+
+type EntryWithComic struct {
+	Entry Entry
+	Comic comics.Comic
+}
+
+type LibraryRepository interface {
+	GetByID(context.Context, uuid.UUID) (*Entry, error)
+	GetByUserAndComic(context.Context, uuid.UUID, uuid.UUID) (*Entry, error)
+	ListByUser(context.Context, uuid.UUID) ([]EntryWithComic, error)
+	Create(context.Context, CreateEntryOpts) (*Entry, error)
+	Delete(context.Context, uuid.UUID) error
+}
+
+type CreateEntryOpts struct {
+	AddedAt time.Time
+	UserID  uuid.UUID
+	ComicID uuid.UUID
+}

--- a/api/pkg/core/library/repository/pg/repository.go
+++ b/api/pkg/core/library/repository/pg/repository.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package pg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/library"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/repository/pgmodels"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/transaction/pgtx"
+	"gorm.io/gorm"
+)
+
+var _ library.LibraryRepository = (*PGLibraryRepository)(nil)
+
+type Deps struct {
+	DB *gorm.DB
+}
+
+func (deps *Deps) Validate() error {
+	if deps.DB == nil {
+		return errors.New("db is required")
+	}
+
+	return nil
+}
+
+type PGLibraryRepository struct {
+	deps Deps
+}
+
+func New(deps Deps) (*PGLibraryRepository, error) {
+	if err := deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	r := &PGLibraryRepository{deps: deps}
+
+	return r, nil
+}
+
+func (r *PGLibraryRepository) db(ctx context.Context) gorm.Interface[pgmodels.LibraryEntry] {
+	return gorm.G[pgmodels.LibraryEntry](pgtx.From(ctx, r.deps.DB))
+}
+
+func (r *PGLibraryRepository) GetByID(ctx context.Context, id uuid.UUID) (*library.Entry, error) {
+	model, err := r.db(ctx).Where("id = ?", id).First(ctx)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrNotFound
+		}
+
+		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
+	}
+
+	ret := r.modelToDomain(model)
+
+	return &ret, nil
+}
+
+func (r *PGLibraryRepository) GetByUserAndComic(
+	ctx context.Context,
+	userID uuid.UUID,
+	comicID uuid.UUID,
+) (*library.Entry, error) {
+	model, err := r.db(ctx).Where("user_id = ? AND comic_id = ?", userID, comicID).First(ctx)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrNotFound
+		}
+
+		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
+	}
+
+	ret := r.modelToDomain(model)
+
+	return &ret, nil
+}
+
+func (r *PGLibraryRepository) ListByUser(ctx context.Context, userID uuid.UUID) ([]library.EntryWithComic, error) {
+	var models []pgmodels.LibraryEntry
+
+	err := pgtx.From(ctx, r.deps.DB).
+		WithContext(ctx).
+		Preload("Comic").
+		Where("user_id = ?", userID).
+		Order("added_at DESC").
+		Find(&models).Error
+	if err != nil {
+		return nil, fmt.Errorf("pgtx.From(ctx, r.deps.DB).Find: %w", err)
+	}
+
+	ret := make([]library.EntryWithComic, 0, len(models))
+	for _, model := range models {
+		ret = append(ret, library.EntryWithComic{
+			Entry: r.modelToDomain(model),
+			Comic: r.comicModelToDomain(model.Comic),
+		})
+	}
+
+	return ret, nil
+}
+
+func (r *PGLibraryRepository) Create(ctx context.Context, opts library.CreateEntryOpts) (*library.Entry, error) {
+	addedAt := opts.AddedAt
+	if addedAt.IsZero() {
+		addedAt = time.Now()
+	}
+
+	model := &pgmodels.LibraryEntry{
+		ID:      uuid.New(),
+		UserID:  opts.UserID,
+		ComicID: opts.ComicID,
+		AddedAt: addedAt,
+	}
+
+	err := r.db(ctx).Create(ctx, model)
+	if err != nil {
+		if errors.Is(err, gorm.ErrDuplicatedKey) {
+			return nil, domain.ErrAlreadyExists
+		}
+
+		return nil, fmt.Errorf("r.db(ctx).Create: %w", err)
+	}
+
+	ret := r.modelToDomain(*model)
+
+	return &ret, nil
+}
+
+func (r *PGLibraryRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	affected, err := r.db(ctx).Where("id = ?", id).Delete(ctx)
+	if err != nil {
+		return fmt.Errorf("r.db(ctx).Where: %w", err)
+	}
+
+	if affected == 0 {
+		return domain.ErrNotFound
+	}
+
+	return nil
+}
+
+func (r *PGLibraryRepository) modelToDomain(model pgmodels.LibraryEntry) library.Entry {
+	return library.Entry{
+		ID:      model.ID,
+		UserID:  model.UserID,
+		ComicID: model.ComicID,
+		AddedAt: model.AddedAt,
+	}
+}
+
+func (r *PGLibraryRepository) comicModelToDomain(model pgmodels.Comic) comics.Comic {
+	return comics.Comic{
+		ID:               model.ID,
+		Source:           model.Source,
+		Slug:             model.Slug,
+		Title:            model.Title,
+		Status:           model.Status,
+		Type:             model.ComicType,
+		Genres:           model.Genres,
+		ChapterCount:     model.ChapterCount,
+		Author:           model.Author,
+		Artist:           model.Artist,
+		Description:      model.Description,
+		AltTitles:        model.AltTitles,
+		Rating:           model.Rating,
+		ReleaseYear:      model.ReleaseYear,
+		SourceURL:        model.SourceURL,
+		ExternalCoverURL: model.ExternalCoverURL,
+		LocalCoverPath:   model.LocalCoverPath,
+		CreatedAt:        model.CreatedAt,
+		UpdatedAt:        model.UpdatedAt,
+	}
+}

--- a/api/pkg/core/library/repository/pg/repository_test.go
+++ b/api/pkg/core/library/repository/pg/repository_test.go
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package pg_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/library"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/library/repository/pg"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/repository/pgtest"
+)
+
+const (
+	libraryComicSource = "asurascans"
+	libraryComicSlug   = "solo-leveling"
+	libraryComicTitle  = "Solo Leveling"
+	libraryComicStatus = "completed"
+	libraryComicType   = "manhwa"
+)
+
+func libraryEntryCols() []string {
+	return []string{"id", "user_id", "comic_id", "added_at"}
+}
+
+func duplicateLibraryEntryKeyErr() error {
+	return &pgconn.PgError{
+		Code:    "23505",
+		Message: `duplicate key value violates unique constraint "idx_library_entry_user_comic"`,
+	}
+}
+
+func newLibraryRepo(t *testing.T) (*pg.PGLibraryRepository, sqlmock.Sqlmock) {
+	t.Helper()
+
+	db, mock := pgtest.New(t)
+
+	r, err := pg.New(pg.Deps{DB: db})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	return r, mock
+}
+
+func TestLibraryNewValidatesDeps(t *testing.T) {
+	t.Parallel()
+
+	r, err := pg.New(pg.Deps{})
+	if err == nil {
+		t.Fatal("New without DB must fail")
+	}
+
+	if r != nil {
+		t.Error("New returned a repository in addition to the error")
+	}
+
+	if want := "deps.Validate: db is required"; err.Error() != want {
+		t.Errorf("err = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestLibraryGetByID(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newLibraryRepo(t)
+
+	id := uuid.New()
+	userID := uuid.New()
+	comicID := uuid.New()
+	addedAt := time.Now().UTC().Truncate(time.Second)
+
+	mock.ExpectQuery(`SELECT \* FROM "library_entries" WHERE id = \$1`).
+		WithArgs(id, 1).
+		WillReturnRows(
+			sqlmock.NewRows(libraryEntryCols()).
+				AddRow(id, userID, comicID, addedAt),
+		)
+
+	got, err := r.GetByID(context.Background(), id)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+
+	want := library.Entry{ID: id, UserID: userID, ComicID: comicID, AddedAt: addedAt}
+	if got == nil || *got != want {
+		t.Errorf("GetByID() = %+v, want %+v", got, want)
+	}
+}
+
+func TestLibraryGetByUserAndComic(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newLibraryRepo(t)
+
+	id := uuid.New()
+	userID := uuid.New()
+	comicID := uuid.New()
+	addedAt := time.Now().UTC().Truncate(time.Second)
+
+	mock.ExpectQuery(`SELECT \* FROM "library_entries" WHERE user_id = \$1 AND comic_id = \$2`).
+		WithArgs(userID, comicID, 1).
+		WillReturnRows(
+			sqlmock.NewRows(libraryEntryCols()).
+				AddRow(id, userID, comicID, addedAt),
+		)
+
+	got, err := r.GetByUserAndComic(context.Background(), userID, comicID)
+	if err != nil {
+		t.Fatalf("GetByUserAndComic: %v", err)
+	}
+
+	if got.ComicID != comicID || got.UserID != userID {
+		t.Errorf("GetByUserAndComic() = %+v", got)
+	}
+}
+
+func TestLibraryCreate(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newLibraryRepo(t)
+
+	userID := uuid.New()
+	comicID := uuid.New()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`INSERT INTO "library_entries"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+	mock.ExpectCommit()
+
+	before := time.Now()
+
+	got, err := r.Create(context.Background(), library.CreateEntryOpts{
+		UserID:  userID,
+		ComicID: comicID,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if got.UserID != userID || got.ComicID != comicID {
+		t.Errorf("Create() = %+v", got)
+	}
+
+	if got.ID == uuid.Nil {
+		t.Error("Create did not generate ID")
+	}
+
+	if got.AddedAt.Before(before) {
+		t.Errorf("added_at not set: %v", got.AddedAt)
+	}
+}
+
+func TestLibraryCreateDuplicateKey(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newLibraryRepo(t)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`INSERT INTO "library_entries"`).WillReturnError(duplicateLibraryEntryKeyErr())
+	mock.ExpectRollback()
+
+	got, err := r.Create(context.Background(), library.CreateEntryOpts{
+		UserID:  uuid.New(),
+		ComicID: uuid.New(),
+	})
+	if !errors.Is(err, domain.ErrAlreadyExists) {
+		t.Errorf("Create = %v, want domain.ErrAlreadyExists", err)
+	}
+
+	if got != nil {
+		t.Errorf("Create returned %+v in addition to the error", got)
+	}
+}
+
+func TestLibraryDelete(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newLibraryRepo(t)
+
+	id := uuid.New()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`DELETE FROM "library_entries" WHERE id = \$1`).
+		WithArgs(id).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	err := r.Delete(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}
+
+func TestLibraryDeleteNotFound(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newLibraryRepo(t)
+
+	id := uuid.New()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`DELETE FROM "library_entries" WHERE id = \$1`).
+		WithArgs(id).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	err := r.Delete(context.Background(), id)
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("Delete = %v, want domain.ErrNotFound", err)
+	}
+}
+
+func TestLibraryListByUser(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newLibraryRepo(t)
+
+	userID := uuid.New()
+	entryID := uuid.New()
+	comicID := uuid.New()
+	addedAt := time.Now().UTC().Truncate(time.Second)
+	created := addedAt
+	updated := addedAt
+
+	mock.ExpectQuery(`SELECT \* FROM "library_entries" WHERE user_id = \$1`).
+		WithArgs(userID).
+		WillReturnRows(
+			sqlmock.NewRows(libraryEntryCols()).
+				AddRow(entryID, userID, comicID, addedAt),
+		)
+
+	mock.ExpectQuery(`SELECT \* FROM "comics" WHERE "comics"\."id" = \$1`).
+		WithArgs(comicID).
+		WillReturnRows(
+			sqlmock.NewRows([]string{
+				"id", "source", "slug", "title", "status", "comic_type",
+				"chapter_count", "author", "artist", "description", "rating", "release_year",
+				"source_url", "external_cover_url", "local_cover_path", "created_at", "updated_at",
+			}).AddRow(
+				comicID, libraryComicSource, libraryComicSlug, libraryComicTitle, libraryComicStatus, libraryComicType,
+				200, "Chugong", "Dubu", "desc", 9.5, 2018,
+				"", "", "", created, updated,
+			),
+		)
+
+	got, err := r.ListByUser(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("ListByUser: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("ListByUser() len = %d, want 1", len(got))
+	}
+
+	if got[0].Entry.ID != entryID || got[0].Comic.ID != comicID {
+		t.Errorf("ListByUser() = %+v", got[0])
+	}
+}

--- a/api/pkg/repository/pgmodels/comic.go
+++ b/api/pkg/repository/pgmodels/comic.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package pgmodels
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+)
+
+type Comic struct {
+	CreatedAt        time.Time      `gorm:"autoCreateTime"`
+	UpdatedAt        time.Time      `gorm:"autoUpdateTime"`
+	Author           string         `gorm:"type:text"`
+	Status           string         `gorm:"type:text"`
+	Source           string         `gorm:"type:text;not null;uniqueIndex:idx_comic_source_slug,priority:1"`
+	Description      string         `gorm:"type:text"`
+	LocalCoverPath   string         `gorm:"type:text"`
+	ExternalCoverURL string         `gorm:"type:text"`
+	SourceURL        string         `gorm:"type:text"`
+	Artist           string         `gorm:"type:text"`
+	Slug             string         `gorm:"type:text;not null;uniqueIndex:idx_comic_source_slug,priority:2"`
+	Title            string         `gorm:"type:text;not null"`
+	ComicType        string         `gorm:"column:comic_type;type:text"`
+	Genres           pq.StringArray `gorm:"type:text[];not null;default:'{}'"`
+	AltTitles        pq.StringArray `gorm:"type:text[];not null;default:'{}'"`
+	LibraryEntries   []LibraryEntry `gorm:"foreignKey:ComicID"`
+	ChapterCount     int
+	ReleaseYear      int
+	Rating           float64
+	ID               uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+}
+
+func (Comic) TableName() string {
+	return "comics"
+}

--- a/api/pkg/repository/pgmodels/libraryentry.go
+++ b/api/pkg/repository/pgmodels/libraryentry.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package pgmodels
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type LibraryEntry struct {
+	AddedAt time.Time `gorm:"not null"`
+	User    User      `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE"`
+	Comic   Comic     `gorm:"foreignKey:ComicID"`
+	ID      uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+	UserID  uuid.UUID `gorm:"type:uuid;not null;uniqueIndex:idx_library_entry_user_comic,priority:1;index"`
+	ComicID uuid.UUID `gorm:"type:uuid;not null;uniqueIndex:idx_library_entry_user_comic,priority:2;index"`
+}
+
+func (LibraryEntry) TableName() string {
+	return "library_entries"
+}

--- a/api/pkg/utils/database/pgdb.go
+++ b/api/pkg/utils/database/pgdb.go
@@ -107,10 +107,12 @@ func createPGDatabase(cfg PGConfig) (*gorm.DB, error) {
 func (pgdb *PGDB) Migrate() error {
 	models := []any{
 		&pgmodels.User{},
+		&pgmodels.Comic{},
 		&pgmodels.FederatedIdentity{},
 		&pgmodels.OIDCProvider{},
 		&pgmodels.Session{},
 		&pgmodels.PasswordCreds{},
+		&pgmodels.LibraryEntry{},
 	}
 
 	for _, m := range models {


### PR DESCRIPTION
## Summary

- Add `comics` and `library_entries` GORM models with unique constraints on `(source, slug)` and `(user_id, comic_id)`
- Introduce `comics` and `library` bounded contexts with domain types, repository interfaces, and PostgreSQL implementations
- Register both models in GORM AutoMigrate

Closes #16

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Smoke-test AutoMigrate against a local Postgres instance