### PR TITLE
Cover image storage and browse proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,4 @@ docs/design
 api/uchiyomiserver
 .cursor
 CONTEXT.md
-covers/
+/covers/

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ docs/design
 api/uchiyomiserver
 .cursor
 CONTEXT.md
+covers/

--- a/api/cmd/uchiyomiserver/config.go
+++ b/api/cmd/uchiyomiserver/config.go
@@ -14,14 +14,11 @@ import (
 )
 
 type cfg struct {
-	OIDC struct {
-		PublicURL            string `env:"PUBLIC_URL,required,notEmpty"`
-		EncryptionKeyB64     string `env:"OIDC_ENCRYPTION_KEY,required,notEmpty"`
-		EncryptionKey        []byte
-		RevalidationInterval time.Duration `env:"OIDC_REVALIDATION_INTERVAL" envDefault:"15m"`
-	}
 	Logger struct {
 		Level logging.LogLevel `env:"LOG_LEVEL" envDefault:"info"`
+	}
+	Covers struct {
+		Dir string `env:"COVERS_DIR" envDefault:"covers"`
 	}
 	PG struct {
 		Host        string `env:"DB_HOST,required"`
@@ -31,6 +28,12 @@ type cfg struct {
 		Schema      string `env:"DB_SCHEMA"`
 		SSLRequired bool   `env:"DB_SSL" envDefault:"false"`
 		Port        int    `env:"DB_PORT" envDefault:"5432"`
+	}
+	OIDC struct {
+		PublicURL            string `env:"PUBLIC_URL,required,notEmpty"`
+		EncryptionKeyB64     string `env:"OIDC_ENCRYPTION_KEY,required,notEmpty"`
+		EncryptionKey        []byte
+		RevalidationInterval time.Duration `env:"OIDC_REVALIDATION_INTERVAL" envDefault:"15m"`
 	}
 	Http struct {
 		AllowedOrigins []string `env:"CORS_ORIGINS" envSeparator:","`

--- a/api/cmd/uchiyomiserver/setup.go
+++ b/api/cmd/uchiyomiserver/setup.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/database"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/fncache"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/health"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/imgcache"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/logging"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/transaction/pgtx"
 
@@ -33,6 +34,9 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
 	httpsession "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/gateway/http"
 	pgsessions "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/repository/pg"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
+	httpcovers "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/gateway/http"
+	coversasura "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/source/asurascans"
 	httphealth "github.com/kharente-deuh/uchiyomi-server/pkg/core/health/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/setup"
 	httpsetup "github.com/kharente-deuh/uchiyomi-server/pkg/core/setup/gateway/http"
@@ -64,6 +68,20 @@ func setupApp(cfg *cfg) (*core.App, error) {
 		return nil, err
 	}
 
+	asuraApp, err := setupAsura(logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init asura source: %w", err)
+	}
+
+	coversBundle, err := setupCovers(coversDeps{
+		Logger:    logger,
+		CoversDir: cfg.Covers.Dir,
+		AsuraApp:  asuraApp,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to init covers: %w", err)
+	}
+
 	apps, err := setupApps(appsDeps{
 		Logger:                        logger,
 		SessionsRepository:            dbr.SessionsRepository,
@@ -77,6 +95,9 @@ func setupApp(cfg *cfg) (*core.App, error) {
 		return nil, err
 	}
 
+	apps.Asura = asuraApp
+	apps.Covers = coversBundle.App
+
 	registry := core.NewHealthRegistry(dbr.PGDB)
 
 	ctrls, err := setupCtrls(ctrlsDeps{
@@ -85,7 +106,8 @@ func setupApp(cfg *cfg) (*core.App, error) {
 		SetupService:         services.Setup,
 		AuthService:          services.Auth,
 		OIDCProvidersService: services.OIDCProviders,
-		AsuraApp:             apps.Asura,
+		AsuraApp:             asuraApp,
+		CoversService:        coversBundle.Service,
 		Registry:             registry,
 	})
 	if err != nil {
@@ -101,6 +123,7 @@ func setupApp(cfg *cfg) (*core.App, error) {
 		core.Deps{
 			SetupCtrl:         ctrls.Setup,
 			AsuraCtrl:         ctrls.Asura,
+			CoversCtrl:        ctrls.Covers,
 			HealthCtrl:        ctrls.Health,
 			AuthCtrl:          ctrls.Auth,
 			UsersCtrl:         ctrls.Users,
@@ -110,6 +133,7 @@ func setupApp(cfg *cfg) (*core.App, error) {
 			Logger:           logger,
 			DB:               dbr.PGDB,
 			Asura:            apps.Asura,
+			Covers:           apps.Covers,
 			Sessions:         apps.Sessions,
 			OIDCRevalidation: apps.OIDCRevalidation,
 		})
@@ -305,6 +329,7 @@ func setupServices(deps servicesDeps) (*services, error) {
 
 type apps struct {
 	Asura            *asura.App
+	Covers           *covers.App
 	Sessions         *sessions.App
 	OIDCRevalidation *oidc.RevalidationApp
 }
@@ -342,18 +367,83 @@ func setupApps(deps appsDeps) (*apps, error) {
 		return nil, fmt.Errorf("failed to init oidc revalidation app: %w", err)
 	}
 
-	asura, err := setupAsura(deps.Logger)
-	if err != nil {
-		return nil, fmt.Errorf("failed to init asura source: %w", err)
-	}
-
 	a := &apps{
-		Asura:            asura,
 		Sessions:         sessionApp,
 		OIDCRevalidation: oidcRevalidation,
 	}
 
 	return a, nil
+}
+
+type coversBundle struct {
+	App     *covers.App
+	Service *covers.Service
+}
+
+type coversDeps struct {
+	Logger    *slog.Logger
+	AsuraApp  *asura.App
+	CoversDir string
+}
+
+func setupCovers(deps coversDeps) (*coversBundle, error) {
+	fetchTimeout := time.Minute
+
+	httpClient := &http.Client{
+		Timeout: fetchTimeout,
+		Transport: &http.Transport{
+			MaxIdleConns:        100,
+			MaxIdleConnsPerHost: 10,
+			IdleConnTimeout:     90 * time.Second,
+		},
+	}
+
+	asuraResolver, err := coversasura.New(
+		coversasura.Config{CDNBaseURL: coversasura.DefaultCDNBaseURL},
+		coversasura.Deps{
+			Getter:     deps.AsuraApp,
+			HTTPClient: httpClient,
+			Logger:     deps.Logger,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("coversasura.New: %w", err)
+	}
+
+	resolvers := map[string]covers.CoverResolver{
+		covers.SourceAsuraScans: asuraResolver,
+	}
+
+	cache, err := imgcache.New(imgcache.Config{
+		Dir:           deps.CoversDir,
+		FetchFn:       covers.NewFetchFn(resolvers),
+		ErrorCacheTTL: time.Minute,
+		MinInterval:   500 * time.Millisecond,
+		Logger:        deps.Logger,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("imgcache.New: %w", err)
+	}
+
+	svc, err := covers.NewService(
+		covers.ServiceConfig{ProxyPathPrefix: core.APIPrefix + "/sources/cover"},
+		covers.ServiceDeps{
+			Cache:      cache,
+			Resolvers:  resolvers,
+			HTTPClient: httpClient,
+			Logger:     deps.Logger,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("covers.NewService: %w", err)
+	}
+
+	app, err := covers.NewApp(covers.AppDeps{Cache: cache})
+	if err != nil {
+		return nil, fmt.Errorf("covers.NewApp: %w", err)
+	}
+
+	return &coversBundle{App: app, Service: svc}, nil
 }
 
 func setupAsura(logger *slog.Logger) (*asura.App, error) {
@@ -488,6 +578,7 @@ func setupAsura(logger *slog.Logger) (*asura.App, error) {
 type ctrls struct {
 	Setup         *httpsetup.Controller
 	Asura         *httpasura.Controller
+	Covers        *httpcovers.Controller
 	Health        *httphealth.Controller
 	Auth          *httpauth.Controller
 	Users         *httpusers.Controller
@@ -496,6 +587,7 @@ type ctrls struct {
 
 type ctrlsDeps struct {
 	AsuraApp             *asura.App
+	CoversService        *covers.Service
 	SetupService         *setup.Service
 	SessionsService      *sessions.Service
 	Logger               *slog.Logger
@@ -533,17 +625,31 @@ func setupCtrls(deps ctrlsDeps) (*ctrls, error) {
 		return nil, fmt.Errorf("failed to init authenticator: %w", err)
 	}
 
-	asura, err := httpasura.New(httpasura.Config{
+	asuraCtrl, err := httpasura.New(httpasura.Config{
 		Endpoint:    "/asura",
 		Middlewares: chi.Middlewares{authenticator.Middleware},
 	},
 		httpasura.Deps{
 			AsuraApp: deps.AsuraApp,
 			Logger:   deps.Logger,
+			CoverURLBuilder: func(source, slug string) string {
+				return deps.CoversService.BuildProxyURL(source, slug)
+			},
 		})
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to init asura controller: %w", err)
+	}
+
+	coversCtrl, err := httpcovers.New(httpcovers.Config{
+		Endpoint:    "/cover",
+		Middlewares: chi.Middlewares{authenticator.Middleware},
+	}, httpcovers.Deps{
+		Service: deps.CoversService,
+		Logger:  deps.Logger,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to init covers controller: %w", err)
 	}
 
 	setup, err := httpsetup.New(httpsetup.Config{Endpoint: "/setup"}, httpsetup.Deps{
@@ -609,7 +715,8 @@ func setupCtrls(deps ctrlsDeps) (*ctrls, error) {
 	}
 
 	c := &ctrls{
-		Asura:         asura,
+		Asura:         asuraCtrl,
+		Covers:        coversCtrl,
 		Setup:         setup,
 		Health:        healthCtrl,
 		Auth:          authCtrl,

--- a/api/cmd/uchiyomiserver/setup_internal_test.go
+++ b/api/cmd/uchiyomiserver/setup_internal_test.go
@@ -172,8 +172,18 @@ func newTestCtrlsForUser(t *testing.T, user *users.User) *ctrls {
 		t.Fatalf("setupAsura: %v", err)
 	}
 
+	coversBundle, err := setupCovers(coversDeps{
+		Logger:    logger,
+		CoversDir: t.TempDir(),
+		AsuraApp:  asuraApp,
+	})
+	if err != nil {
+		t.Fatalf("setupCovers: %v", err)
+	}
+
 	c, err := setupCtrls(ctrlsDeps{
 		AsuraApp:             asuraApp,
+		CoversService:        coversBundle.Service,
 		SessionsService:      newTestSessionsService(t, user),
 		Logger:               logger,
 		Registry:             health.NewRegistry(),

--- a/api/pkg/core/app.go
+++ b/api/pkg/core/app.go
@@ -16,6 +16,8 @@ import (
 	httpauth "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/gateway/http"
 	httpoidcproviders "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
+	httpcovers "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/gateway/http"
 	httphealth "github.com/kharente-deuh/uchiyomi-server/pkg/core/health/gateway/http"
 	httpsetup "github.com/kharente-deuh/uchiyomi-server/pkg/core/setup/gateway/http"
 	httpusers "github.com/kharente-deuh/uchiyomi-server/pkg/core/users/gateway/http"
@@ -64,6 +66,7 @@ type Deps struct {
 
 	SetupCtrl         *httpsetup.Controller
 	AsuraCtrl         *httpasura.Controller
+	CoversCtrl        *httpcovers.Controller
 	HealthCtrl        *httphealth.Controller
 	AuthCtrl          *httpauth.Controller
 	UsersCtrl         *httpusers.Controller
@@ -73,6 +76,7 @@ type Deps struct {
 	Health *health.Registry
 
 	Asura            *asura.App
+	Covers           *covers.App
 	Sessions         *sessions.App
 	OIDCRevalidation interface{ Run(context.Context) error }
 }
@@ -86,6 +90,10 @@ func (deps *Deps) Validate() error {
 		return errors.New("asuraCtrl is required")
 	}
 
+	if deps.CoversCtrl == nil {
+		return errors.New("coversCtrl is required")
+	}
+
 	if deps.Logger == nil {
 		return errors.New("logger is required")
 	}
@@ -96,6 +104,10 @@ func (deps *Deps) Validate() error {
 
 	if deps.Asura == nil {
 		return errors.New("asura is required")
+	}
+
+	if deps.Covers == nil {
+		return errors.New("covers is required")
 	}
 
 	if deps.Sessions == nil {
@@ -177,6 +189,7 @@ func (a *App) startup(ctx context.Context, errG *errgroup.Group) func() error {
 		a.deps.Health.Set(componentMigrations, nil)
 
 		errG.Go(a.runComponent(ctx, componentAsura, a.deps.Asura.Run))
+		errG.Go(a.runComponent(ctx, componentCovers, a.deps.Covers.Run))
 		errG.Go(a.runComponent(ctx, componentSessions, a.deps.Sessions.Run))
 		errG.Go(a.runComponent(ctx, componentOIDCRevalidation, a.deps.OIDCRevalidation.Run))
 
@@ -255,6 +268,7 @@ func (a *App) newRouter(ui http.Handler) chi.Router {
 			a.deps.UsersCtrl.InitRouter(r)
 			a.deps.OIDCProvidersCtrl.InitRouter(r)
 			r.Route("/sources", func(r chi.Router) {
+				a.deps.CoversCtrl.InitRouter(r)
 				a.deps.AsuraCtrl.InitRouter(r)
 			})
 		})

--- a/api/pkg/core/covers/app.go
+++ b/api/pkg/core/covers/app.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package covers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/imgcache"
+)
+
+type AppDeps struct {
+	Cache *imgcache.Cache
+}
+
+func (deps *AppDeps) Validate() error {
+	if deps.Cache == nil {
+		return errors.New("cache is required")
+	}
+
+	return nil
+}
+
+type App struct {
+	deps AppDeps
+}
+
+func NewApp(deps AppDeps) (*App, error) {
+	if err := deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	return &App{deps: deps}, nil
+}
+
+func (a *App) Run(ctx context.Context) error {
+	//nolint:wrapcheck
+	return a.deps.Cache.Run(ctx)
+}

--- a/api/pkg/core/covers/domain.go
+++ b/api/pkg/core/covers/domain.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package covers
+
+import (
+	"context"
+	"errors"
+	"io"
+)
+
+const SourceAsuraScans = "asurascans"
+
+var (
+	ErrUnknownSource  = errors.New("unknown source")
+	ErrSeriesNotFound = errors.New("series not found")
+	ErrDownloadFailed = errors.New("cover download failed")
+)
+
+type CoverResolver interface {
+	ResolveExternalURL(context.Context, string) (string, error)
+	Fetch(context.Context, string) (io.ReadCloser, error)
+}

--- a/api/pkg/core/covers/ext.go
+++ b/api/pkg/core/covers/ext.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package covers
+
+import (
+	"context"
+	"fmt"
+	"mime"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+)
+
+func ExtensionFromURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+
+	ext := path.Ext(u.Path)
+	if ext == "" || ext == "." {
+		return ""
+	}
+
+	return ext
+}
+
+func ExtensionFromContentType(contentType string) string {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return ""
+	}
+
+	exts, err := mime.ExtensionsByType(mediaType)
+	if err != nil || len(exts) == 0 {
+		return ""
+	}
+
+	return exts[0]
+}
+
+func MIMEForExtension(ext string) string {
+	mediaType := mime.TypeByExtension(ext)
+	if mediaType == "" {
+		return "application/octet-stream"
+	}
+
+	return mediaType
+}
+
+func ResolveAbsoluteURL(base, cover string) string {
+	if strings.HasPrefix(cover, "http://") || strings.HasPrefix(cover, "https://") {
+		return cover
+	}
+
+	base = strings.TrimSuffix(base, "/")
+	if strings.HasPrefix(cover, "/") {
+		return base + cover
+	}
+
+	return base + "/" + cover
+}
+
+func cacheKey(source, slug, ext string) string {
+	return source + "/" + slug + ext
+}
+
+func parseCacheKey(key string) (source, slug, ext string, err error) {
+	parts := strings.SplitN(key, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", "", fmt.Errorf("invalid cache key %q", key)
+	}
+
+	source = parts[0]
+	ext = path.Ext(parts[1])
+	if ext == "" {
+		slug = parts[1]
+
+		return source, slug, ext, nil
+	}
+
+	slug = strings.TrimSuffix(parts[1], ext)
+
+	return source, slug, ext, nil
+}
+
+func probeExtension(ctx context.Context, client *http.Client, rawURL string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, rawURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("http.NewRequestWithContext: %w", err)
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("client.Do: %w", err)
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode == http.StatusNotFound {
+		return "", ErrSeriesNotFound
+	}
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("unexpected status %d", res.StatusCode)
+	}
+
+	ext := ExtensionFromContentType(res.Header.Get("Content-Type"))
+	if ext == "" {
+		ext = ".bin"
+	}
+
+	return ext, nil
+}

--- a/api/pkg/core/covers/ext_test.go
+++ b/api/pkg/core/covers/ext_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package covers_test
+
+import (
+	"testing"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
+)
+
+func TestExtensionFromURL(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"https://cdn.example/cover.webp":     ".webp",
+		"https://cdn.example/path/cover.jpg": ".jpg",
+		"https://cdn.example/noext":          "",
+	}
+
+	for raw, want := range tests {
+		if got := covers.ExtensionFromURL(raw); got != want {
+			t.Errorf("ExtensionFromURL(%q) = %q, want %q", raw, got, want)
+		}
+	}
+}
+
+func TestResolveAbsoluteURL(t *testing.T) {
+	t.Parallel()
+
+	base := "https://gg.asuracomic.net"
+
+	if got := covers.ResolveAbsoluteURL(base, "cover.jpg"); got != base+"/cover.jpg" {
+		t.Errorf("relative = %q", got)
+	}
+
+	if got := covers.ResolveAbsoluteURL(base, "/storage/cover.webp"); got != base+"/storage/cover.webp" {
+		t.Errorf("absolute path = %q", got)
+	}
+
+	external := "https://cdn.example/cover.webp"
+	if got := covers.ResolveAbsoluteURL("https://gg.asuracomic.net", external); got != external {
+		t.Errorf("absolute url = %q", got)
+	}
+}

--- a/api/pkg/core/covers/gateway/http/controller.go
+++ b/api/pkg/core/covers/gateway/http/controller.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package http
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/httputils"
+)
+
+type Config struct {
+	Endpoint    string
+	Middlewares chi.Middlewares
+}
+
+func (cfg *Config) Validate() error {
+	if cfg.Endpoint == "" {
+		return errors.New("endpoint is required")
+	}
+
+	if !strings.HasPrefix(cfg.Endpoint, "/") {
+		return fmt.Errorf("endpoint must start with '/', got %q", cfg.Endpoint)
+	}
+
+	hasNilMiddlewares := slices.ContainsFunc(cfg.Middlewares, func(m func(http.Handler) http.Handler) bool {
+		return m == nil
+	})
+
+	if hasNilMiddlewares {
+		return errors.New("all middlewares must not be nil")
+	}
+
+	return nil
+}
+
+type Deps struct {
+	Service *covers.Service
+	Logger  *slog.Logger
+}
+
+func (deps *Deps) Validate() error {
+	if deps.Service == nil {
+		return errors.New("service is required")
+	}
+
+	if deps.Logger == nil {
+		return errors.New("logger is required")
+	}
+
+	return nil
+}
+
+type Controller struct {
+	deps Deps
+	cfg  Config
+}
+
+func New(cfg Config, deps Deps) (*Controller, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("cfg.Validate: %w", err)
+	}
+
+	if err := deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	deps.Logger = deps.Logger.With("component", "covers.gateway.http")
+
+	return &Controller{cfg: cfg, deps: deps}, nil
+}
+
+func (c *Controller) InitRouter(r chi.Router) {
+	r.Route(c.cfg.Endpoint, func(r chi.Router) {
+		for _, m := range c.cfg.Middlewares {
+			r.Use(m)
+		}
+
+		r.Get("/{slug}", c.serveCover)
+	})
+}
+
+func (c *Controller) serveCover(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	source := strings.TrimSpace(r.URL.Query().Get("source"))
+	slug := chi.URLParam(r, "slug")
+
+	if source == "" {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "source is required")
+
+		return
+	}
+
+	diskPath, contentType, err := c.deps.Service.Serve(ctx, source, slug)
+	if err != nil {
+		switch {
+		case errors.Is(err, covers.ErrUnknownSource):
+			httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, err.Error())
+		case errors.Is(err, covers.ErrSeriesNotFound):
+			httputils.WriteError(w, c.deps.Logger, http.StatusNotFound, "series not found")
+		case errors.Is(err, covers.ErrDownloadFailed):
+			httputils.WriteError(w, c.deps.Logger, http.StatusBadGateway, "cover download failed")
+		default:
+			c.deps.Logger.ErrorContext(ctx, "failed to serve cover", "source", source, "slug", slug, "error", err)
+			httputils.WriteError(w, c.deps.Logger, http.StatusBadGateway, "cover download failed")
+		}
+
+		return
+	}
+
+	f, err := os.Open(diskPath)
+	if err != nil {
+		c.deps.Logger.ErrorContext(ctx, "failed to open cached cover", "path", diskPath, "error", err)
+		httputils.WriteError(w, c.deps.Logger, http.StatusInternalServerError, "")
+
+		return
+	}
+
+	defer f.Close()
+
+	w.Header().Set("Content-Type", contentType)
+	http.ServeContent(w, r, diskPath, mustStatModTime(f), f)
+}
+
+func mustStatModTime(f *os.File) (modTime time.Time) {
+	st, err := f.Stat()
+	if err != nil {
+		return time.Time{}
+	}
+
+	return st.ModTime()
+}

--- a/api/pkg/core/covers/gateway/http/controller_test.go
+++ b/api/pkg/core/covers/gateway/http/controller_test.go
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package http_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
+	covershttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/imgcache"
+)
+
+const testExternalCoverURL = "https://cdn.example/cover.webp"
+
+type fakeResolver struct {
+	err   error
+	fetch func(context.Context, string) (io.ReadCloser, error)
+	url   string
+}
+
+func (f *fakeResolver) ResolveExternalURL(context.Context, string) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+
+	return f.url, nil
+}
+
+func (f *fakeResolver) Fetch(ctx context.Context, externalURL string) (io.ReadCloser, error) {
+	if f.fetch != nil {
+		return f.fetch(ctx, externalURL)
+	}
+
+	return io.NopCloser(bytes.NewReader([]byte("cover-bytes"))), nil
+}
+
+func newTestController(t *testing.T, resolvers map[string]covers.CoverResolver) *covershttp.Controller {
+	t.Helper()
+
+	cache, err := imgcache.New(imgcache.Config{
+		Dir:           t.TempDir(),
+		FetchFn:       covers.NewFetchFn(resolvers),
+		ErrorCacheTTL: time.Minute,
+		MinInterval:   time.Millisecond,
+		Logger:        slog.New(slog.DiscardHandler),
+	})
+	if err != nil {
+		t.Fatalf("imgcache.New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	go func() {
+		_ = cache.Run(ctx)
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for !cache.IsReady() {
+		if time.Now().After(deadline) {
+			t.Fatal("cache never became ready")
+		}
+
+		time.Sleep(time.Millisecond)
+	}
+
+	svc, err := covers.NewService(
+		covers.ServiceConfig{ProxyPathPrefix: "/api/sources/cover"},
+		covers.ServiceDeps{
+			Cache:      cache,
+			Resolvers:  resolvers,
+			HTTPClient: &http.Client{Timeout: time.Second},
+			Logger:     slog.New(slog.DiscardHandler),
+		},
+	)
+	if err != nil {
+		t.Fatalf("covers.NewService: %v", err)
+	}
+
+	ctrl, err := covershttp.New(
+		covershttp.Config{Endpoint: "/cover"},
+		covershttp.Deps{Service: svc, Logger: slog.New(slog.DiscardHandler)},
+	)
+	if err != nil {
+		t.Fatalf("covershttp.New: %v", err)
+	}
+
+	return ctrl
+}
+
+func serveCover(t *testing.T, ctrl *covershttp.Controller, path string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	r := chi.NewRouter()
+	ctrl.InitRouter(r)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+
+	return rec
+}
+
+func TestServeCoverDownloadsAndCaches(t *testing.T) {
+	t.Parallel()
+
+	var fetchCount int
+
+	resolvers := map[string]covers.CoverResolver{
+		covers.SourceAsuraScans: &fakeResolver{
+			url: testExternalCoverURL,
+			fetch: func(context.Context, string) (io.ReadCloser, error) {
+				fetchCount++
+
+				return io.NopCloser(bytes.NewReader([]byte("webp-data"))), nil
+			},
+		},
+	}
+
+	ctrl := newTestController(t, resolvers)
+
+	rec := serveCover(t, ctrl, "/cover/solo-leveling?source=asurascans")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	if ct := rec.Header().Get("Content-Type"); ct != "image/webp" {
+		t.Errorf("Content-Type = %q, want image/webp", ct)
+	}
+
+	if !bytes.Equal(rec.Body.Bytes(), []byte("webp-data")) {
+		t.Errorf("body = %q, want webp-data", rec.Body.Bytes())
+	}
+
+	rec = serveCover(t, ctrl, "/cover/solo-leveling?source=asurascans")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	if fetchCount != 1 {
+		t.Errorf("fetchCount = %d, want 1", fetchCount)
+	}
+}
+
+func TestServeCoverUnknownSource(t *testing.T) {
+	t.Parallel()
+
+	ctrl := newTestController(t, map[string]covers.CoverResolver{
+		covers.SourceAsuraScans: &fakeResolver{url: "https://cdn.example/cover.webp"},
+	})
+
+	rec := serveCover(t, ctrl, "/cover/solo-leveling?source=unknown")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestServeCoverSeriesNotFound(t *testing.T) {
+	t.Parallel()
+
+	resolvers := map[string]covers.CoverResolver{
+		covers.SourceAsuraScans: &fakeResolver{err: covers.ErrSeriesNotFound},
+	}
+
+	ctrl := newTestController(t, resolvers)
+
+	rec := serveCover(t, ctrl, "/cover/missing?source=asurascans")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestServeCoverDownloadFailure(t *testing.T) {
+	t.Parallel()
+
+	resolvers := map[string]covers.CoverResolver{
+		covers.SourceAsuraScans: &fakeResolver{
+			url: testExternalCoverURL,
+			fetch: func(context.Context, string) (io.ReadCloser, error) {
+				return nil, errors.New("network down")
+			},
+		},
+	}
+
+	ctrl := newTestController(t, resolvers)
+
+	rec := serveCover(t, ctrl, "/cover/solo-leveling?source=asurascans")
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadGateway)
+	}
+}
+
+func TestServeCoverMissingSourceParam(t *testing.T) {
+	t.Parallel()
+
+	ctrl := newTestController(t, map[string]covers.CoverResolver{
+		covers.SourceAsuraScans: &fakeResolver{url: "https://cdn.example/cover.webp"},
+	})
+
+	rec := serveCover(t, ctrl, "/cover/solo-leveling")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestServeCoverUsesDiskCachePath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	cache, err := imgcache.New(imgcache.Config{
+		Dir: dir,
+		FetchFn: func(context.Context, string) (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader([]byte("cached"))), nil
+		},
+		ErrorCacheTTL: time.Minute,
+		MinInterval:   time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("imgcache.New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	go func() {
+		_ = cache.Run(ctx)
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for !cache.IsReady() {
+		if time.Now().After(deadline) {
+			t.Fatal("cache never became ready")
+		}
+
+		time.Sleep(time.Millisecond)
+	}
+
+	resolvers := map[string]covers.CoverResolver{
+		covers.SourceAsuraScans: &fakeResolver{url: "https://cdn.example/cover.jpg"},
+	}
+
+	svc, err := covers.NewService(
+		covers.ServiceConfig{ProxyPathPrefix: "/api/sources/cover"},
+		covers.ServiceDeps{
+			Cache:      cache,
+			Resolvers:  resolvers,
+			HTTPClient: &http.Client{Timeout: time.Second},
+			Logger:     slog.New(slog.DiscardHandler),
+		},
+	)
+	if err != nil {
+		t.Fatalf("covers.NewService: %v", err)
+	}
+
+	ctrl, err := covershttp.New(
+		covershttp.Config{Endpoint: "/cover"},
+		covershttp.Deps{Service: svc, Logger: slog.New(slog.DiscardHandler)},
+	)
+	if err != nil {
+		t.Fatalf("covershttp.New: %v", err)
+	}
+
+	serveCover(t, ctrl, "/cover/one-piece?source=asurascans")
+
+	wantPath := filepath.Join(dir, "asurascans", "one-piece.jpg")
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Fatalf("os.Stat(%s): %v", wantPath, err)
+	}
+}

--- a/api/pkg/core/covers/service.go
+++ b/api/pkg/core/covers/service.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package covers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"path/filepath"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/imgcache"
+)
+
+type ServiceConfig struct {
+	ProxyPathPrefix string
+}
+
+func (cfg *ServiceConfig) Validate() error {
+	if cfg.ProxyPathPrefix == "" {
+		return errors.New("proxyPathPrefix is required")
+	}
+
+	return nil
+}
+
+type ServiceDeps struct {
+	Cache      *imgcache.Cache
+	Resolvers  map[string]CoverResolver
+	HTTPClient *http.Client
+	Logger     *slog.Logger
+}
+
+func (deps *ServiceDeps) Validate() error {
+	if deps.Cache == nil {
+		return errors.New("cache is required")
+	}
+
+	if len(deps.Resolvers) == 0 {
+		return errors.New("resolvers is required")
+	}
+
+	if deps.HTTPClient == nil {
+		return errors.New("HTTPClient is required")
+	}
+
+	if deps.Logger == nil {
+		return errors.New("logger is required")
+	}
+
+	return nil
+}
+
+type Service struct {
+	deps ServiceDeps
+	cfg  ServiceConfig
+}
+
+func NewService(cfg ServiceConfig, deps ServiceDeps) (*Service, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("cfg.Validate: %w", err)
+	}
+
+	if err := deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	deps.Logger = deps.Logger.With("component", "covers.service")
+
+	return &Service{cfg: cfg, deps: deps}, nil
+}
+
+func (s *Service) BuildProxyURL(source, slug string) string {
+	return fmt.Sprintf("%s/%s?source=%s", s.cfg.ProxyPathPrefix, slug, source)
+}
+
+func (s *Service) Serve(ctx context.Context, source, slug string) (string, string, error) {
+	resolver, ok := s.deps.Resolvers[source]
+	if !ok {
+		return "", "", ErrUnknownSource
+	}
+
+	externalURL, err := resolver.ResolveExternalURL(ctx, slug)
+	if err != nil {
+		if errors.Is(err, ErrSeriesNotFound) {
+			return "", "", ErrSeriesNotFound
+		}
+
+		return "", "", fmt.Errorf("resolver.ResolveExternalURL: %w", err)
+	}
+
+	ext := ExtensionFromURL(externalURL)
+	if ext == "" {
+		ext, err = probeExtension(ctx, s.deps.HTTPClient, externalURL)
+		if err != nil {
+			if errors.Is(err, ErrSeriesNotFound) {
+				return "", "", ErrSeriesNotFound
+			}
+
+			return "", "", fmt.Errorf("%w: %w", ErrDownloadFailed, err)
+		}
+	}
+
+	key := cacheKey(source, slug, ext)
+
+	diskPath, err := s.deps.Cache.Ensure(ctx, key)
+	if err != nil {
+		if errors.Is(err, ErrSeriesNotFound) {
+			return "", "", ErrSeriesNotFound
+		}
+
+		return "", "", fmt.Errorf("%w: %w", ErrDownloadFailed, err)
+	}
+
+	contentType := MIMEForExtension(filepath.Ext(diskPath))
+
+	return diskPath, contentType, nil
+}
+
+func NewFetchFn(resolvers map[string]CoverResolver) func(context.Context, string) (io.ReadCloser, error) {
+	return func(ctx context.Context, key string) (io.ReadCloser, error) {
+		source, slug, _, err := parseCacheKey(key)
+		if err != nil {
+			return nil, fmt.Errorf("parseCacheKey: %w", err)
+		}
+
+		resolver, ok := resolvers[source]
+		if !ok {
+			return nil, ErrUnknownSource
+		}
+
+		externalURL, err := resolver.ResolveExternalURL(ctx, slug)
+		if err != nil {
+			return nil, fmt.Errorf("resolver.ResolveExternalURL: %w", err)
+		}
+
+		rc, err := resolver.Fetch(ctx, externalURL)
+		if err != nil {
+			if errors.Is(err, ErrSeriesNotFound) {
+				return nil, ErrSeriesNotFound
+			}
+
+			return nil, fmt.Errorf("%w: %w", ErrDownloadFailed, err)
+		}
+
+		return rc, nil
+	}
+}

--- a/api/pkg/core/covers/source/asurascans/resolver.go
+++ b/api/pkg/core/covers/source/asurascans/resolver.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package asurascans
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
+	asuradomain "github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/domain"
+)
+
+const DefaultCDNBaseURL = "https://gg.asuracomic.net"
+
+type InfosBySlugGetter interface {
+	GetInfosBySlug(context.Context, string) (*asuradomain.GetInfosBySlugResponse, error)
+}
+
+type Config struct {
+	CDNBaseURL string
+}
+
+func (cfg *Config) Validate() error {
+	if cfg.CDNBaseURL == "" {
+		return errors.New("CDNBaseURL is required")
+	}
+
+	return nil
+}
+
+type Deps struct {
+	Getter     InfosBySlugGetter
+	HTTPClient *http.Client
+	Logger     *slog.Logger
+}
+
+func (deps *Deps) Validate() error {
+	if deps.Getter == nil {
+		return errors.New("getter is required")
+	}
+
+	if deps.HTTPClient == nil {
+		return errors.New("HTTPClient is required")
+	}
+
+	if deps.Logger == nil {
+		return errors.New("logger is required")
+	}
+
+	return nil
+}
+
+type Resolver struct {
+	deps Deps
+	cfg  Config
+}
+
+func New(cfg Config, deps Deps) (*Resolver, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("cfg.Validate: %w", err)
+	}
+
+	if err := deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	deps.Logger = deps.Logger.With("component", "covers.source.asurascans")
+
+	return &Resolver{cfg: cfg, deps: deps}, nil
+}
+
+func (r *Resolver) ResolveExternalURL(ctx context.Context, slug string) (string, error) {
+	infos, err := r.deps.Getter.GetInfosBySlug(ctx, slug)
+	if err != nil {
+		if errors.Is(err, asuradomain.ErrNotFound) {
+			return "", covers.ErrSeriesNotFound
+		}
+
+		return "", fmt.Errorf("getter.GetInfosBySlug: %w", err)
+	}
+
+	if infos.Cover == "" {
+		return "", fmt.Errorf("series %q has no cover", slug)
+	}
+
+	return covers.ResolveAbsoluteURL(r.cfg.CDNBaseURL, infos.Cover), nil
+}
+
+func (r *Resolver) Fetch(ctx context.Context, externalURL string) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, externalURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("http.NewRequestWithContext: %w", err)
+	}
+
+	res, err := r.deps.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTPClient.Do: %w", err)
+	}
+
+	if res.StatusCode == http.StatusNotFound {
+		res.Body.Close()
+
+		return nil, covers.ErrSeriesNotFound
+	}
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
+		res.Body.Close()
+
+		return nil, fmt.Errorf("unexpected status %d", res.StatusCode)
+	}
+
+	return res.Body, nil
+}

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -23,6 +23,9 @@ import (
 	httpoidcproviders "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
 	sessionshttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
+	httpcovers "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/gateway/http"
+	coversasura "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/source/asurascans"
 	healthhttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/health/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/setup"
 	httpsetup "github.com/kharente-deuh/uchiyomi-server/pkg/core/setup/gateway/http"
@@ -33,6 +36,7 @@ import (
 	httasura "github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/fncache"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/health"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/imgcache"
 )
 
 const (
@@ -99,6 +103,61 @@ func (fakeSessionsRepository) UpdateExpiry(context.Context, uuid.UUID, time.Time
 
 func (fakeSessionsRepository) DeleteByTokenHash(context.Context, []byte) error {
 	return errors.New(notImplemented)
+}
+
+func newTestCoversBundle(t *testing.T, asuraApp *asura.App) (*covers.App, *covers.Service) {
+	t.Helper()
+
+	logger := slog.New(slog.DiscardHandler)
+
+	httpClient := &http.Client{Timeout: time.Minute}
+
+	asuraResolver, err := coversasura.New(
+		coversasura.Config{CDNBaseURL: coversasura.DefaultCDNBaseURL},
+		coversasura.Deps{
+			Getter:     asuraApp,
+			HTTPClient: httpClient,
+			Logger:     logger,
+		},
+	)
+	if err != nil {
+		t.Fatalf("coversasura.New: %v", err)
+	}
+
+	resolvers := map[string]covers.CoverResolver{
+		covers.SourceAsuraScans: asuraResolver,
+	}
+
+	cache, err := imgcache.New(imgcache.Config{
+		Dir:           t.TempDir(),
+		FetchFn:       covers.NewFetchFn(resolvers),
+		ErrorCacheTTL: time.Minute,
+		MinInterval:   time.Millisecond,
+		Logger:        logger,
+	})
+	if err != nil {
+		t.Fatalf("imgcache.New: %v", err)
+	}
+
+	svc, err := covers.NewService(
+		covers.ServiceConfig{ProxyPathPrefix: APIPrefix + "/sources/cover"},
+		covers.ServiceDeps{
+			Cache:      cache,
+			Resolvers:  resolvers,
+			HTTPClient: httpClient,
+			Logger:     logger,
+		},
+	)
+	if err != nil {
+		t.Fatalf("covers.NewService: %v", err)
+	}
+
+	app, err := covers.NewApp(covers.AppDeps{Cache: cache})
+	if err != nil {
+		t.Fatalf("covers.NewApp: %v", err)
+	}
+
+	return app, svc
 }
 
 type fakeOIDCRevalidationApp struct{}
@@ -290,12 +349,28 @@ func newTestApp(t *testing.T, db Database, port int) (*App, *health.Registry) {
 		t.Fatalf("httpusers.New: %v", err)
 	}
 
+	coversApp, coversService := newTestCoversBundle(t, asuraApp)
+
 	asuraCtrl, err := httasura.New(
 		httasura.Config{Endpoint: "/asura"},
-		httasura.Deps{Logger: logger, AsuraApp: asuraApp},
+		httasura.Deps{
+			Logger:   logger,
+			AsuraApp: asuraApp,
+			CoverURLBuilder: func(source, slug string) string {
+				return coversService.BuildProxyURL(source, slug)
+			},
+		},
 	)
 	if err != nil {
 		t.Fatalf("httasura.New: %v", err)
+	}
+
+	coversCtrl, err := httpcovers.New(
+		httpcovers.Config{Endpoint: "/cover"},
+		httpcovers.Deps{Service: coversService, Logger: logger},
+	)
+	if err != nil {
+		t.Fatalf("httpcovers.New: %v", err)
 	}
 
 	healthCtrl, err := healthhttp.New(
@@ -322,11 +397,13 @@ func newTestApp(t *testing.T, db Database, port int) (*App, *health.Registry) {
 			AuthCtrl:          authCtrl,
 			UsersCtrl:         usersCtrl,
 			AsuraCtrl:         asuraCtrl,
+			CoversCtrl:        coversCtrl,
 			HealthCtrl:        healthCtrl,
 			OIDCProvidersCtrl: oidcProvidersCtrl,
 			Logger:            logger,
 			Health:            registry,
 			Asura:             asuraApp,
+			Covers:            coversApp,
 			Sessions:          sessionsApp,
 			OIDCRevalidation:  fakeOIDCRevalidationApp{},
 		})

--- a/api/pkg/core/health.go
+++ b/api/pkg/core/health.go
@@ -12,6 +12,7 @@ import (
 const (
 	componentMigrations       = "migrations"
 	componentAsura            = "asura"
+	componentCovers           = "covers"
 	componentSessions         = "sessions"
 	componentOIDCRevalidation = "oidc-revalidation"
 	componentDB               = "db"
@@ -20,7 +21,13 @@ const (
 const notReadyMessage = "service is starting"
 
 func NewHealthRegistry(db Database) *health.Registry {
-	reg := health.NewRegistry(componentMigrations, componentAsura, componentSessions, componentOIDCRevalidation)
+	reg := health.NewRegistry(
+		componentMigrations,
+		componentAsura,
+		componentCovers,
+		componentSessions,
+		componentOIDCRevalidation,
+	)
 	reg.AddProbe(componentDB, db.Ping)
 
 	return reg

--- a/api/pkg/core/health_internal_test.go
+++ b/api/pkg/core/health_internal_test.go
@@ -41,7 +41,15 @@ func TestNewHealthRegistryDeclaresTheLatchesAndTheDBProbe(t *testing.T) {
 
 	rep := reg.Snapshot(context.Background())
 
-	for _, name := range []string{componentMigrations, componentAsura, componentSessions, componentOIDCRevalidation} {
+	components := []string{
+		componentMigrations,
+		componentAsura,
+		componentCovers,
+		componentSessions,
+		componentOIDCRevalidation,
+	}
+
+	for _, name := range components {
 		c, ok := rep.Components[name]
 		if !ok {
 			t.Errorf("latche %s absente du registre", name)

--- a/api/pkg/sources/asurascans/pkg/gateway/http/controller.go
+++ b/api/pkg/sources/asurascans/pkg/gateway/http/controller.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/core"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils"
@@ -44,8 +45,9 @@ func (cfg *Config) Validate() error {
 }
 
 type Deps struct {
-	AsuraApp *core.App
-	Logger   *slog.Logger
+	AsuraApp        *core.App
+	Logger          *slog.Logger
+	CoverURLBuilder func(source, slug string) string
 }
 
 func (deps *Deps) Validate() error {
@@ -55,6 +57,10 @@ func (deps *Deps) Validate() error {
 
 	if deps.Logger == nil {
 		return errors.New("logger is required")
+	}
+
+	if deps.CoverURLBuilder == nil {
+		return errors.New("coverURLBuilder is required")
 	}
 
 	return nil
@@ -117,6 +123,8 @@ func (c *Controller) search(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	buildCover := c.deps.CoverURLBuilder
+
 	dto := searchResDTO{
 		Total: res.Meta.Total,
 		Items: utils.MapSlice(res.Items, func(i domain.SearchResultItem) searchResItemDTO {
@@ -126,7 +134,7 @@ func (c *Controller) search(w http.ResponseWriter, r *http.Request) {
 				CreatedAt:     i.CreatedAt,
 				PublicURL:     i.PublicURL,
 				SourceURL:     i.SourceURL,
-				Cover:         i.Cover,
+				Cover:         buildCover(covers.SourceAsuraScans, i.Slug),
 				Status:        i.Status,
 				Type:          i.Type,
 				Author:        i.Author,
@@ -180,7 +188,7 @@ func (c *Controller) getInfosBySlug(w http.ResponseWriter, r *http.Request) {
 		CreatedAt:     s.CreatedAt,
 		Description:   s.Description,
 		Title:         s.Title,
-		Cover:         s.Cover,
+		Cover:         c.deps.CoverURLBuilder(covers.SourceAsuraScans, s.Slug),
 		Status:        s.Status,
 		Type:          s.Type,
 		Author:        s.Author,

--- a/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
+++ b/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package http_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
+	asura "github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/core"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/domain"
+	asurahttp "github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/fncache"
+)
+
+const testExternalCoverURL = "https://external.example/cover.webp"
+
+func newTestAsuraApp(t *testing.T) *asura.App {
+	t.Helper()
+
+	searchCache, err := fncache.New(
+		fncache.Config[domain.SearchOpts, domain.SearchResult]{
+			Name: "search",
+			Fn: func(context.Context, domain.SearchOpts) (*domain.SearchResult, error) {
+				return &domain.SearchResult{
+					Meta: domain.SearchResultMeta{Total: 1},
+					Items: []domain.SearchResultItem{{
+						Slug:  "solo-leveling",
+						Title: "Solo Leveling",
+						Cover: testExternalCoverURL,
+					}},
+				}, nil
+			},
+			Key:           func(domain.SearchOpts) string { return "k" },
+			TTL:           time.Minute,
+			ErrorTTL:      time.Minute,
+			FetchTimeout:  time.Minute,
+			CleanInterval: time.Minute,
+			MaxEntries:    1,
+		},
+		fncache.Deps{Logger: slog.New(slog.DiscardHandler)},
+	)
+	if err != nil {
+		t.Fatalf("fncache.New(search): %v", err)
+	}
+
+	infosCache, err := fncache.New(
+		fncache.Config[string, domain.GetInfosBySlugResponse]{
+			Name: "infos",
+			Fn: func(_ context.Context, slug string) (*domain.GetInfosBySlugResponse, error) {
+				return &domain.GetInfosBySlugResponse{
+					Slug:  slug,
+					Title: "Solo Leveling",
+					Cover: testExternalCoverURL,
+				}, nil
+			},
+			Key:           func(slug string) string { return slug },
+			TTL:           time.Minute,
+			ErrorTTL:      time.Minute,
+			FetchTimeout:  time.Minute,
+			CleanInterval: time.Minute,
+			MaxEntries:    1,
+		},
+		fncache.Deps{Logger: slog.New(slog.DiscardHandler)},
+	)
+	if err != nil {
+		t.Fatalf("fncache.New(infos): %v", err)
+	}
+
+	chaptersCache, err := fncache.New(
+		fncache.Config[string, []domain.Chapter]{
+			Name:          "chapters",
+			Fn:            func(context.Context, string) (*[]domain.Chapter, error) { return nil, errors.New("n/a") },
+			Key:           func(slug string) string { return slug },
+			TTL:           time.Minute,
+			ErrorTTL:      time.Minute,
+			FetchTimeout:  time.Minute,
+			CleanInterval: time.Minute,
+			MaxEntries:    1,
+		},
+		fncache.Deps{Logger: slog.New(slog.DiscardHandler)},
+	)
+	if err != nil {
+		t.Fatalf("fncache.New(chapters): %v", err)
+	}
+
+	imagesCache, err := fncache.New(
+		fncache.Config[domain.GetImageURLsByChapterOpts, []string]{
+			Name: "images",
+			Fn: func(context.Context, domain.GetImageURLsByChapterOpts) (*[]string, error) {
+				return nil, errors.New("n/a")
+			},
+			Key:           func(domain.GetImageURLsByChapterOpts) string { return "k" },
+			TTL:           time.Minute,
+			ErrorTTL:      time.Minute,
+			FetchTimeout:  time.Minute,
+			CleanInterval: time.Minute,
+			MaxEntries:    1,
+		},
+		fncache.Deps{Logger: slog.New(slog.DiscardHandler)},
+	)
+	if err != nil {
+		t.Fatalf("fncache.New(images): %v", err)
+	}
+
+	app, err := asura.New(asura.Dependencies{
+		Logger:                       slog.New(slog.DiscardHandler),
+		SearchCache:                  searchCache,
+		GetInfosBySlugCache:          infosCache,
+		GetChaptersListBySeriesCache: chaptersCache,
+		GetImageURLsByChapter:        imagesCache,
+	})
+	if err != nil {
+		t.Fatalf("asura.New: %v", err)
+	}
+
+	return app
+}
+
+func coverURLBuilder(source, slug string) string {
+	return "/api/sources/cover/" + slug + "?source=" + source
+}
+
+func TestSearchReturnsProxiedCoverURL(t *testing.T) {
+	t.Parallel()
+
+	ctrl, err := asurahttp.New(
+		asurahttp.Config{Endpoint: "/asura"},
+		asurahttp.Deps{
+			AsuraApp:        newTestAsuraApp(t),
+			Logger:          slog.New(slog.DiscardHandler),
+			CoverURLBuilder: coverURLBuilder,
+		},
+	)
+	if err != nil {
+		t.Fatalf("asurahttp.New: %v", err)
+	}
+
+	r := chi.NewRouter()
+	ctrl.InitRouter(r)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/asura/search?sort=popular&order=desc", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var body struct {
+		Items []struct {
+			Cover string `json:"cover"`
+			Slug  string `json:"slug"`
+		} `json:"items"`
+	}
+
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	if len(body.Items) != 1 {
+		t.Fatalf("len(items) = %d, want 1", len(body.Items))
+	}
+
+	want := coverURLBuilder(covers.SourceAsuraScans, "solo-leveling")
+	if body.Items[0].Cover != want {
+		t.Errorf("cover = %q, want %q", body.Items[0].Cover, want)
+	}
+
+	if body.Items[0].Cover == testExternalCoverURL {
+		t.Error("external cover URL leaked in response")
+	}
+}
+
+func TestGetInfosBySlugReturnsProxiedCoverURL(t *testing.T) {
+	t.Parallel()
+
+	ctrl, err := asurahttp.New(
+		asurahttp.Config{Endpoint: "/asura"},
+		asurahttp.Deps{
+			AsuraApp:        newTestAsuraApp(t),
+			Logger:          slog.New(slog.DiscardHandler),
+			CoverURLBuilder: coverURLBuilder,
+		},
+	)
+	if err != nil {
+		t.Fatalf("asurahttp.New: %v", err)
+	}
+
+	r := chi.NewRouter()
+	ctrl.InitRouter(r)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/asura/series/solo-leveling", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var body struct {
+		Cover string `json:"cover"`
+		Slug  string `json:"slug"`
+	}
+
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	want := coverURLBuilder(covers.SourceAsuraScans, "solo-leveling")
+	if body.Cover != want {
+		t.Errorf("cover = %q, want %q", body.Cover, want)
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       PORT: 3000
       CORS_ORIGINS: ${CORS_ORIGINS:-}
       PUBLIC_URL: ${PUBLIC_URL:-http://localhost:3000}
+      COVERS_DIR: /covers
       OIDC_ENCRYPTION_KEY: "${OIDC_ENCRYPTION_KEY:?set OIDC_ENCRYPTION_KEY, e.g. openssl rand -base64 32}"
     healthcheck:
       test: ["CMD", "/uchiyomiserver", "-healthcheck"]
@@ -48,6 +49,8 @@ services:
       retries: 3
       start_period: 15s
     read_only: true
+    volumes:
+      - covers:/covers
     cap_drop:
       - ALL
     security_opt:
@@ -56,3 +59,4 @@ services:
 
 volumes:
   pgdata:
+  covers:


### PR DESCRIPTION
## Summary

- Add a `covers` bounded context with disk-backed browse cache (`imgcache`), AsuraScans resolver, and authenticated `GET /api/sources/cover/{slug}?source=asurascans`
- Rewrite AsuraScans `search` and `getInfosBySlug` responses to return proxied cover URLs instead of external CDN links
- Wire `COVERS_DIR` config, Docker volume, and health registry component for the cover cache worker

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Manual: authenticate, call `/api/sources/asura/search`, confirm `cover` points to `/api/sources/cover/...`
- [ ] Manual: fetch a proxied cover URL and verify image bytes + `Content-Type`

Closes #19