### PR TITLE
Comics API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,4 @@ docs/design
 api/uchiyomiserver
 .cursor
 CONTEXT.md
-/covers/
+./covers

--- a/api/cmd/uchiyomiserver/setup.go
+++ b/api/cmd/uchiyomiserver/setup.go
@@ -11,6 +11,9 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	core "github.com/kharente-deuh/uchiyomi-server/pkg/core"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
+	httpcomics "github.com/kharente-deuh/uchiyomi-server/pkg/core/comics/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
 	asura "github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/core"
 	asuradomain "github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/domain"
 	asuraclient "github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/transport/http"
@@ -34,10 +37,12 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
 	httpsession "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/gateway/http"
 	pgsessions "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/repository/pg"
+	pgcomics "github.com/kharente-deuh/uchiyomi-server/pkg/core/comics/repository/pg"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
 	httpcovers "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/gateway/http"
 	coversasura "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/source/asurascans"
 	httphealth "github.com/kharente-deuh/uchiyomi-server/pkg/core/health/gateway/http"
+	pglibrary "github.com/kharente-deuh/uchiyomi-server/pkg/core/library/repository/pg"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/setup"
 	httpsetup "github.com/kharente-deuh/uchiyomi-server/pkg/core/setup/gateway/http"
 	httpusers "github.com/kharente-deuh/uchiyomi-server/pkg/core/users/gateway/http"
@@ -68,7 +73,7 @@ func setupApp(cfg *cfg) (*core.App, error) {
 		return nil, err
 	}
 
-	asuraApp, err := setupAsura(logger)
+	asuraApp, err := setupAsura(logger, dbr.ComicsRepository)
 	if err != nil {
 		return nil, fmt.Errorf("failed to init asura source: %w", err)
 	}
@@ -95,6 +100,16 @@ func setupApp(cfg *cfg) (*core.App, error) {
 		return nil, err
 	}
 
+	comicsSvc, err := comics.NewService(comics.Deps{
+		ComicsRepository:  dbr.ComicsRepository,
+		Transactor:        dbr.Txor,
+		LibraryRepository: dbr.LibraryRepository,
+		Sources:           sources.SourceMap{sources.SourceAsuraScans: asuraApp},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to init comicsSvc: %w", err)
+	}
+
 	apps.Asura = asuraApp
 	apps.Covers = coversBundle.App
 
@@ -102,6 +117,7 @@ func setupApp(cfg *cfg) (*core.App, error) {
 
 	ctrls, err := setupCtrls(ctrlsDeps{
 		Logger:               logger,
+		ComicsService:        comicsSvc,
 		SessionsService:      services.Sessions,
 		SetupService:         services.Setup,
 		AuthService:          services.Auth,
@@ -128,6 +144,7 @@ func setupApp(cfg *cfg) (*core.App, error) {
 			AuthCtrl:          ctrls.Auth,
 			UsersCtrl:         ctrls.Users,
 			OIDCProvidersCtrl: ctrls.OIDCProviders,
+			ComicsCtrl:        ctrls.Comics,
 
 			Health:           registry,
 			Logger:           logger,
@@ -152,6 +169,8 @@ type dbRelated struct {
 	PwdRepository                 *pgpwd.PGPasswordCredsRepository
 	OIDCProvidersRepository       *pgoidcproviders.PGOIDCProvidersRepository
 	FederatedIdentitiesRepository *pgfederatedidentities.PGFederatedIdentitiesRepository
+	ComicsRepository              *pgcomics.PGComicsRepository
+	LibraryRepository             *pglibrary.PGLibraryRepository
 }
 
 func setupDBRelated(c *cfg, logger *slog.Logger) (*dbRelated, error) {
@@ -201,6 +220,16 @@ func setupDBRelated(c *cfg, logger *slog.Logger) (*dbRelated, error) {
 		return nil, fmt.Errorf("failed to init federatedIdentitiesRepository: %w", err)
 	}
 
+	comicsRepository, err := pgcomics.New(pgcomics.Deps{DB: pgdb.DB})
+	if err != nil {
+		return nil, fmt.Errorf("failed to init comicsRepository: %w", err)
+	}
+
+	libraryRepository, err := pglibrary.New(pglibrary.Deps{DB: pgdb.DB})
+	if err != nil {
+		return nil, fmt.Errorf("failed to init libraryRepository: %w", err)
+	}
+
 	dbr := &dbRelated{
 		PGDB:                          pgdb,
 		Txor:                          txor,
@@ -209,6 +238,8 @@ func setupDBRelated(c *cfg, logger *slog.Logger) (*dbRelated, error) {
 		PwdRepository:                 pwdRepository,
 		OIDCProvidersRepository:       oidcProvidersRepository,
 		FederatedIdentitiesRepository: federatedIdentitiesRepository,
+		ComicsRepository:              comicsRepository,
+		LibraryRepository:             libraryRepository,
 	}
 
 	return dbr, nil
@@ -446,7 +477,7 @@ func setupCovers(deps coversDeps) (*coversBundle, error) {
 	return &coversBundle{App: app, Service: svc}, nil
 }
 
-func setupAsura(logger *slog.Logger) (*asura.App, error) {
+func setupAsura(logger *slog.Logger, comicsRepo comics.ComicsRepository) (*asura.App, error) {
 	fetchTimeout := time.Minute
 
 	httpClient := &http.Client{
@@ -562,13 +593,14 @@ func setupAsura(logger *slog.Logger) (*asura.App, error) {
 	}
 
 	a, err := asura.New(
-		asura.Config{SourceName: "asurascans"},
+		asura.Config{SourceName: sources.SourceAsuraScans},
 		asura.Deps{
 			Logger:                       logger,
 			SearchCache:                  searchCache,
 			GetInfosBySlugCache:          getInfosBySlugCache,
 			GetChaptersListBySeriesCache: getChaptersListBySerieCache,
 			GetImageURLsByChapter:        getImageURLsByChapterCache,
+			ComicsRepository:             comicsRepo,
 		})
 	if err != nil {
 		return nil, fmt.Errorf("asura.New: %w", err)
@@ -585,6 +617,7 @@ type ctrls struct {
 	Auth          *httpauth.Controller
 	Users         *httpusers.Controller
 	OIDCProviders *httpoidcproviders.Controller
+	Comics        *httpcomics.Controller
 }
 
 type ctrlsDeps struct {
@@ -596,6 +629,7 @@ type ctrlsDeps struct {
 	Registry             *health.Registry
 	AuthService          *auth.Service
 	OIDCProvidersService *oidcproviders.Service
+	ComicsService        *comics.Service
 }
 
 func setupCtrls(deps ctrlsDeps) (*ctrls, error) {
@@ -716,6 +750,15 @@ func setupCtrls(deps ctrlsDeps) (*ctrls, error) {
 		return nil, fmt.Errorf("failed to init oidc providers controller: %w", err)
 	}
 
+	comicsCtrl, err := httpcomics.New(
+		httpcomics.Config{Endpoint: "/comics"}, httpcomics.Deps{
+			Logger:        deps.Logger,
+			ComicsService: deps.ComicsService,
+		})
+	if err != nil {
+		return nil, fmt.Errorf("failed to init comics controller: %w", err)
+	}
+
 	c := &ctrls{
 		Asura:         asuraCtrl,
 		Covers:        coversCtrl,
@@ -724,6 +767,7 @@ func setupCtrls(deps ctrlsDeps) (*ctrls, error) {
 		Auth:          authCtrl,
 		Users:         usersCtrl,
 		OIDCProviders: oidcProvidersCtrl,
+		Comics:        comicsCtrl,
 	}
 
 	return c, nil

--- a/api/cmd/uchiyomiserver/setup.go
+++ b/api/cmd/uchiyomiserver/setup.go
@@ -474,7 +474,7 @@ func setupAsura(logger *slog.Logger) (*asura.App, error) {
 	getImageURLsByChapterTTL := 2 * time.Hour
 
 	searchCache, err := fncache.New(
-		fncache.Config[asuradomain.SearchOpts, asuradomain.SearchResult]{
+		fncache.Config[asuradomain.SearchCacheOpts, asuradomain.SearchCacheResult]{
 			Fn:            apiClient.Search,
 			TTL:           searchTTL,
 			ErrorTTL:      errorTTL,
@@ -482,7 +482,7 @@ func setupAsura(logger *slog.Logger) (*asura.App, error) {
 			CleanInterval: searchTTL,
 			MaxEntries:    256,
 			Name:          "asurascans.search",
-			Key: func(opts asuradomain.SearchOpts) string {
+			Key: func(opts asuradomain.SearchCacheOpts) string {
 				return fmt.Sprintf(
 					"%s %s %s %s %s %s %v %d %d %d",
 					opts.Search,
@@ -561,13 +561,15 @@ func setupAsura(logger *slog.Logger) (*asura.App, error) {
 		return nil, fmt.Errorf("fncache.New (asura.GetChaptersListBySerie): %w", err)
 	}
 
-	a, err := asura.New(asura.Dependencies{
-		Logger:                       logger,
-		SearchCache:                  searchCache,
-		GetInfosBySlugCache:          getInfosBySlugCache,
-		GetChaptersListBySeriesCache: getChaptersListBySerieCache,
-		GetImageURLsByChapter:        getImageURLsByChapterCache,
-	})
+	a, err := asura.New(
+		asura.Config{SourceName: "asurascans"},
+		asura.Deps{
+			Logger:                       logger,
+			SearchCache:                  searchCache,
+			GetInfosBySlugCache:          getInfosBySlugCache,
+			GetChaptersListBySeriesCache: getChaptersListBySerieCache,
+			GetImageURLsByChapter:        getImageURLsByChapterCache,
+		})
 	if err != nil {
 		return nil, fmt.Errorf("asura.New: %w", err)
 	}

--- a/api/cmd/uchiyomiserver/setup_internal_test.go
+++ b/api/cmd/uchiyomiserver/setup_internal_test.go
@@ -15,9 +15,42 @@ import (
 	"github.com/google/uuid"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
+	coredomain "github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/users"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/health"
 )
+
+type stubComicsRepository struct{}
+
+func (stubComicsRepository) GetByID(context.Context, comics.GetByIDOpts) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (stubComicsRepository) GetBySourceSlug(
+	context.Context, comics.GetBySourceSlugOpts,
+) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (stubComicsRepository) Create(context.Context, comics.CreateComicOpts) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (stubComicsRepository) GetBySlugsAndSource(
+	context.Context, sources.SourceName, []string,
+) ([]comics.Comic, error) {
+	return nil, nil
+}
+
+func (stubComicsRepository) Delete(context.Context, uuid.UUID) error {
+	return coredomain.ErrNotFound
+}
+
+func (stubComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]comics.Comic, error) {
+	return nil, nil
+}
 
 type emptyOIDCProvidersRepository struct{}
 
@@ -167,7 +200,7 @@ func newTestCtrlsForUser(t *testing.T, user *users.User) *ctrls {
 
 	logger := slog.New(slog.DiscardHandler)
 
-	asuraApp, err := setupAsura(logger)
+	asuraApp, err := setupAsura(logger, stubComicsRepository{})
 	if err != nil {
 		t.Fatalf("setupAsura: %v", err)
 	}

--- a/api/pkg/core/app.go
+++ b/api/pkg/core/app.go
@@ -16,6 +16,7 @@ import (
 	httpauth "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/gateway/http"
 	httpoidcproviders "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
+	httpcomics "github.com/kharente-deuh/uchiyomi-server/pkg/core/comics/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
 	httpcovers "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/gateway/http"
 	httphealth "github.com/kharente-deuh/uchiyomi-server/pkg/core/health/gateway/http"
@@ -70,6 +71,7 @@ type Deps struct {
 	HealthCtrl        *httphealth.Controller
 	AuthCtrl          *httpauth.Controller
 	UsersCtrl         *httpusers.Controller
+	ComicsCtrl        *httpcomics.Controller
 	OIDCProvidersCtrl *httpoidcproviders.Controller
 
 	Logger *slog.Logger
@@ -132,6 +134,10 @@ func (deps *Deps) Validate() error {
 
 	if deps.OIDCProvidersCtrl == nil {
 		return errors.New("oidcProvidersCtrl is required")
+	}
+
+	if deps.ComicsCtrl == nil {
+		return errors.New("comicsCtrl is required")
 	}
 
 	if deps.Health == nil {
@@ -267,6 +273,7 @@ func (a *App) newRouter(ui http.Handler) chi.Router {
 			a.deps.AuthCtrl.InitRouter(r)
 			a.deps.UsersCtrl.InitRouter(r)
 			a.deps.OIDCProvidersCtrl.InitRouter(r)
+			a.deps.ComicsCtrl.InitRouter(r)
 			r.Route("/sources", func(r chi.Router) {
 				a.deps.CoversCtrl.InitRouter(r)
 				a.deps.AsuraCtrl.InitRouter(r)

--- a/api/pkg/core/auth/credentials/federatedidentities/repository/pg/repository.go
+++ b/api/pkg/core/auth/credentials/federatedidentities/repository/pg/repository.go
@@ -73,7 +73,7 @@ func (r *PGFederatedIdentitiesRepository) Create(ctx context.Context, opts feder
 		return nil, fmt.Errorf("r.db(ctx).Create: %w", err)
 	}
 
-	fi := r.modelToDomain(*model)
+	fi := model.Domain()
 
 	return &fi, nil
 }
@@ -93,7 +93,7 @@ func (r *PGFederatedIdentitiesRepository) Get(ctx context.Context, opts federate
 		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
 	}
 
-	fi := r.modelToDomain(model)
+	fi := model.Domain()
 
 	return &fi, nil
 }
@@ -155,23 +155,8 @@ func (r *PGFederatedIdentitiesRepository) ListDueForRevalidation(
 
 	out := make([]federatedidentities.FederatedIdentity, len(models))
 	for i, model := range models {
-		out[i] = r.modelToDomain(model)
+		out[i] = model.Domain()
 	}
 
 	return out, nil
-}
-
-//nolint:lll
-func (r *PGFederatedIdentitiesRepository) modelToDomain(model pgmodels.FederatedIdentity) federatedidentities.FederatedIdentity {
-	return federatedidentities.FederatedIdentity{
-		ID:              model.ID,
-		UserID:          model.UserID,
-		ProviderID:      model.ProviderID,
-		Subject:         model.Subject,
-		Claims:          model.Claims,
-		RefreshTokenEnc: model.RefreshTokenEnc,
-		LastValidatedAt: model.LastValidatedAt,
-		LastLoginAt:     model.LastLoginAt,
-		CreatedAt:       model.CreatedAt,
-	}
 }

--- a/api/pkg/core/auth/credentials/password/repository/pg/repository.go
+++ b/api/pkg/core/auth/credentials/password/repository/pg/repository.go
@@ -65,7 +65,7 @@ func (r *PGPasswordCredsRepository) Create(ctx context.Context, opts password.Up
 		return nil, fmt.Errorf("r.db(ctx).Create: %w", err)
 	}
 
-	pwdCred := r.modelToDomain(*model)
+	pwdCred := model.Domain()
 
 	return &pwdCred, nil
 }
@@ -81,7 +81,7 @@ func (r *PGPasswordCredsRepository) GetByUserID(ctx context.Context, userID uuid
 		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
 	}
 
-	pwdCreds := r.modelToDomain(model)
+	pwdCreds := model.Domain()
 
 	return &pwdCreds, nil
 }
@@ -101,12 +101,4 @@ func (r *PGPasswordCredsRepository) UpdateByUserID(ctx context.Context, opts pas
 	}
 
 	return nil
-}
-
-func (r *PGPasswordCredsRepository) modelToDomain(model pgmodels.PasswordCreds) password.PasswordCreds {
-	return password.PasswordCreds{
-		UserID:    model.UserID,
-		Hash:      model.Hash,
-		UpdatedAt: model.UpdatedAt,
-	}
 }

--- a/api/pkg/core/auth/oidcproviders/repository/pg/repository.go
+++ b/api/pkg/core/auth/oidcproviders/repository/pg/repository.go
@@ -12,7 +12,6 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/repository/pgmodels"
-	"github.com/kharente-deuh/uchiyomi-server/pkg/utils"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/transaction/pgtx"
 	"github.com/lib/pq"
 	"gorm.io/gorm"
@@ -61,7 +60,7 @@ func (r *PGOIDCProvidersRepository) GetByID(ctx context.Context, id uuid.UUID) (
 		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
 	}
 
-	p := r.modelToDomain(model)
+	p := model.Domain()
 
 	return &p, nil
 }
@@ -77,7 +76,7 @@ func (r *PGOIDCProvidersRepository) GetByIssuerURL(ctx context.Context, issuerUR
 		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
 	}
 
-	p := r.modelToDomain(model)
+	p := model.Domain()
 
 	return &p, nil
 }
@@ -98,7 +97,12 @@ func (r *PGOIDCProvidersRepository) GetAll(ctx context.Context) ([]oidcproviders
 		return nil, fmt.Errorf("pgtx.From(ctx, r.deps.DB).Scan: %w", err)
 	}
 
-	return utils.MapSlice(rows, r.lightRowToDomain), nil
+	out := make([]oidcproviders.LightOIDCProvider, len(rows))
+	for i, row := range rows {
+		out[i] = row.Domain()
+	}
+
+	return out, nil
 }
 
 //nolint:lll
@@ -117,7 +121,12 @@ func (r *PGOIDCProvidersRepository) GetUsers(ctx context.Context, id uuid.UUID) 
 		return nil, fmt.Errorf("pgtx.From(ctx, r.deps.DB).Scan: %w", err)
 	}
 
-	return utils.MapSlice(rows, r.userRowToDomain), nil
+	out := make([]oidcproviders.OIDCProviderUser, len(rows))
+	for i, row := range rows {
+		out[i] = row.Domain()
+	}
+
+	return out, nil
 }
 
 //nolint:lll
@@ -149,7 +158,7 @@ func (r *PGOIDCProvidersRepository) Create(ctx context.Context, opts oidcprovide
 		return nil, fmt.Errorf("r.db(ctx).Create: %w", err)
 	}
 
-	p := r.modelToDomain(*model)
+	p := model.Domain()
 
 	return &p, nil
 }
@@ -205,6 +214,15 @@ type lightProviderRow struct {
 	UserCount   int64
 }
 
+func (r *lightProviderRow) Domain() oidcproviders.LightOIDCProvider {
+	return oidcproviders.LightOIDCProvider{
+		ID:          r.ID,
+		DisplayName: r.DisplayName,
+		CreatedAt:   r.CreatedAt,
+		UserCount:   r.UserCount,
+	}
+}
+
 type providerUserRow struct {
 	LinkedAt time.Time
 	Username string
@@ -212,38 +230,11 @@ type providerUserRow struct {
 	IsAdmin  bool
 }
 
-func (r *PGOIDCProvidersRepository) userRowToDomain(row providerUserRow) oidcproviders.OIDCProviderUser {
+func (r *providerUserRow) Domain() oidcproviders.OIDCProviderUser {
 	return oidcproviders.OIDCProviderUser{
-		ID:       row.ID,
-		Username: row.Username,
-		LinkedAt: row.LinkedAt,
-		IsAdmin:  row.IsAdmin,
-	}
-}
-
-func (r *PGOIDCProvidersRepository) lightRowToDomain(row lightProviderRow) oidcproviders.LightOIDCProvider {
-	return oidcproviders.LightOIDCProvider{
-		ID:          row.ID,
-		DisplayName: row.DisplayName,
-		CreatedAt:   row.CreatedAt,
-		UserCount:   row.UserCount,
-	}
-}
-
-func (r *PGOIDCProvidersRepository) modelToDomain(model pgmodels.OIDCProvider) oidcproviders.OIDCProvider {
-	return oidcproviders.OIDCProvider{
-		ID:              model.ID,
-		DisplayName:     model.DisplayName,
-		IssuerURL:       model.IssuerURL,
-		ClientID:        model.ClientID,
-		ClientSecretEnc: model.ClientSecretEnc,
-		Scopes:          model.Scopes,
-		UsernameClaim:   model.UsernameClaim,
-		RoleClaim:       model.RoleClaim,
-		AdminValues:     model.AdminValues,
-		AllowedValues:   model.AllowedValues,
-		AutoProvision:   model.AutoProvision,
-		CreatedAt:       model.CreatedAt,
-		UpdatedAt:       model.UpdatedAt,
+		ID:       r.ID,
+		Username: r.Username,
+		LinkedAt: r.LinkedAt,
+		IsAdmin:  r.IsAdmin,
 	}
 }

--- a/api/pkg/core/auth/sessions/repository/pg/repository.go
+++ b/api/pkg/core/auth/sessions/repository/pg/repository.go
@@ -75,10 +75,7 @@ func (r *PGSessionsRepository) Insert(ctx context.Context, opts sessions.InsertS
 
 //nolint:lll
 func (r *PGSessionsRepository) GetByTokenHash(ctx context.Context, hash []byte) (*sessions.Session, *users.User, error) {
-	model, err := r.db(ctx).
-		Joins(clause.JoinTarget{Association: "User"}, nil).
-		Where("sessions.token_hash = ?", hash).
-		First(ctx)
+	model, err := r.db(ctx).Joins(clause.JoinTarget{Association: "User"}, nil).Where("sessions.token_hash = ?", hash).First(ctx)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil, domain.ErrNotFound

--- a/api/pkg/core/auth/sessions/repository/pg/repository.go
+++ b/api/pkg/core/auth/sessions/repository/pg/repository.go
@@ -68,7 +68,7 @@ func (r *PGSessionsRepository) Insert(ctx context.Context, opts sessions.InsertS
 		return nil, fmt.Errorf("r.db(ctx).Create: %w", err)
 	}
 
-	session := r.modelToDomain(*model)
+	session := model.Domain()
 
 	return &session, nil
 }
@@ -87,14 +87,8 @@ func (r *PGSessionsRepository) GetByTokenHash(ctx context.Context, hash []byte) 
 		return nil, nil, fmt.Errorf("r.db(ctx).First: %w", err)
 	}
 
-	session := r.modelToDomain(model)
-	user := users.User{
-		ID:        model.User.ID,
-		Name:      model.User.Name,
-		IsAdmin:   model.User.IsAdmin,
-		CreatedAt: model.User.CreatedAt,
-		UpdatedAt: model.User.UpdatedAt,
-	}
+	session := model.Domain()
+	user := model.User.Domain()
 
 	return &session, &user, nil
 }
@@ -149,16 +143,4 @@ func (r *PGSessionsRepository) DeleteExpired(ctx context.Context, now time.Time)
 	}
 
 	return int64(deleted), nil
-}
-
-func (r *PGSessionsRepository) modelToDomain(model pgmodels.Session) sessions.Session {
-	return sessions.Session{
-		ID:          model.ID,
-		UserID:      model.UserID,
-		AuthMethod:  sessions.AuthMethod(model.AuthMethod),
-		CreatedAt:   model.CreatedAt,
-		ExpiresAt:   model.ExpiresAt,
-		ProviderID:  model.ProviderID,
-		ProviderSID: model.ProviderSID,
-	}
 }

--- a/api/pkg/core/comics/domain.go
+++ b/api/pkg/core/comics/domain.go
@@ -11,13 +11,12 @@ import (
 )
 
 type Comic struct {
-	ID           uuid.UUID
-	CreatedAt    time.Time
 	UpdatedAt    time.Time
+	CreatedAt    time.Time
+	Source       sources.SourceName
 	Artist       string
 	Type         sources.SeriesType
 	Description  string
-	Source       sources.SourceName
 	Author       string
 	Status       sources.SeriesStatus
 	Slug         string
@@ -25,12 +24,13 @@ type Comic struct {
 	Genres       []string
 	AltTitles    []string
 	ChapterCount int
+	ID           uuid.UUID
 }
 
 type GetBySourceSlugOpts struct {
-	UserID uuid.UUID
 	Source sources.SourceName
 	Slug   string
+	UserID uuid.UUID
 }
 
 type ComicsRepository interface {

--- a/api/pkg/core/comics/domain.go
+++ b/api/pkg/core/comics/domain.go
@@ -7,64 +7,47 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
 )
 
 type Comic struct {
+	ID           uuid.UUID
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
 	Artist       string
-	Type         ComicType
+	Type         sources.SeriesType
 	Description  string
-	CoverPath    string
-	Source       string
+	Source       sources.SourceName
 	Author       string
-	Status       ComicStatus
+	Status       sources.SeriesStatus
 	Slug         string
 	Title        string
 	Genres       []string
 	AltTitles    []string
 	ChapterCount int
-	ID           uuid.UUID
 }
 
-type ComicType string
-
-const (
-	ComicTypeManga     ComicType = "manga"
-	ComicTypeMangatoon ComicType = "mangatoon"
-	ComicTypeManhua    ComicType = "manhua"
-	ComicTypeManhwa    ComicType = "manhwa"
-)
-
-type ComicStatus string
-
-const (
-	ComicStatusOngoing   ComicStatus = "ongoing"
-	ComicStatusCompleted ComicStatus = "completed"
-	ComicStatusHiatus    ComicStatus = "hiatus"
-	ComicStatusCancelled ComicStatus = "cancelled"
-	ComicStatusDropped   ComicStatus = "dropped"
-)
-
-type SourceSlugKey struct {
-	Source string
+type GetBySourceSlugOpts struct {
+	UserID uuid.UUID
+	Source sources.SourceName
 	Slug   string
 }
 
 type ComicsRepository interface {
-	GetByID(context.Context, uuid.UUID) (*Comic, error)
-	GetBySourceSlug(context.Context, SourceSlugKey) (*Comic, error)
+	GetByID(context.Context, GetByIDOpts) (*Comic, error)
+	GetBySourceSlug(context.Context, GetBySourceSlugOpts) (*Comic, error)
 	Create(context.Context, CreateComicOpts) (*Comic, error)
-	GetBySlugsAndSource(context.Context, string, []string) ([]Comic, error)
+	GetBySlugsAndSource(context.Context, sources.SourceName, []string) ([]Comic, error)
 	Delete(context.Context, uuid.UUID) error
+	GetMany(context.Context, GetManyOpts) ([]Comic, error)
 }
 
 type CreateComicOpts struct {
-	Status       ComicStatus
-	Type         ComicType
+	Status       sources.SeriesStatus
+	Type         sources.SeriesType
 	Description  string
 	CoverPath    string
-	Source       string
+	Source       sources.SourceName
 	Artist       string
 	Slug         string
 	Author       string
@@ -72,4 +55,36 @@ type CreateComicOpts struct {
 	AltTitles    []string
 	Genres       []string
 	ChapterCount int
+}
+
+type ComicsService interface {
+	Create(context.Context, CreateOpts) (*Comic, error)
+	GetByID(context.Context, GetByIDOpts) (*Comic, error)
+	GetMany(context.Context, GetManyOpts) ([]Comic, error)
+	Delete(context.Context, DeleteOpts) error
+}
+
+type CreateOpts struct {
+	Source sources.SourceName
+	Slug   string
+	UserID uuid.UUID
+}
+
+type GetByIDOpts struct {
+	UserID uuid.UUID
+	ID     uuid.UUID
+}
+
+type GetManyOpts struct {
+	UserID *uuid.UUID
+	Source *sources.SourceName
+	Type   *sources.SeriesType
+	Status *sources.SeriesStatus
+	Limit  int
+	Offset int
+}
+
+type DeleteOpts struct {
+	UserID uuid.UUID
+	ID     uuid.UUID
 }

--- a/api/pkg/core/comics/domain.go
+++ b/api/pkg/core/comics/domain.go
@@ -10,26 +10,41 @@ import (
 )
 
 type Comic struct {
-	CreatedAt        time.Time
-	UpdatedAt        time.Time
-	Artist           string
-	Type             string
-	Description      string
-	LocalCoverPath   string
-	ExternalCoverURL string
-	SourceURL        string
-	Source           string
-	Author           string
-	Status           string
-	Slug             string
-	Title            string
-	Genres           []string
-	AltTitles        []string
-	ChapterCount     int
-	ReleaseYear      int
-	Rating           float64
-	ID               uuid.UUID
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+	Artist       string
+	Type         ComicType
+	Description  string
+	CoverPath    string
+	Source       string
+	Author       string
+	Status       ComicStatus
+	Slug         string
+	Title        string
+	Genres       []string
+	AltTitles    []string
+	ChapterCount int
+	ID           uuid.UUID
 }
+
+type ComicType string
+
+const (
+	ComicTypeManga     ComicType = "manga"
+	ComicTypeMangatoon ComicType = "mangatoon"
+	ComicTypeManhua    ComicType = "manhua"
+	ComicTypeManhwa    ComicType = "manhwa"
+)
+
+type ComicStatus string
+
+const (
+	ComicStatusOngoing   ComicStatus = "ongoing"
+	ComicStatusCompleted ComicStatus = "completed"
+	ComicStatusHiatus    ComicStatus = "hiatus"
+	ComicStatusCancelled ComicStatus = "cancelled"
+	ComicStatusDropped   ComicStatus = "dropped"
+)
 
 type SourceSlugKey struct {
 	Source string
@@ -40,23 +55,21 @@ type ComicsRepository interface {
 	GetByID(context.Context, uuid.UUID) (*Comic, error)
 	GetBySourceSlug(context.Context, SourceSlugKey) (*Comic, error)
 	Create(context.Context, CreateComicOpts) (*Comic, error)
+	GetBySlugsAndSource(context.Context, string, []string) ([]Comic, error)
+	Delete(context.Context, uuid.UUID) error
 }
 
 type CreateComicOpts struct {
-	Status           string
-	Type             string
-	Description      string
-	LocalCoverPath   string
-	ExternalCoverURL string
-	SourceURL        string
-	Source           string
-	Artist           string
-	Slug             string
-	Author           string
-	Title            string
-	AltTitles        []string
-	Genres           []string
-	ChapterCount     int
-	ReleaseYear      int
-	Rating           float64
+	Status       ComicStatus
+	Type         ComicType
+	Description  string
+	CoverPath    string
+	Source       string
+	Artist       string
+	Slug         string
+	Author       string
+	Title        string
+	AltTitles    []string
+	Genres       []string
+	ChapterCount int
 }

--- a/api/pkg/core/comics/gateway/http/controller.go
+++ b/api/pkg/core/comics/gateway/http/controller.go
@@ -121,6 +121,7 @@ func (c *Controller) create(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		c.deps.Logger.Error("failed to create comic", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
+
 		return
 	}
 
@@ -170,6 +171,7 @@ func (c *Controller) getMany(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		c.deps.Logger.Error("user not found in context")
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
+
 		return
 	}
 
@@ -187,6 +189,7 @@ func (c *Controller) getMany(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		c.deps.Logger.Error("failed to get many comics", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
+
 		return
 	}
 
@@ -264,39 +267,57 @@ func (c *Controller) getManyQuery(r *http.Request) (*comics.GetManyOpts, error) 
 		opts.Status = &parsed
 	}
 
-	qLimit := r.URL.Query().Get("limit")
-	if qLimit == "" {
-		opts.Limit = 10
-	} else {
-		limit, err := strconv.Atoi(qLimit)
-		if err != nil {
-			return nil, fmt.Errorf("invalid limit: %w", err)
-		}
-
-		if limit < 1 {
-			opts.Limit = 10
-		} else if limit > 100 {
-			opts.Limit = 100
-		} else {
-			opts.Limit = limit
-		}
+	limit, err := parseQueryLimit(r.URL.Query().Get("limit"))
+	if err != nil {
+		return nil, fmt.Errorf("parseQueryLimit: %w", err)
 	}
 
-	qOffset := r.URL.Query().Get("offset")
-	if qOffset == "" {
-		opts.Offset = 0
-	} else {
-		offset, err := strconv.Atoi(qOffset)
-		if err != nil {
-			return nil, fmt.Errorf("invalid offset: %w", err)
-		}
+	opts.Limit = limit
 
-		if offset < 0 {
-			opts.Offset = 0
-		} else {
-			opts.Offset = offset
-		}
+	offset, err := parseQueryOffset(r.URL.Query().Get("offset"))
+	if err != nil {
+		return nil, fmt.Errorf("parseQueryOffset: %w", err)
 	}
+
+	opts.Offset = offset
 
 	return opts, nil
+}
+
+func parseQueryLimit(q string) (int, error) {
+	if q == "" {
+		return 10, nil
+	}
+
+	limit, err := strconv.Atoi(q)
+	if err != nil {
+		return 0, fmt.Errorf("invalid limit: %w", err)
+	}
+
+	if limit < 1 {
+		return 10, nil
+	}
+
+	if limit > 100 {
+		return 100, nil
+	}
+
+	return limit, nil
+}
+
+func parseQueryOffset(q string) (int, error) {
+	if q == "" {
+		return 0, nil
+	}
+
+	offset, err := strconv.Atoi(q)
+	if err != nil {
+		return 0, fmt.Errorf("invalid offset: %w", err)
+	}
+
+	if offset < 0 {
+		return 0, nil
+	}
+
+	return offset, nil
 }

--- a/api/pkg/core/comics/gateway/http/controller.go
+++ b/api/pkg/core/comics/gateway/http/controller.go
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package http
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/go-chi/chi/v5"
+	httpsession "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/httputils"
+)
+
+type Config struct {
+	Endpoint    string
+	Middlewares chi.Middlewares
+}
+
+func (cfg *Config) Validate() error {
+	if cfg.Endpoint == "" {
+		return errors.New("endpoint is required")
+	}
+
+	if !strings.HasPrefix(cfg.Endpoint, "/") {
+		return fmt.Errorf("endpoint must start with '/', got %q", cfg.Endpoint)
+	}
+
+	hasNilMiddlewares := slices.ContainsFunc(cfg.Middlewares, func(m func(http.Handler) http.Handler) bool {
+		return m == nil
+	})
+
+	if hasNilMiddlewares {
+		return errors.New("all middlewares must not be nil")
+	}
+
+	return nil
+}
+
+type Deps struct {
+	ComicsService comics.ComicsService
+	Logger        *slog.Logger
+}
+
+func (deps *Deps) Validate() error {
+	if deps.ComicsService == nil {
+		return errors.New("comics service is required")
+	}
+
+	if deps.Logger == nil {
+		return errors.New("logger is required")
+	}
+
+	return nil
+}
+
+type Controller struct {
+	deps Deps
+	cfg  Config
+}
+
+func New(cfg Config, deps Deps) (*Controller, error) {
+	var err error
+	if err = cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("cfg.Validate: %w", err)
+	}
+
+	if err = deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	return &Controller{deps: deps, cfg: cfg}, nil
+}
+
+func (c *Controller) InitRouter(r chi.Router) {
+	r.Route(c.cfg.Endpoint, func(r chi.Router) {
+		r.Use(c.cfg.Middlewares...)
+
+		r.Post("/", c.create)
+		r.Get("/", c.getMany)
+		r.Get("/{id}", c.getByID)
+		r.Delete("/{id}", c.deleteByID)
+	})
+}
+
+func (c *Controller) create(w http.ResponseWriter, r *http.Request) {
+	var req createRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		c.deps.Logger.Error("failed to decode request", "error", err)
+		http.Error(w, "invalid request", http.StatusBadRequest)
+
+		return
+	}
+
+	ctx := r.Context()
+
+	user, ok := httpsession.UserFrom(ctx)
+	if !ok {
+		c.deps.Logger.Error("user not found in context")
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+
+		return
+	}
+
+	comic, err := c.deps.ComicsService.Create(r.Context(), comics.CreateOpts{
+		Source: req.Source,
+		Slug:   req.Slug,
+		UserID: user.ID,
+	})
+
+	if err != nil {
+		c.deps.Logger.Error("failed to create comic", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusCreated, lightComicFromDomain(comic))
+}
+
+func (c *Controller) getByID(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user, ok := httpsession.UserFrom(ctx)
+	if !ok {
+		c.deps.Logger.Error("user not found in context")
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+
+		return
+	}
+
+	id, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "id must be a valid UUID")
+
+		return
+	}
+
+	comic, err := c.deps.ComicsService.GetByID(ctx, comics.GetByIDOpts{
+		UserID: user.ID,
+		ID:     id,
+	})
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusNotFound, "comic not found")
+
+			return
+		}
+
+		c.deps.Logger.Error("failed to get comic by id", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, comicResponseFromDomain(comic))
+}
+
+func (c *Controller) getMany(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user, ok := httpsession.UserFrom(ctx)
+	if !ok {
+		c.deps.Logger.Error("user not found in context")
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	opts, err := c.getManyQuery(r)
+	if err != nil {
+		c.deps.Logger.Error("failed to get many comics", "error", err)
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "invalid query parameters")
+
+		return
+	}
+
+	opts.UserID = &user.ID
+
+	comics, err := c.deps.ComicsService.GetMany(ctx, *opts)
+	if err != nil {
+		c.deps.Logger.Error("failed to get many comics", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	res := make([]lightComic, len(comics))
+	for i, comic := range comics {
+		res[i] = lightComicFromDomain(&comic)
+	}
+
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, res)
+}
+
+func (c *Controller) deleteByID(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user, ok := httpsession.UserFrom(ctx)
+	if !ok {
+		c.deps.Logger.Error("user not found in context")
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+
+		return
+	}
+
+	id, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "id must be a valid UUID")
+
+		return
+	}
+
+	err = c.deps.ComicsService.Delete(ctx, comics.DeleteOpts{
+		UserID: user.ID,
+		ID:     id,
+	})
+	if err != nil && !errors.Is(err, domain.ErrNotFound) {
+		c.deps.Logger.Error("failed to delete comic by id", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, "")
+}
+
+func (c *Controller) getManyQuery(r *http.Request) (*comics.GetManyOpts, error) {
+	opts := &comics.GetManyOpts{}
+
+	source := r.URL.Query().Get("source")
+	if source != "" {
+		parsed, err := sources.ParseSourceName(source)
+		if err != nil {
+			return nil, fmt.Errorf("sources.ParseSourceName: %w", err)
+		}
+
+		opts.Source = &parsed
+	}
+
+	comicType := r.URL.Query().Get("type")
+	if comicType != "" {
+		parsed, err := sources.ParseSeriesType(comicType)
+		if err != nil {
+			//nolint:wrapcheck
+			return nil, err
+		}
+
+		opts.Type = &parsed
+	}
+
+	comicStatus := r.URL.Query().Get("status")
+	if comicStatus != "" {
+		parsed, err := sources.ParseSeriesStatus(comicStatus)
+		if err != nil {
+			//nolint:wrapcheck
+			return nil, err
+		}
+
+		opts.Status = &parsed
+	}
+
+	qLimit := r.URL.Query().Get("limit")
+	if qLimit == "" {
+		opts.Limit = 10
+	} else {
+		limit, err := strconv.Atoi(qLimit)
+		if err != nil {
+			return nil, fmt.Errorf("invalid limit: %w", err)
+		}
+
+		if limit < 1 {
+			opts.Limit = 10
+		} else if limit > 100 {
+			opts.Limit = 100
+		} else {
+			opts.Limit = limit
+		}
+	}
+
+	qOffset := r.URL.Query().Get("offset")
+	if qOffset == "" {
+		opts.Offset = 0
+	} else {
+		offset, err := strconv.Atoi(qOffset)
+		if err != nil {
+			return nil, fmt.Errorf("invalid offset: %w", err)
+		}
+
+		if offset < 0 {
+			opts.Offset = 0
+		} else {
+			opts.Offset = offset
+		}
+	}
+
+	return opts, nil
+}

--- a/api/pkg/core/comics/gateway/http/controller_test.go
+++ b/api/pkg/core/comics/gateway/http/controller_test.go
@@ -33,13 +33,13 @@ const (
 )
 
 type stubComicsService struct {
-	createResult *comics.Comic
-	createErr    error
-	getByIDResult *comics.Comic
+	createErr     error
 	getByIDErr    error
-	getManyResult []comics.Comic
 	getManyErr    error
 	deleteErr     error
+	createResult  *comics.Comic
+	getByIDResult *comics.Comic
+	getManyResult []comics.Comic
 }
 
 func (s *stubComicsService) Create(_ context.Context, _ comics.CreateOpts) (*comics.Comic, error) {
@@ -172,7 +172,11 @@ func TestCreateRequiresAuthentication(t *testing.T) {
 
 	r := newTestRouter(t, &stubComicsService{}, nil)
 
-	req := httptest.NewRequest(http.MethodPost, comicsEndpoint+"/", bytes.NewReader([]byte(`{"source":"asurascans","slug":"solo-leveling"}`)))
+	req := httptest.NewRequest(
+		http.MethodPost,
+		comicsEndpoint+"/",
+		bytes.NewReader([]byte(`{"source":"asurascans","slug":"solo-leveling"}`)),
+	)
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
@@ -196,7 +200,12 @@ func TestCreateReturnsComic(t *testing.T) {
 
 	r := newTestRouter(t, &stubComicsService{createResult: comic}, authenticatorFor(t, user))
 
-	req := httptest.NewRequest(http.MethodPost, comicsEndpoint+"/", bytes.NewReader([]byte(`{"source":"asurascans","slug":"solo-leveling"}`)))
+	req := httptest.NewRequest(
+		http.MethodPost,
+		comicsEndpoint+"/",
+		bytes.NewReader([]byte(`{"source":"asurascans","slug":"solo-leveling"}`)),
+	)
+
 	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
@@ -216,12 +225,12 @@ func TestCreateReturnsComic(t *testing.T) {
 }
 
 type comicshttpLightComic struct {
-	ID           uuid.UUID          `json:"id"`
-	Title        string             `json:"title"`
-	Slug         string             `json:"slug"`
-	Source       sources.SourceName `json:"source"`
+	Title        string               `json:"title"`
+	Slug         string               `json:"slug"`
+	Source       sources.SourceName   `json:"source"`
 	Status       sources.SeriesStatus `json:"status"`
 	ChapterCount int                  `json:"chapter_count"`
+	ID           uuid.UUID            `json:"id"`
 }
 
 func TestGetByIDNotFound(t *testing.T) {

--- a/api/pkg/core/comics/gateway/http/controller_test.go
+++ b/api/pkg/core/comics/gateway/http/controller_test.go
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package http_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
+	sessionshttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
+	comicshttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/comics/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/users"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+)
+
+const (
+	comicsEndpoint = "/comics"
+	cookieName     = "uchiyomi_session"
+	testToken      = "letoken"
+	testUsername   = "alice"
+)
+
+type stubComicsService struct {
+	createResult *comics.Comic
+	createErr    error
+	getByIDResult *comics.Comic
+	getByIDErr    error
+	getManyResult []comics.Comic
+	getManyErr    error
+	deleteErr     error
+}
+
+func (s *stubComicsService) Create(_ context.Context, _ comics.CreateOpts) (*comics.Comic, error) {
+	return s.createResult, s.createErr
+}
+
+func (s *stubComicsService) GetByID(_ context.Context, _ comics.GetByIDOpts) (*comics.Comic, error) {
+	return s.getByIDResult, s.getByIDErr
+}
+
+func (s *stubComicsService) GetMany(_ context.Context, _ comics.GetManyOpts) ([]comics.Comic, error) {
+	return s.getManyResult, s.getManyErr
+}
+
+func (s *stubComicsService) Delete(_ context.Context, _ comics.DeleteOpts) error {
+	return s.deleteErr
+}
+
+type stubSessionService struct {
+	result *sessions.AuthenticatedSession
+}
+
+func (s *stubSessionService) Authenticate(_ context.Context, _ string) (*sessions.AuthenticatedSession, error) {
+	if s.result == nil {
+		return nil, sessions.ErrInvalidSession
+	}
+
+	return s.result, nil
+}
+
+func testLogger() (*slog.Logger, *bytes.Buffer) {
+	var buf bytes.Buffer
+
+	return slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})), &buf
+}
+
+func frozenNow() time.Time {
+	return time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
+}
+
+func authenticatorFor(t *testing.T, user *users.User) chi.Middlewares {
+	t.Helper()
+
+	logger, _ := testLogger()
+
+	cookies, err := sessionshttp.NewCookieManager(sessionshttp.CookieConfig{Name: cookieName, Path: "/"})
+	if err != nil {
+		t.Fatalf("NewCookieManager: %v", err)
+	}
+
+	a, err := sessionshttp.NewAuthenticator(sessionshttp.AuthenticatorDeps{
+		SessionService: &stubSessionService{result: &sessions.AuthenticatedSession{
+			User:    user,
+			Session: sessions.Session{ID: uuid.New(), UserID: user.ID, ExpiresAt: frozenNow().Add(time.Hour)},
+		}},
+		Cookies: cookies,
+		Logger:  logger,
+		Now:     frozenNow,
+	})
+	if err != nil {
+		t.Fatalf("NewAuthenticator: %v", err)
+	}
+
+	return chi.Middlewares{a.Middleware}
+}
+
+func newTestRouter(t *testing.T, svc comics.ComicsService, mws chi.Middlewares) chi.Router {
+	t.Helper()
+
+	logger := slog.New(slog.DiscardHandler)
+
+	c, err := comicshttp.New(
+		comicshttp.Config{Endpoint: comicsEndpoint, Middlewares: mws},
+		comicshttp.Deps{Logger: logger, ComicsService: svc},
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	r := chi.NewRouter()
+	c.InitRouter(r)
+
+	return r
+}
+
+func TestConfigValidate(t *testing.T) {
+	t.Parallel()
+
+	passthrough := func(next http.Handler) http.Handler { return next }
+
+	tests := map[string]struct {
+		wantErr string
+		cfg     comicshttp.Config
+	}{
+		"valid": {cfg: comicshttp.Config{Endpoint: comicsEndpoint}},
+		"empty": {cfg: comicshttp.Config{}, wantErr: "endpoint is required"},
+		"without leading slash": {
+			cfg:     comicshttp.Config{Endpoint: "comics"},
+			wantErr: `endpoint must start with '/', got "comics"`,
+		},
+		"nil middleware": {
+			cfg:     comicshttp.Config{Endpoint: comicsEndpoint, Middlewares: chi.Middlewares{passthrough, nil}},
+			wantErr: "all middlewares must not be nil",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.cfg.Validate()
+
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() = %v, want nil", err)
+				}
+
+				return
+			}
+
+			if err == nil || err.Error() != tc.wantErr {
+				t.Errorf("Validate() = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestCreateRequiresAuthentication(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRouter(t, &stubComicsService{}, nil)
+
+	req := httptest.NewRequest(http.MethodPost, comicsEndpoint+"/", bytes.NewReader([]byte(`{"source":"asurascans","slug":"solo-leveling"}`)))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestCreateReturnsComic(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	comic := &comics.Comic{
+		ID:           uuid.New(),
+		Title:        "Solo Leveling",
+		Slug:         "solo-leveling",
+		Source:       sources.SourceAsuraScans,
+		Status:       sources.SeriesStatusCompleted,
+		ChapterCount: 200,
+	}
+
+	r := newTestRouter(t, &stubComicsService{createResult: comic}, authenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodPost, comicsEndpoint+"/", bytes.NewReader([]byte(`{"source":"asurascans","slug":"solo-leveling"}`)))
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+
+	var got comicshttpLightComic
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if got.ID != comic.ID || got.Slug != comic.Slug {
+		t.Errorf("response = %+v, want comic %+v", got, comic)
+	}
+}
+
+type comicshttpLightComic struct {
+	ID           uuid.UUID          `json:"id"`
+	Title        string             `json:"title"`
+	Slug         string             `json:"slug"`
+	Source       sources.SourceName `json:"source"`
+	Status       sources.SeriesStatus `json:"status"`
+	ChapterCount int                  `json:"chapter_count"`
+}
+
+func TestGetByIDNotFound(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	comicID := uuid.New()
+
+	r := newTestRouter(t, &stubComicsService{
+		getByIDErr: fmt.Errorf("s.deps.ComicsRepository.GetByID: %w", domain.ErrNotFound),
+	}, authenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodGet, comicsEndpoint+"/"+comicID.String(), nil)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestGetManyReturnsComics(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	items := []comics.Comic{{
+		ID:     uuid.New(),
+		Slug:   "solo-leveling",
+		Source: sources.SourceAsuraScans,
+		Title:  "Solo Leveling",
+		Status: sources.SeriesStatusCompleted,
+	}}
+
+	r := newTestRouter(t, &stubComicsService{getManyResult: items}, authenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodGet, comicsEndpoint+"/", nil)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var got []comicshttpLightComic
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if len(got) != 1 || got[0].Slug != items[0].Slug {
+		t.Errorf("response = %+v, want %+v", got, items)
+	}
+}
+
+func TestDeleteByID(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	comicID := uuid.New()
+
+	r := newTestRouter(t, &stubComicsService{}, authenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodDelete, comicsEndpoint+"/"+comicID.String(), nil)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+func TestDeleteByIDInternalError(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	comicID := uuid.New()
+	sentinel := errors.New("db down")
+
+	r := newTestRouter(t, &stubComicsService{deleteErr: sentinel}, authenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodDelete, comicsEndpoint+"/"+comicID.String(), nil)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+}

--- a/api/pkg/core/comics/gateway/http/dto.go
+++ b/api/pkg/core/comics/gateway/http/dto.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package http
+
+import (
+	"github.com/google/uuid"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+)
+
+type lightComic struct {
+	ID           uuid.UUID          `json:"id"`
+	Title        string             `json:"title"`
+	Slug         string             `json:"slug"`
+	Source       sources.SourceName `json:"source"`
+	Status       sources.SeriesStatus `json:"status"`
+	ChapterCount int                  `json:"chapter_count"`
+}
+
+func lightComicFromDomain(comic *comics.Comic) lightComic {
+	return lightComic{
+		ID:           comic.ID,
+		ChapterCount: comic.ChapterCount,
+		Title:        comic.Title,
+		Slug:         comic.Slug,
+		Source:       comic.Source,
+		Status:       comic.Status,
+	}
+}
+
+type createRequest struct {
+	Source sources.SourceName `json:"source" validate:"required"`
+	Slug   string             `json:"slug" validate:"required"`
+}
+
+type comicResponse struct {
+	ID           uuid.UUID          `json:"id"`
+	Artist       string             `json:"artist"`
+	Type         sources.SeriesType   `json:"type"`
+	Description  string               `json:"description"`
+	Source       sources.SourceName   `json:"source"`
+	Author       string               `json:"author"`
+	Status       sources.SeriesStatus `json:"status"`
+	Slug         string               `json:"slug"`
+	Title        string               `json:"title"`
+	Genres       []string             `json:"genres"`
+	AltTitles    []string             `json:"alt_titles"`
+	ChapterCount int                  `json:"chapter_count"`
+}
+
+func comicResponseFromDomain(comic *comics.Comic) comicResponse {
+	return comicResponse{
+		ID:           comic.ID,
+		Artist:       comic.Artist,
+		ChapterCount: comic.ChapterCount,
+		Type:         comic.Type,
+		Description:  comic.Description,
+		Source:       comic.Source,
+		Author:       comic.Author,
+		Status:       comic.Status,
+		Slug:         comic.Slug,
+		Title:        comic.Title,
+		Genres:       comic.Genres,
+		AltTitles:    comic.AltTitles,
+	}
+}

--- a/api/pkg/core/comics/gateway/http/dto.go
+++ b/api/pkg/core/comics/gateway/http/dto.go
@@ -10,12 +10,12 @@ import (
 )
 
 type lightComic struct {
-	ID           uuid.UUID          `json:"id"`
-	Title        string             `json:"title"`
-	Slug         string             `json:"slug"`
-	Source       sources.SourceName `json:"source"`
+	Title        string               `json:"title"`
+	Slug         string               `json:"slug"`
+	Source       sources.SourceName   `json:"source"`
 	Status       sources.SeriesStatus `json:"status"`
 	ChapterCount int                  `json:"chapter_count"`
+	ID           uuid.UUID            `json:"id"`
 }
 
 func lightComicFromDomain(comic *comics.Comic) lightComic {
@@ -35,8 +35,7 @@ type createRequest struct {
 }
 
 type comicResponse struct {
-	ID           uuid.UUID          `json:"id"`
-	Artist       string             `json:"artist"`
+	Artist       string               `json:"artist"`
 	Type         sources.SeriesType   `json:"type"`
 	Description  string               `json:"description"`
 	Source       sources.SourceName   `json:"source"`
@@ -47,6 +46,7 @@ type comicResponse struct {
 	Genres       []string             `json:"genres"`
 	AltTitles    []string             `json:"alt_titles"`
 	ChapterCount int                  `json:"chapter_count"`
+	ID           uuid.UUID            `json:"id"`
 }
 
 func comicResponseFromDomain(comic *comics.Comic) comicResponse {

--- a/api/pkg/core/comics/repository/pg/repository.go
+++ b/api/pkg/core/comics/repository/pg/repository.go
@@ -12,9 +12,11 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/repository/pgmodels"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/transaction/pgtx"
 	"github.com/lib/pq"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 var _ comics.ComicsRepository = (*PGComicsRepository)(nil)
@@ -49,8 +51,12 @@ func (r *PGComicsRepository) db(ctx context.Context) gorm.Interface[pgmodels.Com
 	return gorm.G[pgmodels.Comic](pgtx.From(ctx, r.deps.DB))
 }
 
-func (r *PGComicsRepository) GetByID(ctx context.Context, id uuid.UUID) (*comics.Comic, error) {
-	model, err := r.db(ctx).Where("id = ?", id).First(ctx)
+func (r *PGComicsRepository) GetByID(ctx context.Context, opts comics.GetByIDOpts) (*comics.Comic, error) {
+	model, err := r.db(ctx).
+		Joins(clause.JoinTarget{Association: "LibraryEntries"}, nil).
+		Where("comics.id = ? AND library_entries.user_id = ?", opts.ID, opts.UserID).
+		First(ctx)
+
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, domain.ErrNotFound
@@ -64,8 +70,11 @@ func (r *PGComicsRepository) GetByID(ctx context.Context, id uuid.UUID) (*comics
 	return &ret, nil
 }
 
-func (r *PGComicsRepository) GetBySourceSlug(ctx context.Context, key comics.SourceSlugKey) (*comics.Comic, error) {
-	model, err := r.db(ctx).Where("source = ? AND slug = ?", key.Source, key.Slug).First(ctx)
+func (r *PGComicsRepository) GetBySourceSlug(ctx context.Context, opts comics.GetBySourceSlugOpts) (*comics.Comic, error) {
+	model, err := r.db(ctx).
+		Joins(clause.JoinTarget{Association: "LibraryEntries"}, nil).
+		Where("comics.slug = ? AND comics.source = ? AND library_entries.user_id = ?", opts.Slug, opts.Source, opts.UserID).
+		First(ctx)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, domain.ErrNotFound
@@ -95,7 +104,6 @@ func (r *PGComicsRepository) Create(ctx context.Context, opts comics.CreateComic
 		Artist:       opts.Artist,
 		Description:  opts.Description,
 		AltTitles:    pq.StringArray(opts.AltTitles),
-		CoverPath:    opts.CoverPath,
 		CreatedAt:    now,
 		UpdatedAt:    now,
 	}
@@ -114,8 +122,43 @@ func (r *PGComicsRepository) Create(ctx context.Context, opts comics.CreateComic
 	return &ret, nil
 }
 
+func (r *PGComicsRepository) GetMany(ctx context.Context, opts comics.GetManyOpts) ([]comics.Comic, error) {
+	q := r.db(ctx).Joins(clause.JoinTarget{Association: "LibraryEntries"}, nil).Order("comics.created_at DESC")
+	if opts.UserID != nil {
+		q = q.Where("library_entries.user_id = ?", opts.UserID)
+	}
+
+	if opts.Source != nil {
+		q = q.Where("comics.source = ?", opts.Source)
+	}
+
+	if opts.Type != nil {
+		q = q.Where("comics.type = ?", opts.Type)
+	}
+
+	if opts.Status != nil {
+		q = q.Where("comics.status = ?", opts.Status)
+	}
+
+	models, err := q.Offset(opts.Offset).Limit(opts.Limit).Find(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
+	}
+
+	ret := make([]comics.Comic, len(models))
+	for i, model := range models {
+		ret[i] = model.Domain()
+	}
+
+	return ret, nil
+}
+
 // nolint:lll
-func (r *PGComicsRepository) GetBySlugsAndSource(ctx context.Context, source string, slugs []string) ([]comics.Comic, error) {
+func (r *PGComicsRepository) GetBySlugsAndSource(
+	ctx context.Context,
+	source sources.SourceName,
+	slugs []string,
+) ([]comics.Comic, error) {
 	models, err := r.db(ctx).Where("source = ? AND slug IN (?)", source, slugs).Find(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)

--- a/api/pkg/core/comics/repository/pg/repository.go
+++ b/api/pkg/core/comics/repository/pg/repository.go
@@ -59,7 +59,7 @@ func (r *PGComicsRepository) GetByID(ctx context.Context, id uuid.UUID) (*comics
 		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
 	}
 
-	ret := r.modelToDomain(model)
+	ret := model.Domain()
 
 	return &ret, nil
 }
@@ -74,7 +74,7 @@ func (r *PGComicsRepository) GetBySourceSlug(ctx context.Context, key comics.Sou
 		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
 	}
 
-	ret := r.modelToDomain(model)
+	ret := model.Domain()
 
 	return &ret, nil
 }
@@ -83,25 +83,21 @@ func (r *PGComicsRepository) Create(ctx context.Context, opts comics.CreateComic
 	now := time.Now()
 
 	model := &pgmodels.Comic{
-		ID:               uuid.New(),
-		Source:           opts.Source,
-		Slug:             opts.Slug,
-		Title:            opts.Title,
-		Status:           opts.Status,
-		ComicType:        opts.Type,
-		Genres:           pq.StringArray(opts.Genres),
-		ChapterCount:     opts.ChapterCount,
-		Author:           opts.Author,
-		Artist:           opts.Artist,
-		Description:      opts.Description,
-		AltTitles:        pq.StringArray(opts.AltTitles),
-		Rating:           opts.Rating,
-		ReleaseYear:      opts.ReleaseYear,
-		SourceURL:        opts.SourceURL,
-		ExternalCoverURL: opts.ExternalCoverURL,
-		LocalCoverPath:   opts.LocalCoverPath,
-		CreatedAt:        now,
-		UpdatedAt:        now,
+		ID:           uuid.New(),
+		Source:       opts.Source,
+		Slug:         opts.Slug,
+		Title:        opts.Title,
+		Status:       pgmodels.ComicStatusFromDomain(opts.Status),
+		ComicType:    pgmodels.ComicTypeFromDomain(opts.Type),
+		Genres:       pq.StringArray(opts.Genres),
+		ChapterCount: opts.ChapterCount,
+		Author:       opts.Author,
+		Artist:       opts.Artist,
+		Description:  opts.Description,
+		AltTitles:    pq.StringArray(opts.AltTitles),
+		CoverPath:    opts.CoverPath,
+		CreatedAt:    now,
+		UpdatedAt:    now,
 	}
 
 	err := r.db(ctx).Create(ctx, model)
@@ -113,31 +109,35 @@ func (r *PGComicsRepository) Create(ctx context.Context, opts comics.CreateComic
 		return nil, fmt.Errorf("r.db(ctx).Create: %w", err)
 	}
 
-	ret := r.modelToDomain(*model)
+	ret := model.Domain()
 
 	return &ret, nil
 }
 
-func (r *PGComicsRepository) modelToDomain(model pgmodels.Comic) comics.Comic {
-	return comics.Comic{
-		ID:               model.ID,
-		Source:           model.Source,
-		Slug:             model.Slug,
-		Title:            model.Title,
-		Status:           model.Status,
-		Type:             model.ComicType,
-		Genres:           model.Genres,
-		ChapterCount:     model.ChapterCount,
-		Author:           model.Author,
-		Artist:           model.Artist,
-		Description:      model.Description,
-		AltTitles:        model.AltTitles,
-		Rating:           model.Rating,
-		ReleaseYear:      model.ReleaseYear,
-		SourceURL:        model.SourceURL,
-		ExternalCoverURL: model.ExternalCoverURL,
-		LocalCoverPath:   model.LocalCoverPath,
-		CreatedAt:        model.CreatedAt,
-		UpdatedAt:        model.UpdatedAt,
+// nolint:lll
+func (r *PGComicsRepository) GetBySlugsAndSource(ctx context.Context, source string, slugs []string) ([]comics.Comic, error) {
+	models, err := r.db(ctx).Where("source = ? AND slug IN (?)", source, slugs).Find(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
 	}
+
+	ret := make([]comics.Comic, len(models))
+	for i, model := range models {
+		ret[i] = model.Domain()
+	}
+
+	return ret, nil
+}
+
+func (r *PGComicsRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	affected, err := r.db(ctx).Where("id = ?", id).Delete(ctx)
+	if err != nil {
+		return fmt.Errorf("r.db(ctx).Where: %w", err)
+	}
+
+	if affected == 0 {
+		return domain.ErrNotFound
+	}
+
+	return nil
 }

--- a/api/pkg/core/comics/repository/pg/repository.go
+++ b/api/pkg/core/comics/repository/pg/repository.go
@@ -53,7 +53,7 @@ func (r *PGComicsRepository) db(ctx context.Context) gorm.Interface[pgmodels.Com
 
 func (r *PGComicsRepository) GetByID(ctx context.Context, opts comics.GetByIDOpts) (*comics.Comic, error) {
 	model, err := r.db(ctx).
-		Joins(clause.JoinTarget{Association: "LibraryEntries"}, nil).
+		Joins(clause.JoinTarget{Association: pgmodels.ComicLibraryEntries}, nil).
 		Where("comics.id = ? AND library_entries.user_id = ?", opts.ID, opts.UserID).
 		First(ctx)
 
@@ -70,9 +70,10 @@ func (r *PGComicsRepository) GetByID(ctx context.Context, opts comics.GetByIDOpt
 	return &ret, nil
 }
 
+//nolint:lll
 func (r *PGComicsRepository) GetBySourceSlug(ctx context.Context, opts comics.GetBySourceSlugOpts) (*comics.Comic, error) {
 	model, err := r.db(ctx).
-		Joins(clause.JoinTarget{Association: "LibraryEntries"}, nil).
+		Joins(clause.JoinTarget{Association: pgmodels.ComicLibraryEntries}, nil).
 		Where("comics.slug = ? AND comics.source = ? AND library_entries.user_id = ?", opts.Slug, opts.Source, opts.UserID).
 		First(ctx)
 	if err != nil {
@@ -123,7 +124,7 @@ func (r *PGComicsRepository) Create(ctx context.Context, opts comics.CreateComic
 }
 
 func (r *PGComicsRepository) GetMany(ctx context.Context, opts comics.GetManyOpts) ([]comics.Comic, error) {
-	q := r.db(ctx).Joins(clause.JoinTarget{Association: "LibraryEntries"}, nil).Order("comics.created_at DESC")
+	q := r.db(ctx).Joins(clause.JoinTarget{Association: pgmodels.ComicLibraryEntries}, nil).Order("comics.created_at DESC")
 	if opts.UserID != nil {
 		q = q.Where("library_entries.user_id = ?", opts.UserID)
 	}

--- a/api/pkg/core/comics/repository/pg/repository_test.go
+++ b/api/pkg/core/comics/repository/pg/repository_test.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//nolint:goconst
 package pg_test
 
 import (

--- a/api/pkg/core/comics/repository/pg/repository_test.go
+++ b/api/pkg/core/comics/repository/pg/repository_test.go
@@ -174,8 +174,6 @@ func TestCreate(t *testing.T) {
 		Artist:       "Dubu",
 		Description:  "desc",
 		AltTitles:    []string{"Na Honjaman Level Up"},
-		Rating:       9.5,
-		ReleaseYear:  2018,
 	})
 	if err != nil {
 		t.Fatalf("Create: %v", err)

--- a/api/pkg/core/comics/repository/pg/repository_test.go
+++ b/api/pkg/core/comics/repository/pg/repository_test.go
@@ -15,14 +15,15 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics/repository/pg"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/repository/pgtest"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
 )
 
 const (
-	comicSource = "asurascans"
+	comicSource = sources.SourceAsuraScans
 	comicSlug   = "solo-leveling"
 	comicTitle  = "Solo Leveling"
-	comicStatus = "completed"
-	comicType   = "manhwa"
+	comicStatus = sources.SeriesStatusCompleted
+	comicType   = sources.SeriesTypeManhwa
 )
 
 func duplicateComicKeyErr() error {
@@ -68,25 +69,25 @@ func TestGetByID(t *testing.T) {
 	r, mock := newComicsRepo(t)
 
 	id := uuid.New()
+	userID := uuid.New()
 	created := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
 	updated := time.Now().UTC().Truncate(time.Second)
 
-	mock.ExpectQuery(`SELECT \* FROM "comics" WHERE id = \$1`).
-		WithArgs(id, 1).
+	mock.ExpectQuery(`FROM "comics".*comics.id = \$1 AND library_entries.user_id = \$2`).
+		WithArgs(id, userID, 1).
 		WillReturnRows(
 			sqlmock.NewRows([]string{
 				"id", "source", "slug", "title", "status", "comic_type",
-				"chapter_count", "author", "artist", "description", "rating", "release_year",
-				"source_url", "external_cover_url", "local_cover_path", "created_at", "updated_at",
+				"chapter_count", "author", "artist", "description",
+				"genres", "alt_titles", "created_at", "updated_at",
 			}).AddRow(
-				id, comicSource, comicSlug, comicTitle, comicStatus, comicType,
-				200, "Chugong", "Dubu", "desc", 9.5, 2018,
-				"https://api.asurascans.com/series/solo-leveling", "https://cover.example/cover.webp",
-				"covers/solo-leveling.webp", created, updated,
+				id, string(comicSource), comicSlug, comicTitle, string(comicStatus), string(comicType),
+				200, "Chugong", "Dubu", "desc",
+				"{}", "{}", created, updated,
 			),
 		)
 
-	got, err := r.GetByID(context.Background(), id)
+	got, err := r.GetByID(context.Background(), comics.GetByIDOpts{ID: id, UserID: userID})
 	if err != nil {
 		t.Fatalf("GetByID: %v", err)
 	}
@@ -101,10 +102,13 @@ func TestGetByIDNotFound(t *testing.T) {
 
 	r, mock := newComicsRepo(t)
 
-	mock.ExpectQuery(`SELECT \* FROM "comics"`).
+	userID := uuid.New()
+
+	mock.ExpectQuery(`FROM "comics".*comics.id = \$1 AND library_entries.user_id = \$2`).
+		WithArgs(sqlmock.AnyArg(), userID, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}))
 
-	got, err := r.GetByID(context.Background(), uuid.New())
+	got, err := r.GetByID(context.Background(), comics.GetByIDOpts{ID: uuid.New(), UserID: userID})
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Errorf("GetByID = %v, want domain.ErrNotFound", err)
 	}
@@ -120,24 +124,28 @@ func TestGetBySourceSlug(t *testing.T) {
 	r, mock := newComicsRepo(t)
 
 	id := uuid.New()
+	userID := uuid.New()
 	created := time.Now().UTC().Truncate(time.Second)
 	updated := created
 
-	mock.ExpectQuery(`SELECT \* FROM "comics" WHERE source = \$1 AND slug = \$2`).
-		WithArgs(comicSource, comicSlug, 1).
+	mock.ExpectQuery(
+		`FROM "comics".*comics.slug = \$1 AND comics.source = \$2 AND library_entries.user_id = \$3`,
+	).
+		WithArgs(comicSlug, string(comicSource), userID, 1).
 		WillReturnRows(
 			sqlmock.NewRows([]string{
 				"id", "source", "slug", "title", "status", "comic_type",
-				"chapter_count", "author", "artist", "description", "rating", "release_year",
-				"source_url", "external_cover_url", "local_cover_path", "created_at", "updated_at",
+				"chapter_count", "author", "artist", "description",
+				"genres", "alt_titles", "created_at", "updated_at",
 			}).AddRow(
-				id, comicSource, comicSlug, comicTitle, comicStatus, comicType,
-				200, "Chugong", "Dubu", "desc", 9.5, 2018,
-				"", "", "", created, updated,
+				id, string(comicSource), comicSlug, comicTitle, string(comicStatus), string(comicType),
+				200, "Chugong", "Dubu", "desc",
+				"{}", "{}", created, updated,
 			),
 		)
 
-	got, err := r.GetBySourceSlug(context.Background(), comics.SourceSlugKey{
+	got, err := r.GetBySourceSlug(context.Background(), comics.GetBySourceSlugOpts{
+		UserID: userID,
 		Source: comicSource,
 		Slug:   comicSlug,
 	})
@@ -188,29 +196,103 @@ func TestCreate(t *testing.T) {
 	}
 
 	if got.CreatedAt.Before(before) || got.UpdatedAt.Before(before) {
-		t.Errorf("timestamps not set: created=%v updated=%v", got.CreatedAt, got.UpdatedAt)
+		t.Errorf("Create timestamps too early: created=%v updated=%v", got.CreatedAt, got.UpdatedAt)
 	}
 }
 
-func TestCreateDuplicateKey(t *testing.T) {
+func TestCreateDuplicate(t *testing.T) {
 	t.Parallel()
 
 	r, mock := newComicsRepo(t)
 
 	mock.ExpectBegin()
-	mock.ExpectQuery(`INSERT INTO "comics"`).WillReturnError(duplicateComicKeyErr())
+	mock.ExpectQuery(`INSERT INTO "comics"`).
+		WillReturnError(duplicateComicKeyErr())
 	mock.ExpectRollback()
 
-	got, err := r.Create(context.Background(), comics.CreateComicOpts{
+	_, err := r.Create(context.Background(), comics.CreateComicOpts{
 		Source: comicSource,
 		Slug:   comicSlug,
 		Title:  comicTitle,
+		Status: comicStatus,
+		Type:   comicType,
 	})
 	if !errors.Is(err, domain.ErrAlreadyExists) {
 		t.Errorf("Create = %v, want domain.ErrAlreadyExists", err)
 	}
+}
 
-	if got != nil {
-		t.Errorf("Create returned %+v in addition to the error", got)
+func TestGetMany(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newComicsRepo(t)
+
+	userID := uuid.New()
+	id := uuid.New()
+	created := time.Now().UTC().Truncate(time.Second)
+	updated := created
+
+	mock.ExpectQuery(`FROM "comics".*library_entries.user_id = \$1`).
+		WithArgs(userID, 10).
+		WillReturnRows(
+			sqlmock.NewRows([]string{
+				"id", "source", "slug", "title", "status", "comic_type",
+				"chapter_count", "author", "artist", "description",
+				"genres", "alt_titles", "created_at", "updated_at",
+			}).AddRow(
+				id, string(comicSource), comicSlug, comicTitle, string(comicStatus), string(comicType),
+				200, "Chugong", "Dubu", "desc",
+				"{}", "{}", created, updated,
+			),
+		)
+
+	got, err := r.GetMany(context.Background(), comics.GetManyOpts{
+		UserID: &userID,
+		Limit:  10,
+	})
+	if err != nil {
+		t.Fatalf("GetMany: %v", err)
+	}
+
+	if len(got) != 1 || got[0].ID != id {
+		t.Errorf("GetMany() = %+v", got)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newComicsRepo(t)
+
+	id := uuid.New()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`DELETE FROM "comics" WHERE id = \$1`).
+		WithArgs(id).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	err := r.Delete(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}
+
+func TestDeleteNotFound(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newComicsRepo(t)
+
+	id := uuid.New()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`DELETE FROM "comics" WHERE id = \$1`).
+		WithArgs(id).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	err := r.Delete(context.Background(), id)
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("Delete = %v, want domain.ErrNotFound", err)
 	}
 }

--- a/api/pkg/core/comics/service.go
+++ b/api/pkg/core/comics/service.go
@@ -63,11 +63,7 @@ func NewService(deps Deps) (*Service, error) {
 func (s *Service) Create(ctx context.Context, opts CreateOpts) (*Comic, error) {
 	var comic *Comic
 
-	comic, err := s.deps.ComicsRepository.GetBySourceSlug(ctx, GetBySourceSlugOpts{
-		UserID: opts.UserID,
-		Slug:   opts.Slug,
-		Source: opts.Source,
-	})
+	comic, err := s.deps.ComicsRepository.GetBySourceSlug(ctx, GetBySourceSlugOpts(opts))
 
 	if err == nil {
 		return comic, nil
@@ -120,6 +116,10 @@ func (s *Service) Create(ctx context.Context, opts CreateOpts) (*Comic, error) {
 		return nil
 	})
 
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.Transactor.WithinTx: %w", err)
+	}
+
 	return comic, nil
 }
 
@@ -159,5 +159,6 @@ func (s *Service) Delete(ctx context.Context, opts DeleteOpts) error {
 		return nil
 	})
 
+	//nolint:wrapcheck
 	return err
 }

--- a/api/pkg/core/comics/service.go
+++ b/api/pkg/core/comics/service.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package comics
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/library"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/transaction"
+)
+
+var _ ComicsService = (*Service)(nil)
+
+type Deps struct {
+	ComicsRepository  ComicsRepository
+	Transactor        transaction.Transactor
+	LibraryRepository library.LibraryRepository
+	Sources           sources.SourceMap
+}
+
+func (deps *Deps) Validate() error {
+	if deps.ComicsRepository == nil {
+		return errors.New("comics repository is required")
+	}
+
+	if deps.Transactor == nil {
+		return errors.New("transactor is required")
+	}
+
+	if deps.LibraryRepository == nil {
+		return errors.New("library repository is required")
+	}
+
+	if deps.Sources == nil {
+		return errors.New("sources is required")
+	}
+
+	for _, source := range deps.Sources {
+		if source == nil {
+			return errors.New("source is required")
+		}
+	}
+
+	return nil
+}
+
+type Service struct {
+	deps Deps
+}
+
+func NewService(deps Deps) (*Service, error) {
+	if err := deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	return &Service{deps: deps}, nil
+}
+
+func (s *Service) Create(ctx context.Context, opts CreateOpts) (*Comic, error) {
+	var comic *Comic
+
+	comic, err := s.deps.ComicsRepository.GetBySourceSlug(ctx, GetBySourceSlugOpts{
+		UserID: opts.UserID,
+		Slug:   opts.Slug,
+		Source: opts.Source,
+	})
+
+	if err == nil {
+		return comic, nil
+	}
+
+	if !errors.Is(err, domain.ErrNotFound) {
+		return nil, fmt.Errorf("s.deps.ComicsRepository.GetBySourceSlug: %w", err)
+	}
+
+	var item *sources.GetInfosBySlugResponse
+
+	src, ok := s.deps.Sources[opts.Source]
+	if !ok {
+		return nil, fmt.Errorf("source %s not found", opts.Source)
+	}
+
+	item, err = src.GetInfosBySlug(ctx, opts.Slug)
+	if err != nil {
+		return nil, fmt.Errorf("src.GetInfosBySlug: %w", err)
+	}
+
+	err = s.deps.Transactor.WithinTx(ctx, transaction.TxOpts{}, func(ctx context.Context) error {
+		created, err := s.deps.ComicsRepository.Create(ctx, CreateComicOpts{
+			Status:       item.Status,
+			Type:         item.Type,
+			Description:  item.Description,
+			Source:       opts.Source,
+			Artist:       item.Artist,
+			Slug:         item.Slug,
+			Author:       item.Author,
+			Title:        item.Title,
+			AltTitles:    item.AltTitles,
+			Genres:       item.Genres,
+			ChapterCount: item.ChapterCount,
+		})
+		if err != nil {
+			return fmt.Errorf("s.deps.ComicsRepository.Create: %w", err)
+		}
+
+		_, err = s.deps.LibraryRepository.Create(ctx, library.CreateOpts{
+			UserID:  opts.UserID,
+			ComicID: created.ID,
+		})
+		if err != nil {
+			return fmt.Errorf("s.deps.LibraryRepository.Create: %w", err)
+		}
+
+		comic = created
+
+		return nil
+	})
+
+	return comic, nil
+}
+
+func (s *Service) GetByID(ctx context.Context, opts GetByIDOpts) (*Comic, error) {
+	comic, err := s.deps.ComicsRepository.GetByID(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.ComicsRepository.GetByID: %w", err)
+	}
+
+	return comic, nil
+}
+
+func (s *Service) GetMany(ctx context.Context, opts GetManyOpts) ([]Comic, error) {
+	comics, err := s.deps.ComicsRepository.GetMany(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.ComicsRepository.GetMany: %w", err)
+	}
+
+	return comics, nil
+}
+
+func (s *Service) Delete(ctx context.Context, opts DeleteOpts) error {
+	err := s.deps.Transactor.WithinTx(ctx, transaction.TxOpts{}, func(ctx context.Context) error {
+		err := s.deps.LibraryRepository.Delete(ctx, library.DeleteOpts{
+			UserID:  opts.UserID,
+			ComicID: opts.ID,
+		})
+		if err != nil && errors.Is(err, domain.ErrNotFound) {
+			return fmt.Errorf("s.deps.LibraryRepository.Delete: %w", err)
+		}
+
+		err = s.deps.ComicsRepository.Delete(ctx, opts.ID)
+		if err != nil && !errors.Is(err, domain.ErrNotFound) {
+			return fmt.Errorf("s.deps.ComicsRepository.Delete: %w", err)
+		}
+
+		return nil
+	})
+
+	return err
+}

--- a/api/pkg/core/comics/service_test.go
+++ b/api/pkg/core/comics/service_test.go
@@ -21,8 +21,8 @@ const (
 )
 
 type fakeTransactor struct {
-	calls int
 	err   error
+	calls int
 }
 
 func (f *fakeTransactor) WithinTx(ctx context.Context, _ transaction.TxOpts, fn func(context.Context) error) error {
@@ -36,23 +36,22 @@ func (f *fakeTransactor) WithinTx(ctx context.Context, _ transaction.TxOpts, fn 
 }
 
 type fakeComicsRepository struct {
-	getBySourceSlugResult *comics.Comic
-	getBySourceSlugErr    error
-	createResult          *comics.Comic
-	createErr             error
-	getByIDResult         *comics.Comic
 	getByIDErr            error
-	getManyResult         []comics.Comic
-	getManyErr            error
+	getBySourceSlugErr    error
 	deleteErr             error
-
-	getBySourceSlugCalls int
-	createCalls          int
-	getByIDCalls         int
-	getManyCalls         int
-	deleteCalls          int
-	lastCreateOpts       comics.CreateComicOpts
-	lastDeleteID         uuid.UUID
+	createErr             error
+	getManyErr            error
+	getByIDResult         *comics.Comic
+	getBySourceSlugResult *comics.Comic
+	createResult          *comics.Comic
+	getManyResult         []comics.Comic
+	lastCreateOpts        comics.CreateComicOpts
+	getBySourceSlugCalls  int
+	createCalls           int
+	getByIDCalls          int
+	getManyCalls          int
+	deleteCalls           int
+	lastDeleteID          uuid.UUID
 }
 
 func (f *fakeComicsRepository) GetByID(_ context.Context, _ comics.GetByIDOpts) (*comics.Comic, error) {
@@ -89,6 +88,7 @@ func (f *fakeComicsRepository) Create(_ context.Context, opts comics.CreateComic
 	}, nil
 }
 
+//nolint:lll
 func (f *fakeComicsRepository) GetBySlugsAndSource(context.Context, sources.SourceName, []string) ([]comics.Comic, error) {
 	panic("GetBySlugsAndSource must not be called by the comics service")
 }
@@ -138,10 +138,10 @@ func (f *fakeLibraryRepository) Delete(_ context.Context, opts library.DeleteOpt
 }
 
 type fakeSource struct {
-	infos    *sources.GetInfosBySlugResponse
 	err      error
-	calls    int
+	infos    *sources.GetInfosBySlugResponse
 	lastSlug string
+	calls    int
 }
 
 func (f *fakeSource) GetInfosBySlug(_ context.Context, slug string) (*sources.GetInfosBySlugResponse, error) {

--- a/api/pkg/core/comics/service_test.go
+++ b/api/pkg/core/comics/service_test.go
@@ -1,0 +1,468 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package comics_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/library"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/transaction"
+)
+
+const (
+	testSlug   = "solo-leveling"
+	testSource = sources.SourceAsuraScans
+)
+
+type fakeTransactor struct {
+	calls int
+	err   error
+}
+
+func (f *fakeTransactor) WithinTx(ctx context.Context, _ transaction.TxOpts, fn func(context.Context) error) error {
+	f.calls++
+
+	if err := fn(ctx); err != nil {
+		return err
+	}
+
+	return f.err
+}
+
+type fakeComicsRepository struct {
+	getBySourceSlugResult *comics.Comic
+	getBySourceSlugErr    error
+	createResult          *comics.Comic
+	createErr             error
+	getByIDResult         *comics.Comic
+	getByIDErr            error
+	getManyResult         []comics.Comic
+	getManyErr            error
+	deleteErr             error
+
+	getBySourceSlugCalls int
+	createCalls          int
+	getByIDCalls         int
+	getManyCalls         int
+	deleteCalls          int
+	lastCreateOpts       comics.CreateComicOpts
+	lastDeleteID         uuid.UUID
+}
+
+func (f *fakeComicsRepository) GetByID(_ context.Context, _ comics.GetByIDOpts) (*comics.Comic, error) {
+	f.getByIDCalls++
+
+	return f.getByIDResult, f.getByIDErr
+}
+
+func (f *fakeComicsRepository) GetBySourceSlug(_ context.Context, _ comics.GetBySourceSlugOpts) (*comics.Comic, error) {
+	f.getBySourceSlugCalls++
+
+	return f.getBySourceSlugResult, f.getBySourceSlugErr
+}
+
+func (f *fakeComicsRepository) Create(_ context.Context, opts comics.CreateComicOpts) (*comics.Comic, error) {
+	f.createCalls++
+	f.lastCreateOpts = opts
+
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+
+	if f.createResult != nil {
+		return f.createResult, nil
+	}
+
+	return &comics.Comic{
+		ID:     uuid.New(),
+		Slug:   opts.Slug,
+		Source: opts.Source,
+		Title:  opts.Title,
+		Type:   opts.Type,
+		Status: opts.Status,
+	}, nil
+}
+
+func (f *fakeComicsRepository) GetBySlugsAndSource(context.Context, sources.SourceName, []string) ([]comics.Comic, error) {
+	panic("GetBySlugsAndSource must not be called by the comics service")
+}
+
+func (f *fakeComicsRepository) Delete(_ context.Context, id uuid.UUID) error {
+	f.deleteCalls++
+	f.lastDeleteID = id
+
+	return f.deleteErr
+}
+
+func (f *fakeComicsRepository) GetMany(_ context.Context, _ comics.GetManyOpts) ([]comics.Comic, error) {
+	f.getManyCalls++
+
+	return f.getManyResult, f.getManyErr
+}
+
+type fakeLibraryRepository struct {
+	createErr   error
+	deleteErr   error
+	createCalls int
+	deleteCalls int
+	lastCreate  library.CreateOpts
+	lastDelete  library.DeleteOpts
+}
+
+func (f *fakeLibraryRepository) Create(_ context.Context, opts library.CreateOpts) (*library.Entry, error) {
+	f.createCalls++
+	f.lastCreate = opts
+
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+
+	return &library.Entry{
+		ID:      uuid.New(),
+		UserID:  opts.UserID,
+		ComicID: opts.ComicID,
+	}, nil
+}
+
+func (f *fakeLibraryRepository) Delete(_ context.Context, opts library.DeleteOpts) error {
+	f.deleteCalls++
+	f.lastDelete = opts
+
+	return f.deleteErr
+}
+
+type fakeSource struct {
+	infos    *sources.GetInfosBySlugResponse
+	err      error
+	calls    int
+	lastSlug string
+}
+
+func (f *fakeSource) GetInfosBySlug(_ context.Context, slug string) (*sources.GetInfosBySlugResponse, error) {
+	f.calls++
+	f.lastSlug = slug
+
+	if f.err != nil {
+		return nil, f.err
+	}
+
+	return f.infos, nil
+}
+
+func validServiceDeps() comics.Deps {
+	return comics.Deps{
+		ComicsRepository:  &fakeComicsRepository{},
+		LibraryRepository: &fakeLibraryRepository{},
+		Transactor:        &fakeTransactor{},
+		Sources: sources.SourceMap{
+			testSource: &fakeSource{
+				infos: &sources.GetInfosBySlugResponse{
+					Slug:         testSlug,
+					Title:        "Solo Leveling",
+					Status:       sources.SeriesStatusCompleted,
+					Type:         sources.SeriesTypeManhwa,
+					ChapterCount: 200,
+				},
+			},
+		},
+	}
+}
+
+func TestNewServiceRejectsMissingDeps(t *testing.T) {
+	t.Parallel()
+
+	svc, err := comics.NewService(comics.Deps{})
+	if err == nil {
+		t.Fatal("NewService without deps must fail")
+	}
+
+	if svc != nil {
+		t.Errorf("NewService returned a service (%v) in addition to the error", svc)
+	}
+
+	if got := err.Error(); got != "deps.Validate: comics repository is required" {
+		t.Errorf("err = %q, want %q", got, "deps.Validate: comics repository is required")
+	}
+}
+
+func TestCreateReturnsExistingComic(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	existing := &comics.Comic{ID: uuid.New(), Slug: testSlug, Source: testSource}
+
+	comicsRepo := &fakeComicsRepository{
+		getBySourceSlugResult: existing,
+	}
+	source := &fakeSource{}
+	deps := validServiceDeps()
+	deps.ComicsRepository = comicsRepo
+	deps.Sources = sources.SourceMap{testSource: source}
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	got, err := svc.Create(context.Background(), comics.CreateOpts{
+		UserID: userID,
+		Source: testSource,
+		Slug:   testSlug,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if got != existing {
+		t.Errorf("Create() = %+v, want existing comic %+v", got, existing)
+	}
+
+	if comicsRepo.getBySourceSlugCalls != 1 {
+		t.Errorf("GetBySourceSlug called %d times, want 1", comicsRepo.getBySourceSlugCalls)
+	}
+
+	if source.calls != 0 {
+		t.Errorf("source.GetInfosBySlug called %d times, want 0", source.calls)
+	}
+}
+
+func TestCreateFetchesSourceAndPersistsLibraryEntry(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	comicsRepo := &fakeComicsRepository{getBySourceSlugErr: domain.ErrNotFound}
+	libraryRepo := &fakeLibraryRepository{}
+	tx := &fakeTransactor{}
+	source := &fakeSource{
+		infos: &sources.GetInfosBySlugResponse{
+			Slug:         testSlug,
+			Title:        "Solo Leveling",
+			Status:       sources.SeriesStatusCompleted,
+			Type:         sources.SeriesTypeManhwa,
+			ChapterCount: 200,
+			Author:       "Chugong",
+		},
+	}
+
+	deps := validServiceDeps()
+	deps.ComicsRepository = comicsRepo
+	deps.LibraryRepository = libraryRepo
+	deps.Transactor = tx
+	deps.Sources = sources.SourceMap{testSource: source}
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	got, err := svc.Create(context.Background(), comics.CreateOpts{
+		UserID: userID,
+		Source: testSource,
+		Slug:   testSlug,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if got.Slug != testSlug || got.Source != testSource {
+		t.Errorf("Create() = %+v", got)
+	}
+
+	if tx.calls != 1 {
+		t.Errorf("WithinTx called %d times, want 1", tx.calls)
+	}
+
+	if comicsRepo.createCalls != 1 {
+		t.Errorf("ComicsRepository.Create called %d times, want 1", comicsRepo.createCalls)
+	}
+
+	if comicsRepo.lastCreateOpts.Slug != testSlug || comicsRepo.lastCreateOpts.Author != "Chugong" {
+		t.Errorf("CreateComicOpts = %+v", comicsRepo.lastCreateOpts)
+	}
+
+	if libraryRepo.createCalls != 1 {
+		t.Errorf("LibraryRepository.Create called %d times, want 1", libraryRepo.createCalls)
+	}
+
+	if libraryRepo.lastCreate.UserID != userID || libraryRepo.lastCreate.ComicID != got.ID {
+		t.Errorf("library CreateOpts = %+v, comic ID = %s", libraryRepo.lastCreate, got.ID)
+	}
+
+	if source.lastSlug != testSlug {
+		t.Errorf("source slug = %q, want %q", source.lastSlug, testSlug)
+	}
+}
+
+func TestCreateUnknownSource(t *testing.T) {
+	t.Parallel()
+
+	deps := validServiceDeps()
+	deps.ComicsRepository = &fakeComicsRepository{getBySourceSlugErr: domain.ErrNotFound}
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	_, err = svc.Create(context.Background(), comics.CreateOpts{
+		UserID: uuid.New(),
+		Source: "unknown",
+		Slug:   testSlug,
+	})
+	if err == nil {
+		t.Fatal("Create with unknown source must fail")
+	}
+
+	if want := "source unknown not found"; err.Error() != want {
+		t.Errorf("err = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestCreatePropagatesSourceError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("upstream unavailable")
+	source := &fakeSource{err: sentinel}
+	deps := validServiceDeps()
+	deps.ComicsRepository = &fakeComicsRepository{getBySourceSlugErr: domain.ErrNotFound}
+	deps.Sources = sources.SourceMap{testSource: source}
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	_, err = svc.Create(context.Background(), comics.CreateOpts{
+		UserID: uuid.New(),
+		Source: testSource,
+		Slug:   testSlug,
+	})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("Create = %v, original error no longer reachable", err)
+	}
+}
+
+func TestGetByIDDelegatesToRepository(t *testing.T) {
+	t.Parallel()
+
+	comic := &comics.Comic{ID: uuid.New()}
+	repo := &fakeComicsRepository{getByIDResult: comic}
+	deps := validServiceDeps()
+	deps.ComicsRepository = repo
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	got, err := svc.GetByID(context.Background(), comics.GetByIDOpts{
+		UserID: uuid.New(),
+		ID:     comic.ID,
+	})
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+
+	if got != comic {
+		t.Errorf("GetByID() = %+v, want %+v", got, comic)
+	}
+
+	if repo.getByIDCalls != 1 {
+		t.Errorf("GetByID called %d times, want 1", repo.getByIDCalls)
+	}
+}
+
+func TestGetManyDelegatesToRepository(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	items := []comics.Comic{{ID: uuid.New(), Slug: testSlug}}
+	repo := &fakeComicsRepository{getManyResult: items}
+	deps := validServiceDeps()
+	deps.ComicsRepository = repo
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	got, err := svc.GetMany(context.Background(), comics.GetManyOpts{UserID: &userID})
+	if err != nil {
+		t.Fatalf("GetMany: %v", err)
+	}
+
+	if len(got) != 1 || got[0].ID != items[0].ID {
+		t.Errorf("GetMany() = %+v, want %+v", got, items)
+	}
+}
+
+func TestDeleteRemovesLibraryEntryAndComic(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	comicID := uuid.New()
+	comicsRepo := &fakeComicsRepository{}
+	libraryRepo := &fakeLibraryRepository{}
+	tx := &fakeTransactor{}
+
+	deps := validServiceDeps()
+	deps.ComicsRepository = comicsRepo
+	deps.LibraryRepository = libraryRepo
+	deps.Transactor = tx
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	err = svc.Delete(context.Background(), comics.DeleteOpts{
+		UserID: userID,
+		ID:     comicID,
+	})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if tx.calls != 1 {
+		t.Errorf("WithinTx called %d times, want 1", tx.calls)
+	}
+
+	if libraryRepo.deleteCalls != 1 {
+		t.Errorf("LibraryRepository.Delete called %d times, want 1", libraryRepo.deleteCalls)
+	}
+
+	if libraryRepo.lastDelete.UserID != userID || libraryRepo.lastDelete.ComicID != comicID {
+		t.Errorf("library DeleteOpts = %+v", libraryRepo.lastDelete)
+	}
+
+	if comicsRepo.deleteCalls != 1 || comicsRepo.lastDeleteID != comicID {
+		t.Errorf("ComicsRepository.Delete comic ID = %s, want %s", comicsRepo.lastDeleteID, comicID)
+	}
+}
+
+func TestDeleteReturnsWhenLibraryEntryMissing(t *testing.T) {
+	t.Parallel()
+
+	deps := validServiceDeps()
+	deps.LibraryRepository = &fakeLibraryRepository{deleteErr: domain.ErrNotFound}
+	deps.ComicsRepository = &fakeComicsRepository{}
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	err = svc.Delete(context.Background(), comics.DeleteOpts{
+		UserID: uuid.New(),
+		ID:     uuid.New(),
+	})
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("Delete = %v, want domain.ErrNotFound", err)
+	}
+}

--- a/api/pkg/core/covers/source/asurascans/resolver.go
+++ b/api/pkg/core/covers/source/asurascans/resolver.go
@@ -11,13 +11,14 @@ import (
 	"net/http"
 
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
 	asuradomain "github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/domain"
 )
 
 const DefaultCDNBaseURL = "https://gg.asuracomic.net"
 
 type InfosBySlugGetter interface {
-	GetInfosBySlug(context.Context, string) (*asuradomain.GetInfosBySlugResponse, error)
+	GetInfosBySlug(context.Context, string) (*sources.GetInfosBySlugResponse, error)
 }
 
 type Config struct {

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -23,14 +23,18 @@ import (
 	httpoidcproviders "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
 	sessionshttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
+	httpcomics "github.com/kharente-deuh/uchiyomi-server/pkg/core/comics/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
 	httpcovers "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/gateway/http"
 	coversasura "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/source/asurascans"
+	coredomain "github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	healthhttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/health/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/setup"
 	httpsetup "github.com/kharente-deuh/uchiyomi-server/pkg/core/setup/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/users"
 	httpusers "github.com/kharente-deuh/uchiyomi-server/pkg/core/users/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
 	asura "github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/core"
 	asuradomain "github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/domain"
 	httasura "github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/gateway/http"
@@ -248,6 +252,54 @@ func (fakeOIDCProvidersService) Probe(context.Context, string) (*oidcproviders.P
 	return nil, errors.New(notImplemented)
 }
 
+type stubComicsRepository struct{}
+
+func (stubComicsRepository) GetByID(context.Context, comics.GetByIDOpts) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (stubComicsRepository) GetBySourceSlug(
+	context.Context, comics.GetBySourceSlugOpts,
+) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (stubComicsRepository) Create(context.Context, comics.CreateComicOpts) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (stubComicsRepository) GetBySlugsAndSource(
+	context.Context, sources.SourceName, []string,
+) ([]comics.Comic, error) {
+	return nil, nil
+}
+
+func (stubComicsRepository) Delete(context.Context, uuid.UUID) error {
+	return coredomain.ErrNotFound
+}
+
+func (stubComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]comics.Comic, error) {
+	return nil, nil
+}
+
+type fakeComicsService struct{}
+
+func (fakeComicsService) Create(context.Context, comics.CreateOpts) (*comics.Comic, error) {
+	return nil, errors.New(notImplemented)
+}
+
+func (fakeComicsService) GetByID(context.Context, comics.GetByIDOpts) (*comics.Comic, error) {
+	return nil, errors.New(notImplemented)
+}
+
+func (fakeComicsService) GetMany(context.Context, comics.GetManyOpts) ([]comics.Comic, error) {
+	return nil, errors.New(notImplemented)
+}
+
+func (fakeComicsService) Delete(context.Context, comics.DeleteOpts) error {
+	return errors.New(notImplemented)
+}
+
 func newTestCache[P any, T any](t *testing.T, name string, logger *slog.Logger) *fncache.Cache[P, T] {
 	t.Helper()
 
@@ -274,19 +326,25 @@ func newTestCache[P any, T any](t *testing.T, name string, logger *slog.Logger) 
 func newTestAsura(t *testing.T, logger *slog.Logger) *asura.App {
 	t.Helper()
 
-	app, err := asura.New(asura.Dependencies{
-		Logger:      logger,
-		SearchCache: newTestCache[asuradomain.SearchOpts, asuradomain.SearchResult](t, "search", logger),
-		GetInfosBySlugCache: newTestCache[string, asuradomain.GetInfosBySlugResponse](
-			t, "infos", logger,
-		),
-		GetChaptersListBySeriesCache: newTestCache[string, []asuradomain.Chapter](
-			t, "chapters", logger,
-		),
-		GetImageURLsByChapter: newTestCache[asuradomain.GetImageURLsByChapterOpts, []string](
-			t, "images", logger,
-		),
-	})
+	app, err := asura.New(
+		asura.Config{SourceName: sources.SourceAsuraScans},
+		asura.Deps{
+			Logger: logger,
+			SearchCache: newTestCache[asuradomain.SearchCacheOpts, asuradomain.SearchCacheResult](
+				t, "search", logger,
+			),
+			GetInfosBySlugCache: newTestCache[string, asuradomain.GetInfosBySlugResponse](
+				t, "infos", logger,
+			),
+			GetChaptersListBySeriesCache: newTestCache[string, []asuradomain.Chapter](
+				t, "chapters", logger,
+			),
+			GetImageURLsByChapter: newTestCache[asuradomain.GetImageURLsByChapterOpts, []string](
+				t, "images", logger,
+			),
+			ComicsRepository: stubComicsRepository{},
+		},
+	)
 	if err != nil {
 		t.Fatalf("asura.New: %v", err)
 	}
@@ -389,6 +447,14 @@ func newTestApp(t *testing.T, db Database, port int) (*App, *health.Registry) {
 		t.Fatalf("httpoidcproviders.New: %v", err)
 	}
 
+	comicsCtrl, err := httpcomics.New(
+		httpcomics.Config{Endpoint: "/comics"},
+		httpcomics.Deps{Logger: logger, ComicsService: fakeComicsService{}},
+	)
+	if err != nil {
+		t.Fatalf("httpcomics.New: %v", err)
+	}
+
 	app, err := New(
 		Config{ServerPort: port, AllowedOrigins: []string{"*"}},
 		Deps{
@@ -400,6 +466,7 @@ func newTestApp(t *testing.T, db Database, port int) (*App, *health.Registry) {
 			CoversCtrl:        coversCtrl,
 			HealthCtrl:        healthCtrl,
 			OIDCProvidersCtrl: oidcProvidersCtrl,
+			ComicsCtrl:        comicsCtrl,
 			Logger:            logger,
 			Health:            registry,
 			Asura:             asuraApp,

--- a/api/pkg/core/library/domain.go
+++ b/api/pkg/core/library/domain.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
 )
 
 type Entry struct {
@@ -17,21 +16,17 @@ type Entry struct {
 	ComicID uuid.UUID
 }
 
-type EntryWithComic struct {
-	Entry Entry
-	Comic comics.Comic
-}
-
 type LibraryRepository interface {
-	GetByID(context.Context, uuid.UUID) (*Entry, error)
-	GetByUserAndComic(context.Context, uuid.UUID, uuid.UUID) (*Entry, error)
-	ListByUser(context.Context, uuid.UUID) ([]EntryWithComic, error)
-	Create(context.Context, CreateEntryOpts) (*Entry, error)
-	Delete(context.Context, uuid.UUID) error
+	Create(context.Context, CreateOpts) (*Entry, error)
+	Delete(context.Context, DeleteOpts) error
 }
 
-type CreateEntryOpts struct {
-	AddedAt time.Time
+type CreateOpts struct {
+	UserID  uuid.UUID
+	ComicID uuid.UUID
+}
+
+type DeleteOpts struct {
 	UserID  uuid.UUID
 	ComicID uuid.UUID
 }

--- a/api/pkg/core/library/repository/pg/repository.go
+++ b/api/pkg/core/library/repository/pg/repository.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
+
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/library"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/repository/pgmodels"
@@ -49,75 +49,12 @@ func (r *PGLibraryRepository) db(ctx context.Context) gorm.Interface[pgmodels.Li
 	return gorm.G[pgmodels.LibraryEntry](pgtx.From(ctx, r.deps.DB))
 }
 
-func (r *PGLibraryRepository) GetByID(ctx context.Context, id uuid.UUID) (*library.Entry, error) {
-	model, err := r.db(ctx).Where("id = ?", id).First(ctx)
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, domain.ErrNotFound
-		}
-
-		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
-	}
-
-	ret := r.modelToDomain(model)
-
-	return &ret, nil
-}
-
-func (r *PGLibraryRepository) GetByUserAndComic(
-	ctx context.Context,
-	userID uuid.UUID,
-	comicID uuid.UUID,
-) (*library.Entry, error) {
-	model, err := r.db(ctx).Where("user_id = ? AND comic_id = ?", userID, comicID).First(ctx)
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, domain.ErrNotFound
-		}
-
-		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
-	}
-
-	ret := r.modelToDomain(model)
-
-	return &ret, nil
-}
-
-func (r *PGLibraryRepository) ListByUser(ctx context.Context, userID uuid.UUID) ([]library.EntryWithComic, error) {
-	var models []pgmodels.LibraryEntry
-
-	err := pgtx.From(ctx, r.deps.DB).
-		WithContext(ctx).
-		Preload("Comic").
-		Where("user_id = ?", userID).
-		Order("added_at DESC").
-		Find(&models).Error
-	if err != nil {
-		return nil, fmt.Errorf("pgtx.From(ctx, r.deps.DB).Find: %w", err)
-	}
-
-	ret := make([]library.EntryWithComic, 0, len(models))
-	for _, model := range models {
-		ret = append(ret, library.EntryWithComic{
-			Entry: r.modelToDomain(model),
-			Comic: r.comicModelToDomain(model.Comic),
-		})
-	}
-
-	return ret, nil
-}
-
-func (r *PGLibraryRepository) Create(ctx context.Context, opts library.CreateEntryOpts) (*library.Entry, error) {
-	addedAt := opts.AddedAt
-	if addedAt.IsZero() {
-		addedAt = time.Now()
-	}
-
+func (r *PGLibraryRepository) Create(ctx context.Context, opts library.CreateOpts) (*library.Entry, error) {
 	model := &pgmodels.LibraryEntry{
 		ID:      uuid.New(),
 		UserID:  opts.UserID,
 		ComicID: opts.ComicID,
-		AddedAt: addedAt,
+		AddedAt: time.Now(),
 	}
 
 	err := r.db(ctx).Create(ctx, model)
@@ -129,13 +66,13 @@ func (r *PGLibraryRepository) Create(ctx context.Context, opts library.CreateEnt
 		return nil, fmt.Errorf("r.db(ctx).Create: %w", err)
 	}
 
-	ret := r.modelToDomain(*model)
+	ret := model.Domain()
 
 	return &ret, nil
 }
 
-func (r *PGLibraryRepository) Delete(ctx context.Context, id uuid.UUID) error {
-	affected, err := r.db(ctx).Where("id = ?", id).Delete(ctx)
+func (r *PGLibraryRepository) Delete(ctx context.Context, opts library.DeleteOpts) error {
+	affected, err := r.db(ctx).Where("user_id = ? AND comic_id = ?", opts.UserID, opts.ComicID).Delete(ctx)
 	if err != nil {
 		return fmt.Errorf("r.db(ctx).Where: %w", err)
 	}
@@ -147,35 +84,161 @@ func (r *PGLibraryRepository) Delete(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
-func (r *PGLibraryRepository) modelToDomain(model pgmodels.LibraryEntry) library.Entry {
-	return library.Entry{
-		ID:      model.ID,
-		UserID:  model.UserID,
-		ComicID: model.ComicID,
-		AddedAt: model.AddedAt,
-	}
-}
+// func (r *PGLibraryRepository) GetByID(ctx context.Context, id uuid.UUID) (*library.Entry, error) {
+// 	model, err := r.db(ctx).Where("id = ?", id).First(ctx)
+// 	if err != nil {
+// 		if errors.Is(err, gorm.ErrRecordNotFound) {
+// 			return nil, domain.ErrNotFound
+// 		}
 
-func (r *PGLibraryRepository) comicModelToDomain(model pgmodels.Comic) comics.Comic {
-	return comics.Comic{
-		ID:               model.ID,
-		Source:           model.Source,
-		Slug:             model.Slug,
-		Title:            model.Title,
-		Status:           model.Status,
-		Type:             model.ComicType,
-		Genres:           model.Genres,
-		ChapterCount:     model.ChapterCount,
-		Author:           model.Author,
-		Artist:           model.Artist,
-		Description:      model.Description,
-		AltTitles:        model.AltTitles,
-		Rating:           model.Rating,
-		ReleaseYear:      model.ReleaseYear,
-		SourceURL:        model.SourceURL,
-		ExternalCoverURL: model.ExternalCoverURL,
-		LocalCoverPath:   model.LocalCoverPath,
-		CreatedAt:        model.CreatedAt,
-		UpdatedAt:        model.UpdatedAt,
-	}
-}
+// 		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
+// 	}
+
+// 	ret := model.Domain()
+
+// 	return &ret, nil
+// }
+
+// //nolint:lll
+// func (r *PGLibraryRepository) GetByIDByUser(ctx context.Context, opts library.GetByIDByUserOpts) (*library.Entry, error) {
+// 	model, err := r.db(ctx).Where("user_id = ? AND id = ?", opts.UserID, opts.ID).First(ctx)
+// 	if err != nil {
+// 		if errors.Is(err, gorm.ErrRecordNotFound) {
+// 			return nil, domain.ErrNotFound
+// 		}
+
+// 		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
+// 	}
+
+// 	ret := model.Domain()
+
+// 	return &ret, nil
+// }
+
+// //nolint:lll
+// func (r *PGLibraryRepository) GetBySlugByUserWithComic(ctx context.Context, opts library.GetBySlugByUserOpts) (*library.EntryWithComic, error) {
+// 	model, err := r.db(ctx).Joins(clause.JoinTarget{Association: "Comic"}, nil).Where(
+// 		"library_entries.user_id = ? AND comics.slug = ? AND comics.source = ?",
+// 		opts.UserID, opts.Slug, opts.Source,
+// 	).First(ctx)
+
+// 	if err != nil {
+// 		if errors.Is(err, gorm.ErrRecordNotFound) {
+// 			return nil, domain.ErrNotFound
+// 		}
+
+// 		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
+// 	}
+
+// 	return &library.EntryWithComic{
+// 		Entry: model.Domain(),
+// 		Comic: model.Comic.Domain(),
+// 	}, nil
+// }
+
+// func (r *PGLibraryRepository) ListByUser(ctx context.Context, userID uuid.UUID) ([]library.EntryWithComic, error) {
+// 	var models []pgmodels.LibraryEntry
+
+// 	err := pgtx.From(ctx, r.deps.DB).
+// 		WithContext(ctx).
+// 		Preload("Comic").
+// 		Where("user_id = ?", userID).
+// 		Order("added_at DESC").
+// 		Find(&models).Error
+// 	if err != nil {
+// 		return nil, fmt.Errorf("pgtx.From(ctx, r.deps.DB).Find: %w", err)
+// 	}
+
+// 	ret := make([]library.EntryWithComic, 0, len(models))
+// 	for _, model := range models {
+// 		ret = append(ret, library.EntryWithComic{
+// 			Entry: model.Domain(),
+// 			Comic: model.Comic.Domain(),
+// 		})
+// 	}
+
+// 	return ret, nil
+// }
+
+// func (r *PGLibraryRepository) Create(ctx context.Context, opts library.CreateEntryOpts) (*library.Entry, error) {
+// 	addedAt := opts.AddedAt
+// 	if addedAt.IsZero() {
+// 		addedAt = time.Now()
+// 	}
+
+// 	model := &pgmodels.LibraryEntry{
+// 		ID:      uuid.New(),
+// 		UserID:  opts.UserID,
+// 		ComicID: opts.ComicID,
+// 		AddedAt: addedAt,
+// 	}
+
+// 	err := r.db(ctx).Create(ctx, model)
+// 	if err != nil {
+// 		if errors.Is(err, gorm.ErrDuplicatedKey) {
+// 			return nil, domain.ErrAlreadyExists
+// 		}
+
+// 		return nil, fmt.Errorf("r.db(ctx).Create: %w", err)
+// 	}
+
+// 	ret := model.Domain()
+
+// 	return &ret, nil
+// }
+
+// func (r *PGLibraryRepository) Delete(ctx context.Context, id uuid.UUID) error {
+// 	affected, err := r.db(ctx).Where("id = ?", id).Delete(ctx)
+// 	if err != nil {
+// 		return fmt.Errorf("r.db(ctx).Where: %w", err)
+// 	}
+
+// 	if affected == 0 {
+// 		return domain.ErrNotFound
+// 	}
+
+// 	return nil
+// }
+
+// func (r *PGLibraryRepository) GetByComicID(ctx context.Context, comicID uuid.UUID) ([]library.Entry, error) {
+// 	models, err := r.db(ctx).Where("comic_id = ?", comicID).Find(ctx)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
+// 	}
+
+// 	ret := make([]library.Entry, 0, len(models))
+// 	for _, model := range models {
+// 		ret = append(ret, model.Domain())
+// 	}
+
+// 	return ret, nil
+// }
+
+// func (r *PGLibraryRepository) ListComics(ctx context.Context, opts library.ListEntriesOpts) ([]comics.Comic, error) {
+// 	query := r.db(ctx).Joins(clause.JoinTarget{Association: "Comic"}, nil).Where("user_id = ?", opts.UserID)
+// 	if opts.Source != nil {
+// 		query = query.Where("comic.source = ?", opts.Source)
+// 	}
+
+// 	if opts.Type != nil {
+// 		query = query.Where("comic.type = ?", opts.Type)
+// 	}
+
+// 	if opts.Status != nil {
+// 		query = query.Where("comic.status = ?", opts.Status)
+// 	}
+
+// 	query = query.Offset(opts.Offset).Limit(opts.Limit).Order("added_at DESC")
+
+// 	models, err := query.Find(ctx)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
+// 	}
+
+// 	ret := make([]comics.Comic, 0, len(models))
+// 	for _, model := range models {
+// 		ret = append(ret, model.Comic.Domain())
+// 	}
+
+// 	return ret, nil
+// }

--- a/api/pkg/core/library/repository/pg/repository_test.go
+++ b/api/pkg/core/library/repository/pg/repository_test.go
@@ -17,18 +17,6 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/repository/pgtest"
 )
 
-const (
-	libraryComicSource = "asurascans"
-	libraryComicSlug   = "solo-leveling"
-	libraryComicTitle  = "Solo Leveling"
-	libraryComicStatus = "completed"
-	libraryComicType   = "manhwa"
-)
-
-func libraryEntryCols() []string {
-	return []string{"id", "user_id", "comic_id", "added_at"}
-}
-
 func duplicateLibraryEntryKeyErr() error {
 	return &pgconn.PgError{
 		Code:    "23505",
@@ -66,61 +54,6 @@ func TestLibraryNewValidatesDeps(t *testing.T) {
 	}
 }
 
-func TestLibraryGetByID(t *testing.T) {
-	t.Parallel()
-
-	r, mock := newLibraryRepo(t)
-
-	id := uuid.New()
-	userID := uuid.New()
-	comicID := uuid.New()
-	addedAt := time.Now().UTC().Truncate(time.Second)
-
-	mock.ExpectQuery(`SELECT \* FROM "library_entries" WHERE id = \$1`).
-		WithArgs(id, 1).
-		WillReturnRows(
-			sqlmock.NewRows(libraryEntryCols()).
-				AddRow(id, userID, comicID, addedAt),
-		)
-
-	got, err := r.GetByID(context.Background(), id)
-	if err != nil {
-		t.Fatalf("GetByID: %v", err)
-	}
-
-	want := library.Entry{ID: id, UserID: userID, ComicID: comicID, AddedAt: addedAt}
-	if got == nil || *got != want {
-		t.Errorf("GetByID() = %+v, want %+v", got, want)
-	}
-}
-
-func TestLibraryGetByUserAndComic(t *testing.T) {
-	t.Parallel()
-
-	r, mock := newLibraryRepo(t)
-
-	id := uuid.New()
-	userID := uuid.New()
-	comicID := uuid.New()
-	addedAt := time.Now().UTC().Truncate(time.Second)
-
-	mock.ExpectQuery(`SELECT \* FROM "library_entries" WHERE user_id = \$1 AND comic_id = \$2`).
-		WithArgs(userID, comicID, 1).
-		WillReturnRows(
-			sqlmock.NewRows(libraryEntryCols()).
-				AddRow(id, userID, comicID, addedAt),
-		)
-
-	got, err := r.GetByUserAndComic(context.Background(), userID, comicID)
-	if err != nil {
-		t.Fatalf("GetByUserAndComic: %v", err)
-	}
-
-	if got.ComicID != comicID || got.UserID != userID {
-		t.Errorf("GetByUserAndComic() = %+v", got)
-	}
-}
-
 func TestLibraryCreate(t *testing.T) {
 	t.Parallel()
 
@@ -136,7 +69,7 @@ func TestLibraryCreate(t *testing.T) {
 
 	before := time.Now()
 
-	got, err := r.Create(context.Background(), library.CreateEntryOpts{
+	got, err := r.Create(context.Background(), library.CreateOpts{
 		UserID:  userID,
 		ComicID: comicID,
 	})
@@ -166,7 +99,7 @@ func TestLibraryCreateDuplicateKey(t *testing.T) {
 	mock.ExpectQuery(`INSERT INTO "library_entries"`).WillReturnError(duplicateLibraryEntryKeyErr())
 	mock.ExpectRollback()
 
-	got, err := r.Create(context.Background(), library.CreateEntryOpts{
+	got, err := r.Create(context.Background(), library.CreateOpts{
 		UserID:  uuid.New(),
 		ComicID: uuid.New(),
 	})
@@ -184,15 +117,19 @@ func TestLibraryDelete(t *testing.T) {
 
 	r, mock := newLibraryRepo(t)
 
-	id := uuid.New()
+	userID := uuid.New()
+	comicID := uuid.New()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(`DELETE FROM "library_entries" WHERE id = \$1`).
-		WithArgs(id).
+	mock.ExpectExec(`DELETE FROM "library_entries" WHERE user_id = \$1 AND comic_id = \$2`).
+		WithArgs(userID, comicID).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 
-	err := r.Delete(context.Background(), id)
+	err := r.Delete(context.Background(), library.DeleteOpts{
+		UserID:  userID,
+		ComicID: comicID,
+	})
 	if err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
@@ -203,63 +140,20 @@ func TestLibraryDeleteNotFound(t *testing.T) {
 
 	r, mock := newLibraryRepo(t)
 
-	id := uuid.New()
+	userID := uuid.New()
+	comicID := uuid.New()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(`DELETE FROM "library_entries" WHERE id = \$1`).
-		WithArgs(id).
+	mock.ExpectExec(`DELETE FROM "library_entries" WHERE user_id = \$1 AND comic_id = \$2`).
+		WithArgs(userID, comicID).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
-	err := r.Delete(context.Background(), id)
+	err := r.Delete(context.Background(), library.DeleteOpts{
+		UserID:  userID,
+		ComicID: comicID,
+	})
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Errorf("Delete = %v, want domain.ErrNotFound", err)
-	}
-}
-
-func TestLibraryListByUser(t *testing.T) {
-	t.Parallel()
-
-	r, mock := newLibraryRepo(t)
-
-	userID := uuid.New()
-	entryID := uuid.New()
-	comicID := uuid.New()
-	addedAt := time.Now().UTC().Truncate(time.Second)
-	created := addedAt
-	updated := addedAt
-
-	mock.ExpectQuery(`SELECT \* FROM "library_entries" WHERE user_id = \$1`).
-		WithArgs(userID).
-		WillReturnRows(
-			sqlmock.NewRows(libraryEntryCols()).
-				AddRow(entryID, userID, comicID, addedAt),
-		)
-
-	mock.ExpectQuery(`SELECT \* FROM "comics" WHERE "comics"\."id" = \$1`).
-		WithArgs(comicID).
-		WillReturnRows(
-			sqlmock.NewRows([]string{
-				"id", "source", "slug", "title", "status", "comic_type",
-				"chapter_count", "author", "artist", "description", "rating", "release_year",
-				"source_url", "external_cover_url", "local_cover_path", "created_at", "updated_at",
-			}).AddRow(
-				comicID, libraryComicSource, libraryComicSlug, libraryComicTitle, libraryComicStatus, libraryComicType,
-				200, "Chugong", "Dubu", "desc", 9.5, 2018,
-				"", "", "", created, updated,
-			),
-		)
-
-	got, err := r.ListByUser(context.Background(), userID)
-	if err != nil {
-		t.Fatalf("ListByUser: %v", err)
-	}
-
-	if len(got) != 1 {
-		t.Fatalf("ListByUser() len = %d, want 1", len(got))
-	}
-
-	if got[0].Entry.ID != entryID || got[0].Comic.ID != comicID {
-		t.Errorf("ListByUser() = %+v", got[0])
 	}
 }

--- a/api/pkg/core/users/repository/pg/repository.go
+++ b/api/pkg/core/users/repository/pg/repository.go
@@ -67,7 +67,7 @@ func (r *PGUsersRepository) GetByID(ctx context.Context, id uuid.UUID) (*users.U
 		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
 	}
 
-	ret := r.modelToDomain(user)
+	ret := user.Domain()
 
 	return &ret, nil
 }
@@ -90,7 +90,7 @@ func (r *PGUsersRepository) Create(ctx context.Context, opts users.CreateUserOpt
 		return nil, fmt.Errorf("r.db(ctx).Create: %w", err)
 	}
 
-	user := r.modelToDomain(*model)
+	user := model.Domain()
 
 	return &user, nil
 }
@@ -105,7 +105,7 @@ func (r *PGUsersRepository) GetByUsername(ctx context.Context, name string) (*us
 		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
 	}
 
-	ret := r.modelToDomain(user)
+	ret := user.Domain()
 
 	return &ret, nil
 }
@@ -125,17 +125,7 @@ func (r *PGUsersRepository) Update(ctx context.Context, opts users.UpdateUserOpt
 		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
 	}
 
-	ret := r.modelToDomain(user)
+	ret := user.Domain()
 
 	return &ret, nil
-}
-
-func (r *PGUsersRepository) modelToDomain(model pgmodels.User) users.User {
-	return users.User{
-		ID:        model.ID,
-		Name:      model.Name,
-		IsAdmin:   model.IsAdmin,
-		CreatedAt: model.CreatedAt,
-		UpdatedAt: model.UpdatedAt,
-	}
 }

--- a/api/pkg/repository/pgmodels/comic.go
+++ b/api/pkg/repository/pgmodels/comic.go
@@ -7,24 +7,24 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
 	"github.com/lib/pq"
 )
 
 type Comic struct {
-	CreatedAt      time.Time      `gorm:"autoCreateTime"`
-	UpdatedAt      time.Time      `gorm:"autoUpdateTime"`
-	Author         string         `gorm:"type:text"`
-	Status         ComicStatus    `gorm:"type:enum('ongoing','completed','hiatus','cancelled','dropped')"`
-	Source         string         `gorm:"type:text;not null;uniqueIndex:idx_comic_source_slug,priority:1"`
-	Description    string         `gorm:"type:text"`
-	CoverPath      string         `gorm:"type:text"`
-	Artist         string         `gorm:"type:text"`
-	Slug           string         `gorm:"type:text;not null;uniqueIndex:idx_comic_source_slug,priority:2"`
-	Title          string         `gorm:"type:text;not null"`
-	ComicType      ComicType      `gorm:"column:comic_type;type:enum('manga','mangatoon','manhua','manwha')"`
-	Genres         pq.StringArray `gorm:"type:text[];not null;default:'{}'"`
-	AltTitles      pq.StringArray `gorm:"type:text[];not null;default:'{}'"`
-	LibraryEntries []LibraryEntry `gorm:"foreignKey:ComicID"`
+	CreatedAt      time.Time          `gorm:"autoCreateTime"`
+	UpdatedAt      time.Time          `gorm:"autoUpdateTime"`
+	Author         string             `gorm:"type:text"`
+	Status         ComicStatus        `gorm:"type:enum('ongoing','completed','hiatus','cancelled','dropped')"`
+	Source         sources.SourceName `gorm:"type:enum('asurascans');not null;uniqueIndex:idx_comic_source_slug,priority:1;"`
+	Description    string             `gorm:"type:text"`
+	Artist         string             `gorm:"type:text"`
+	Slug           string             `gorm:"type:text;not null;uniqueIndex:idx_comic_source_slug,priority:2"`
+	Title          string             `gorm:"type:text;not null"`
+	ComicType      ComicType          `gorm:"column:comic_type;type:enum('manga','mangatoon','manhua','manwha')"`
+	Genres         pq.StringArray     `gorm:"type:text[];not null;default:'{}'"`
+	AltTitles      pq.StringArray     `gorm:"type:text[];not null;default:'{}'"`
+	LibraryEntries []LibraryEntry     `gorm:"foreignKey:ComicID"`
 	ChapterCount   int
 	ID             uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
 }
@@ -47,7 +47,6 @@ func (c *Comic) Domain() comics.Comic {
 		Artist:       c.Artist,
 		Description:  c.Description,
 		AltTitles:    c.AltTitles,
-		CoverPath:    c.CoverPath,
 		CreatedAt:    c.CreatedAt,
 		UpdatedAt:    c.UpdatedAt,
 	}
@@ -62,11 +61,11 @@ const (
 	ComicTypeManhwa    ComicType = "manhwa"
 )
 
-func (t *ComicType) Domain() comics.ComicType {
-	return comics.ComicType(*t)
+func (t *ComicType) Domain() sources.SeriesType {
+	return sources.SeriesType(*t)
 }
 
-func ComicTypeFromDomain(t comics.ComicType) ComicType {
+func ComicTypeFromDomain(t sources.SeriesType) ComicType {
 	return ComicType(t)
 }
 
@@ -80,10 +79,10 @@ const (
 	ComicStatusDropped   ComicStatus = "dropped"
 )
 
-func (t *ComicStatus) Domain() comics.ComicStatus {
-	return comics.ComicStatus(*t)
+func (t *ComicStatus) Domain() sources.SeriesStatus {
+	return sources.SeriesStatus(*t)
 }
 
-func ComicStatusFromDomain(t comics.ComicStatus) ComicStatus {
+func ComicStatusFromDomain(t sources.SeriesStatus) ComicStatus {
 	return ComicStatus(t)
 }

--- a/api/pkg/repository/pgmodels/comic.go
+++ b/api/pkg/repository/pgmodels/comic.go
@@ -19,14 +19,14 @@ type Comic struct {
 	CreatedAt time.Time   `gorm:"autoCreateTime"`
 	UpdatedAt time.Time   `gorm:"autoUpdateTime"`
 	Author    string      `gorm:"type:text"`
-	Status    ComicStatus `gorm:"type:enum('ongoing','completed','hiatus','cancelled','dropped')"`
+	Status    ComicStatus `gorm:"type:text"`
 	//nolint:lll
-	Source         sources.SourceName `gorm:"type:enum('asurascans');not null;uniqueIndex:idx_comic_source_slug,priority:1;"`
+	Source         sources.SourceName `gorm:"type:text;not null;uniqueIndex:idx_comic_source_slug,priority:1;"`
 	Description    string             `gorm:"type:text"`
 	Artist         string             `gorm:"type:text"`
 	Slug           string             `gorm:"type:text;not null;uniqueIndex:idx_comic_source_slug,priority:2"`
 	Title          string             `gorm:"type:text;not null"`
-	ComicType      ComicType          `gorm:"column:comic_type;type:enum('manga','mangatoon','manhua','manwha')"`
+	ComicType      ComicType          `gorm:"column:comic_type;type:text"`
 	Genres         pq.StringArray     `gorm:"type:text[];not null;default:'{}'"`
 	AltTitles      pq.StringArray     `gorm:"type:text[];not null;default:'{}'"`
 	LibraryEntries []LibraryEntry     `gorm:"foreignKey:ComicID"`

--- a/api/pkg/repository/pgmodels/comic.go
+++ b/api/pkg/repository/pgmodels/comic.go
@@ -6,32 +6,84 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
 	"github.com/lib/pq"
 )
 
 type Comic struct {
-	CreatedAt        time.Time      `gorm:"autoCreateTime"`
-	UpdatedAt        time.Time      `gorm:"autoUpdateTime"`
-	Author           string         `gorm:"type:text"`
-	Status           string         `gorm:"type:text"`
-	Source           string         `gorm:"type:text;not null;uniqueIndex:idx_comic_source_slug,priority:1"`
-	Description      string         `gorm:"type:text"`
-	LocalCoverPath   string         `gorm:"type:text"`
-	ExternalCoverURL string         `gorm:"type:text"`
-	SourceURL        string         `gorm:"type:text"`
-	Artist           string         `gorm:"type:text"`
-	Slug             string         `gorm:"type:text;not null;uniqueIndex:idx_comic_source_slug,priority:2"`
-	Title            string         `gorm:"type:text;not null"`
-	ComicType        string         `gorm:"column:comic_type;type:text"`
-	Genres           pq.StringArray `gorm:"type:text[];not null;default:'{}'"`
-	AltTitles        pq.StringArray `gorm:"type:text[];not null;default:'{}'"`
-	LibraryEntries   []LibraryEntry `gorm:"foreignKey:ComicID"`
-	ChapterCount     int
-	ReleaseYear      int
-	Rating           float64
-	ID               uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+	CreatedAt      time.Time      `gorm:"autoCreateTime"`
+	UpdatedAt      time.Time      `gorm:"autoUpdateTime"`
+	Author         string         `gorm:"type:text"`
+	Status         ComicStatus    `gorm:"type:enum('ongoing','completed','hiatus','cancelled','dropped')"`
+	Source         string         `gorm:"type:text;not null;uniqueIndex:idx_comic_source_slug,priority:1"`
+	Description    string         `gorm:"type:text"`
+	CoverPath      string         `gorm:"type:text"`
+	Artist         string         `gorm:"type:text"`
+	Slug           string         `gorm:"type:text;not null;uniqueIndex:idx_comic_source_slug,priority:2"`
+	Title          string         `gorm:"type:text;not null"`
+	ComicType      ComicType      `gorm:"column:comic_type;type:enum('manga','mangatoon','manhua','manwha')"`
+	Genres         pq.StringArray `gorm:"type:text[];not null;default:'{}'"`
+	AltTitles      pq.StringArray `gorm:"type:text[];not null;default:'{}'"`
+	LibraryEntries []LibraryEntry `gorm:"foreignKey:ComicID"`
+	ChapterCount   int
+	ID             uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
 }
 
 func (Comic) TableName() string {
 	return "comics"
+}
+
+func (c *Comic) Domain() comics.Comic {
+	return comics.Comic{
+		ID:           c.ID,
+		Source:       c.Source,
+		Slug:         c.Slug,
+		Title:        c.Title,
+		Status:       c.Status.Domain(),
+		Type:         c.ComicType.Domain(),
+		Genres:       c.Genres,
+		ChapterCount: c.ChapterCount,
+		Author:       c.Author,
+		Artist:       c.Artist,
+		Description:  c.Description,
+		AltTitles:    c.AltTitles,
+		CoverPath:    c.CoverPath,
+		CreatedAt:    c.CreatedAt,
+		UpdatedAt:    c.UpdatedAt,
+	}
+}
+
+type ComicType string
+
+const (
+	ComicTypeManga     ComicType = "manga"
+	ComicTypeMangatoon ComicType = "mangatoon"
+	ComicTypeManhua    ComicType = "manhua"
+	ComicTypeManhwa    ComicType = "manhwa"
+)
+
+func (t *ComicType) Domain() comics.ComicType {
+	return comics.ComicType(*t)
+}
+
+func ComicTypeFromDomain(t comics.ComicType) ComicType {
+	return ComicType(t)
+}
+
+type ComicStatus string
+
+const (
+	ComicStatusOngoing   ComicStatus = "ongoing"
+	ComicStatusCompleted ComicStatus = "completed"
+	ComicStatusHiatus    ComicStatus = "hiatus"
+	ComicStatusCancelled ComicStatus = "cancelled"
+	ComicStatusDropped   ComicStatus = "dropped"
+)
+
+func (t *ComicStatus) Domain() comics.ComicStatus {
+	return comics.ComicStatus(*t)
+}
+
+func ComicStatusFromDomain(t comics.ComicStatus) ComicStatus {
+	return ComicStatus(t)
 }

--- a/api/pkg/repository/pgmodels/comic.go
+++ b/api/pkg/repository/pgmodels/comic.go
@@ -11,11 +11,16 @@ import (
 	"github.com/lib/pq"
 )
 
+const (
+	ComicLibraryEntries string = "LibraryEntries"
+)
+
 type Comic struct {
-	CreatedAt      time.Time          `gorm:"autoCreateTime"`
-	UpdatedAt      time.Time          `gorm:"autoUpdateTime"`
-	Author         string             `gorm:"type:text"`
-	Status         ComicStatus        `gorm:"type:enum('ongoing','completed','hiatus','cancelled','dropped')"`
+	CreatedAt time.Time   `gorm:"autoCreateTime"`
+	UpdatedAt time.Time   `gorm:"autoUpdateTime"`
+	Author    string      `gorm:"type:text"`
+	Status    ComicStatus `gorm:"type:enum('ongoing','completed','hiatus','cancelled','dropped')"`
+	//nolint:lll
 	Source         sources.SourceName `gorm:"type:enum('asurascans');not null;uniqueIndex:idx_comic_source_slug,priority:1;"`
 	Description    string             `gorm:"type:text"`
 	Artist         string             `gorm:"type:text"`

--- a/api/pkg/repository/pgmodels/federatedidentity.go
+++ b/api/pkg/repository/pgmodels/federatedidentity.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/federatedidentities"
 )
 
 type FederatedIdentity struct {
@@ -28,6 +29,20 @@ type FederatedIdentity struct {
 
 func (FederatedIdentity) TableName() string {
 	return "federated_identities"
+}
+
+func (f *FederatedIdentity) Domain() federatedidentities.FederatedIdentity {
+	return federatedidentities.FederatedIdentity{
+		ID:              f.ID,
+		UserID:          f.UserID,
+		ProviderID:      f.ProviderID,
+		Subject:         f.Subject,
+		Claims:          f.Claims,
+		RefreshTokenEnc: f.RefreshTokenEnc,
+		LastValidatedAt: f.LastValidatedAt,
+		LastLoginAt:     f.LastLoginAt,
+		CreatedAt:       f.CreatedAt,
+	}
 }
 
 type Claims map[string]any

--- a/api/pkg/repository/pgmodels/libraryentry.go
+++ b/api/pkg/repository/pgmodels/libraryentry.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/library"
 )
 
 type LibraryEntry struct {
@@ -19,4 +20,13 @@ type LibraryEntry struct {
 
 func (LibraryEntry) TableName() string {
 	return "library_entries"
+}
+
+func (e *LibraryEntry) Domain() library.Entry {
+	return library.Entry{
+		ID:      e.ID,
+		UserID:  e.UserID,
+		ComicID: e.ComicID,
+		AddedAt: e.AddedAt,
+	}
 }

--- a/api/pkg/repository/pgmodels/oidcprovider.go
+++ b/api/pkg/repository/pgmodels/oidcprovider.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
 	"github.com/lib/pq"
 )
 
@@ -28,4 +29,22 @@ type OIDCProvider struct {
 
 func (OIDCProvider) TableName() string {
 	return "oidc_providers"
+}
+
+func (p *OIDCProvider) Domain() oidcproviders.OIDCProvider {
+	return oidcproviders.OIDCProvider{
+		ID:              p.ID,
+		DisplayName:     p.DisplayName,
+		IssuerURL:       p.IssuerURL,
+		ClientID:        p.ClientID,
+		ClientSecretEnc: p.ClientSecretEnc,
+		Scopes:          p.Scopes,
+		UsernameClaim:   p.UsernameClaim,
+		RoleClaim:       p.RoleClaim,
+		AdminValues:     p.AdminValues,
+		AllowedValues:   p.AllowedValues,
+		AutoProvision:   p.AutoProvision,
+		CreatedAt:       p.CreatedAt,
+		UpdatedAt:       p.UpdatedAt,
+	}
 }

--- a/api/pkg/repository/pgmodels/passwordcreds.go
+++ b/api/pkg/repository/pgmodels/passwordcreds.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/credentials/password"
 )
 
 type PasswordCreds struct {
@@ -17,4 +18,12 @@ type PasswordCreds struct {
 
 func (PasswordCreds) TableName() string {
 	return "password_credentials"
+}
+
+func (p *PasswordCreds) Domain() password.PasswordCreds {
+	return password.PasswordCreds{
+		UserID:    p.UserID,
+		Hash:      p.Hash,
+		UpdatedAt: p.UpdatedAt,
+	}
 }

--- a/api/pkg/repository/pgmodels/session.go
+++ b/api/pkg/repository/pgmodels/session.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
 )
 
 type Session struct {
@@ -22,4 +23,16 @@ type Session struct {
 
 func (Session) TableName() string {
 	return "sessions"
+}
+
+func (s *Session) Domain() sessions.Session {
+	return sessions.Session{
+		ID:          s.ID,
+		UserID:      s.UserID,
+		AuthMethod:  sessions.AuthMethod(s.AuthMethod),
+		CreatedAt:   s.CreatedAt,
+		ExpiresAt:   s.ExpiresAt,
+		ProviderID:  s.ProviderID,
+		ProviderSID: s.ProviderSID,
+	}
 }

--- a/api/pkg/repository/pgmodels/user.go
+++ b/api/pkg/repository/pgmodels/user.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/users"
 )
 
 type User struct {
@@ -21,4 +22,14 @@ type User struct {
 
 func (User) TableName() string {
 	return "users"
+}
+
+func (u *User) Domain() users.User {
+	return users.User{
+		ID:        u.ID,
+		Name:      u.Name,
+		IsAdmin:   u.IsAdmin,
+		CreatedAt: u.CreatedAt,
+		UpdatedAt: u.UpdatedAt,
+	}
 }

--- a/api/pkg/sources/asurascans/pkg/core/app.go
+++ b/api/pkg/sources/asurascans/pkg/core/app.go
@@ -9,20 +9,35 @@ import (
 	"log/slog"
 	"slices"
 
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/fncache"
 	"golang.org/x/sync/errgroup"
 )
 
-type Dependencies struct {
+type Config struct {
+	SourceName string
+}
+
+func (c *Config) Validate() error {
+	if c.SourceName == "" {
+		return errors.New("sourceName is required")
+	}
+
+	return nil
+}
+
+type Deps struct {
 	Logger                       *slog.Logger
-	SearchCache                  *fncache.Cache[domain.SearchOpts, domain.SearchResult]
+	SearchCache                  *fncache.Cache[domain.SearchCacheOpts, domain.SearchCacheResult]
 	GetInfosBySlugCache          *fncache.Cache[string, domain.GetInfosBySlugResponse]
 	GetChaptersListBySeriesCache *fncache.Cache[string, []domain.Chapter]
 	GetImageURLsByChapter        *fncache.Cache[domain.GetImageURLsByChapterOpts, []string]
+	ComicsRepository             comics.ComicsRepository
 }
 
-func (deps *Dependencies) Validate() error {
+func (deps *Deps) Validate() error {
 	if deps.SearchCache == nil {
 		return errors.New("searchCache is required")
 	}
@@ -43,17 +58,24 @@ func (deps *Dependencies) Validate() error {
 }
 
 type App struct {
-	deps Dependencies
+	deps Deps
+	cfg  Config
 }
 
-func New(deps Dependencies) (*App, error) {
-	if err := deps.Validate(); err != nil {
+func New(cfg Config, deps Deps) (*App, error) {
+	var err error
+	if err = cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("cfg.Validate: %w", err)
+	}
+
+	if err = deps.Validate(); err != nil {
 		return nil, fmt.Errorf("deps.Validate: %w", err)
 	}
 
 	deps.Logger = deps.Logger.With("component", "sources.asurascans")
 
 	app := &App{
+		cfg:  cfg,
 		deps: deps,
 	}
 
@@ -79,8 +101,46 @@ func (a *App) Run(ctx context.Context) error {
 }
 
 func (a *App) Search(ctx context.Context, opts domain.SearchOpts) (*domain.SearchResult, error) {
-	//nolint:wrapcheck
-	return a.deps.SearchCache.Get(ctx, opts)
+	res, err := a.deps.SearchCache.Get(ctx, domain.SearchCacheOpts{
+		Search:      opts.Search,
+		Sort:        opts.Sort,
+		SortOrder:   opts.SortOrder,
+		Status:      opts.Status,
+		Type:        opts.Type,
+		Artist:      opts.Artist,
+		Genres:      opts.Genres,
+		Offset:      opts.Offset,
+		Limit:       opts.Limit,
+		MinChapters: opts.MinChapters,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("a.deps.SearchCache.Get: %w", err)
+	}
+
+	slugs := make([]string, len(res.Items))
+	for i, item := range res.Items {
+		slugs[i] = item.Slug
+	}
+
+	foundComics, err := a.deps.ComicsRepository.GetBySlugsAndSource(ctx, a.cfg.SourceName, slugs)
+	if err != nil {
+		return nil, fmt.Errorf("a.deps.ComicsRepository.GetBySlugsAndSource: %w", err)
+	}
+
+	items := make([]domain.SearchResultItem, len(foundComics))
+	for i, item := range res.Items {
+		isInLibrary := utils.ContainsSlice(foundComics, func(c comics.Comic) bool {
+			return c.Slug == item.Slug
+		})
+
+		items[i] = item.Domain(isInLibrary)
+	}
+
+	return &domain.SearchResult{
+		Items: items,
+		Meta:  res.Meta,
+	}, nil
 }
 
 func (a *App) GetInfosBySlug(ctx context.Context, slug string) (*domain.GetInfosBySlugResponse, error) {

--- a/api/pkg/sources/asurascans/pkg/core/app.go
+++ b/api/pkg/sources/asurascans/pkg/core/app.go
@@ -10,19 +10,23 @@ import (
 	"slices"
 
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/fncache"
 	"golang.org/x/sync/errgroup"
 )
 
+var _ sources.Source = (*App)(nil)
+
 type Config struct {
-	SourceName string
+	SourceName sources.SourceName
 }
 
 func (c *Config) Validate() error {
-	if c.SourceName == "" {
-		return errors.New("sourceName is required")
+	_, err := sources.ParseSourceName(string(c.SourceName))
+	if err != nil {
+		return fmt.Errorf("sources.ParseSourceName: %w", err)
 	}
 
 	return nil
@@ -52,6 +56,10 @@ func (deps *Deps) Validate() error {
 
 	if deps.GetImageURLsByChapter == nil {
 		return errors.New("getImageURLsByChapter is required")
+	}
+
+	if deps.ComicsRepository == nil {
+		return errors.New("comicsRepository is required")
 	}
 
 	return nil
@@ -128,7 +136,7 @@ func (a *App) Search(ctx context.Context, opts domain.SearchOpts) (*domain.Searc
 		return nil, fmt.Errorf("a.deps.ComicsRepository.GetBySlugsAndSource: %w", err)
 	}
 
-	items := make([]domain.SearchResultItem, len(foundComics))
+	items := make([]domain.SearchResultItem, len(res.Items))
 	for i, item := range res.Items {
 		isInLibrary := utils.ContainsSlice(foundComics, func(c comics.Comic) bool {
 			return c.Slug == item.Slug
@@ -143,9 +151,16 @@ func (a *App) Search(ctx context.Context, opts domain.SearchOpts) (*domain.Searc
 	}, nil
 }
 
-func (a *App) GetInfosBySlug(ctx context.Context, slug string) (*domain.GetInfosBySlugResponse, error) {
-	//nolint:wrapcheck
-	return a.deps.GetInfosBySlugCache.Get(ctx, slug)
+func (a *App) GetInfosBySlug(ctx context.Context, slug string) (*sources.GetInfosBySlugResponse, error) {
+	infos, err := a.deps.GetInfosBySlugCache.Get(ctx, slug)
+	if err != nil {
+		//nolint:wrapcheck
+		return nil, err
+	}
+
+	res := infos.Source()
+
+	return &res, nil
 }
 
 func (a *App) GetChaptersListBySeries(ctx context.Context, slug string) ([]domain.Chapter, error) {

--- a/api/pkg/sources/asurascans/pkg/core/app_test.go
+++ b/api/pkg/sources/asurascans/pkg/core/app_test.go
@@ -8,10 +8,44 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
+	coredomain "github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/core"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/fncache"
 )
+
+type stubComicsRepository struct{}
+
+func (stubComicsRepository) GetByID(context.Context, comics.GetByIDOpts) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (stubComicsRepository) GetBySourceSlug(
+	context.Context, comics.GetBySourceSlugOpts,
+) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (stubComicsRepository) Create(context.Context, comics.CreateComicOpts) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (stubComicsRepository) GetBySlugsAndSource(
+	context.Context, sources.SourceName, []string,
+) ([]comics.Comic, error) {
+	return nil, nil
+}
+
+func (stubComicsRepository) Delete(context.Context, uuid.UUID) error {
+	return coredomain.ErrNotFound
+}
+
+func (stubComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]comics.Comic, error) {
+	return nil, nil
+}
 
 func newCache[P any, T any](
 	t *testing.T, key func(P) string, fn func(context.Context, P) (*T, error),
@@ -37,14 +71,33 @@ func newCache[P any, T any](
 
 func identityKey(s string) string { return s }
 
-func fullDeps(t *testing.T) core.Dependencies {
+func searchCacheKey(opts domain.SearchCacheOpts) string {
+	return domain.SearchOpts{
+		Search:      opts.Search,
+		Sort:        opts.Sort,
+		SortOrder:   opts.SortOrder,
+		Status:      opts.Status,
+		Type:        opts.Type,
+		Artist:      opts.Artist,
+		Genres:      opts.Genres,
+		Offset:      opts.Offset,
+		Limit:       opts.Limit,
+		MinChapters: opts.MinChapters,
+	}.CacheKey()
+}
+
+func testConfig() core.Config {
+	return core.Config{SourceName: sources.SourceAsuraScans}
+}
+
+func fullDeps(t *testing.T) core.Deps {
 	t.Helper()
 
-	return core.Dependencies{
+	return core.Deps{
 		Logger: slog.New(slog.DiscardHandler),
-		SearchCache: newCache(t, domain.SearchOpts.CacheKey,
-			func(context.Context, domain.SearchOpts) (*domain.SearchResult, error) {
-				return &domain.SearchResult{}, nil
+		SearchCache: newCache(t, searchCacheKey,
+			func(context.Context, domain.SearchCacheOpts) (*domain.SearchCacheResult, error) {
+				return &domain.SearchCacheResult{}, nil
 			}),
 		GetInfosBySlugCache: newCache(t, identityKey,
 			func(context.Context, string) (*domain.GetInfosBySlugResponse, error) {
@@ -62,32 +115,37 @@ func fullDeps(t *testing.T) core.Dependencies {
 
 				return &urls, nil
 			}),
+		ComicsRepository: stubComicsRepository{},
 	}
 }
 
-func TestDependenciesValidate(t *testing.T) {
+func TestDepsValidate(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		drop    func(*core.Dependencies)
+		drop    func(*core.Deps)
 		wantErr string
 	}{
-		"complet": {drop: func(*core.Dependencies) {}},
+		"complet": {drop: func(*core.Deps) {}},
 		"without searchCache": {
-			drop:    func(d *core.Dependencies) { d.SearchCache = nil },
+			drop:    func(d *core.Deps) { d.SearchCache = nil },
 			wantErr: "searchCache is required",
 		},
 		"without getInfosBySlugCache": {
-			drop:    func(d *core.Dependencies) { d.GetInfosBySlugCache = nil },
+			drop:    func(d *core.Deps) { d.GetInfosBySlugCache = nil },
 			wantErr: "getInfosBySlugCache is required",
 		},
 		"without getChaptersListBySeriesCache": {
-			drop:    func(d *core.Dependencies) { d.GetChaptersListBySeriesCache = nil },
+			drop:    func(d *core.Deps) { d.GetChaptersListBySeriesCache = nil },
 			wantErr: "getChaptersListBySeriesCache is required",
 		},
 		"without getImageURLsByChapter": {
-			drop:    func(d *core.Dependencies) { d.GetImageURLsByChapter = nil },
+			drop:    func(d *core.Deps) { d.GetImageURLsByChapter = nil },
 			wantErr: "getImageURLsByChapter is required",
+		},
+		"without comicsRepository": {
+			drop:    func(d *core.Deps) { d.ComicsRepository = nil },
+			wantErr: "comicsRepository is required",
 		},
 	}
 
@@ -118,7 +176,7 @@ func TestDependenciesValidate(t *testing.T) {
 func TestNewRejectsIncompleteDeps(t *testing.T) {
 	t.Parallel()
 
-	app, err := core.New(core.Dependencies{})
+	app, err := core.New(testConfig(), core.Deps{})
 	if err == nil {
 		t.Fatal("New with empty dependencies must fail")
 	}
@@ -135,7 +193,7 @@ func TestNewRejectsIncompleteDeps(t *testing.T) {
 func TestNewSucceeds(t *testing.T) {
 	t.Parallel()
 
-	app, err := core.New(fullDeps(t))
+	app, err := core.New(testConfig(), fullDeps(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -148,17 +206,17 @@ func TestNewSucceeds(t *testing.T) {
 func TestAppSearchDelegatesToCache(t *testing.T) {
 	t.Parallel()
 
-	called := make(chan domain.SearchOpts, 1)
+	called := make(chan domain.SearchCacheOpts, 1)
 
 	deps := fullDeps(t)
-	deps.SearchCache = newCache(t, domain.SearchOpts.CacheKey,
-		func(_ context.Context, opts domain.SearchOpts) (*domain.SearchResult, error) {
+	deps.SearchCache = newCache(t, searchCacheKey,
+		func(_ context.Context, opts domain.SearchCacheOpts) (*domain.SearchCacheResult, error) {
 			called <- opts
 
-			return &domain.SearchResult{Meta: domain.SearchResultMeta{Total: 3}}, nil
+			return &domain.SearchCacheResult{Meta: domain.SearchResultMeta{Total: 3}}, nil
 		})
 
-	app, err := core.New(deps)
+	app, err := core.New(testConfig(), deps)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -180,7 +238,7 @@ func TestAppSearchDelegatesToCache(t *testing.T) {
 func TestAppGetChaptersListBySeriesReturnsACopy(t *testing.T) {
 	t.Parallel()
 
-	app, err := core.New(fullDeps(t))
+	app, err := core.New(testConfig(), fullDeps(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -209,7 +267,7 @@ func TestAppGetChaptersListBySeriesReturnsACopy(t *testing.T) {
 func TestAppGetImageURLsByChapterReturnsACopy(t *testing.T) {
 	t.Parallel()
 
-	app, err := core.New(fullDeps(t))
+	app, err := core.New(testConfig(), fullDeps(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -240,7 +298,7 @@ func TestAppGetImageURLsByChapterReturnsACopy(t *testing.T) {
 func TestAppRunReturnsOnContextCancel(t *testing.T) {
 	t.Parallel()
 
-	app, err := core.New(fullDeps(t))
+	app, err := core.New(testConfig(), fullDeps(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}

--- a/api/pkg/sources/asurascans/pkg/domain/apiclient.go
+++ b/api/pkg/sources/asurascans/pkg/domain/apiclient.go
@@ -8,135 +8,14 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
 )
 
 type ApiClient interface {
-	Search(context.Context, SearchOpts) (*SearchResult, error)
+	Search(context.Context, SearchCacheOpts) (*SearchCacheResult, error)
 	GetInfosBySlug(context.Context, string) (*GetInfosBySlugResponse, error)
 	GetChaptersListBySerie(context.Context, string) (*[]Chapter, error)
 	GetImageURLsByChapter(context.Context, GetImageURLsByChapterOpts) (*[]string, error)
-}
-
-type SeriesType string
-
-const (
-	SeriesTypeManga     SeriesType = "manga"
-	SeriesTypeMangatoon SeriesType = "mangatoon"
-	SeriesTypeManhua    SeriesType = "manhua"
-	SeriesTypeManhwa    SeriesType = "manhwa"
-)
-
-func IsSeriesType(s string) bool {
-	values := []SeriesType{
-		SeriesTypeManga,
-		SeriesTypeMangatoon,
-		SeriesTypeManhua,
-		SeriesTypeManhwa,
-	}
-
-	return slices.Contains(values, SeriesType(s))
-}
-
-type SeriesGenre string
-
-const (
-	SeriesGenreAction        SeriesGenre = "action"
-	SeriesGenreAdventure     SeriesGenre = "adventure"
-	SeriesGenreComedy        SeriesGenre = "comedy"
-	SeriesGenreCrazyMc       SeriesGenre = "crazy-mc"
-	SeriesGenreDarkFantasy   SeriesGenre = "dark-fantasy"
-	SeriesGenreDemon         SeriesGenre = "demon"
-	SeriesGenreDrama         SeriesGenre = "drama"
-	SeriesGenreDungeons      SeriesGenre = "dungeons"
-	SeriesGenreFantasy       SeriesGenre = "fantasy"
-	SeriesGenreGame          SeriesGenre = "game"
-	SeriesGenreGeniusMc      SeriesGenre = "genius-mc"
-	SeriesGenreIsekai        SeriesGenre = "isekai"
-	SeriesGenreKuchikuchi    SeriesGenre = "kuchikuchi"
-	SeriesGenreMagic         SeriesGenre = "magic"
-	SeriesGenreMartialArts   SeriesGenre = "martial-arts"
-	SeriesGenreMurim         SeriesGenre = "murim"
-	SeriesGenreMystery       SeriesGenre = "mystery"
-	SeriesGenreNecromancer   SeriesGenre = "necromancer"
-	SeriesGenreOverpowered   SeriesGenre = "overpowered"
-	SeriesGenrePsychological SeriesGenre = "psychological"
-	SeriesGenreRegression    SeriesGenre = "regression"
-	SeriesGenreReincarnation SeriesGenre = "reincarnation"
-	SeriesGenreRevenge       SeriesGenre = "revenge"
-	SeriesGenreRomance       SeriesGenre = "romance"
-	SeriesGenreSchoolLife    SeriesGenre = "school-life"
-	SeriesGenreSciFi         SeriesGenre = "sci-fi"
-	SeriesGenreShoujo        SeriesGenre = "shoujo"
-	SeriesGenreShounen       SeriesGenre = "shounen"
-	SeriesGenreSystem        SeriesGenre = "system"
-	SeriesGenreTower         SeriesGenre = "tower"
-	SeriesGenreTragedy       SeriesGenre = "tragedy"
-	SeriesGenreVillain       SeriesGenre = "villain"
-	SeriesGenreViolence      SeriesGenre = "violence"
-)
-
-func IsSeriesGenre(s string) bool {
-	values := []SeriesGenre{
-		SeriesGenreAction,
-		SeriesGenreAdventure,
-		SeriesGenreComedy,
-		SeriesGenreCrazyMc,
-		SeriesGenreDarkFantasy,
-		SeriesGenreDemon,
-		SeriesGenreDrama,
-		SeriesGenreDungeons,
-		SeriesGenreFantasy,
-		SeriesGenreGame,
-		SeriesGenreGeniusMc,
-		SeriesGenreIsekai,
-		SeriesGenreKuchikuchi,
-		SeriesGenreMagic,
-		SeriesGenreMartialArts,
-		SeriesGenreMurim,
-		SeriesGenreMystery,
-		SeriesGenreNecromancer,
-		SeriesGenreOverpowered,
-		SeriesGenrePsychological,
-		SeriesGenreRegression,
-		SeriesGenreReincarnation,
-		SeriesGenreRevenge,
-		SeriesGenreRomance,
-		SeriesGenreSchoolLife,
-		SeriesGenreSciFi,
-		SeriesGenreShoujo,
-		SeriesGenreShounen,
-		SeriesGenreSystem,
-		SeriesGenreTower,
-		SeriesGenreTragedy,
-		SeriesGenreVillain,
-		SeriesGenreViolence,
-	}
-
-	return slices.Contains(values, SeriesGenre(s))
-}
-
-type SeriesStatus string
-
-const (
-	SeriesStatusOngoing   SeriesStatus = "ongoing"
-	SeriesStatusCompleted SeriesStatus = "completed"
-	SeriesStatusHiatus    SeriesStatus = "hiatus"
-	SeriesStatusCancelled SeriesStatus = "cancelled"
-	SeriesStatusDropped   SeriesStatus = "dropped"
-	SeriesStatusNone      SeriesStatus = ""
-)
-
-func IsSeriesStatus(s string) bool {
-	values := []SeriesStatus{
-		SeriesStatusOngoing,
-		SeriesStatusCompleted,
-		SeriesStatusHiatus,
-		SeriesStatusCancelled,
-		SeriesStatusDropped,
-		SeriesStatusNone,
-	}
-
-	return slices.Contains(values, SeriesStatus(s))
 }
 
 type SortType string
@@ -187,10 +66,10 @@ type SearchCacheOpts struct {
 	Search      string
 	Sort        SortType
 	SortOrder   SortOrder
-	Status      SeriesStatus
-	Type        SeriesType
+	Status      sources.SeriesStatus
+	Type        sources.SeriesType
 	Artist      string
-	Genres      []SeriesGenre
+	Genres      []string
 	Offset      int
 	Limit       int
 	MinChapters int
@@ -200,10 +79,10 @@ type SearchOpts struct {
 	Search      string
 	Sort        SortType
 	SortOrder   SortOrder
-	Status      SeriesStatus
-	Type        SeriesType
+	Status      sources.SeriesStatus
+	Type        sources.SeriesType
 	Artist      string
-	Genres      []SeriesGenre
+	Genres      []string
 	Offset      int
 	Limit       int
 	MinChapters int
@@ -233,15 +112,15 @@ type SearchResultItem struct {
 	PublicURL      string
 	SourceURL      string
 	Cover          string
-	Status         SeriesStatus
-	Type           SeriesType
+	Status         sources.SeriesStatus
+	Type           sources.SeriesType
 	Author         string
 	Artist         string
 	Description    string
 	Slug           string
 	Title          string
 	AltTitles      []string
-	Genres         []SeriesGenre
+	Genres         []string
 	LatestChapters []SearchResultItemChapter
 	ChapterCount   int
 	ID             int
@@ -257,15 +136,15 @@ type SearchCacheResultItem struct {
 	PublicURL      string
 	SourceURL      string
 	Cover          string
-	Status         SeriesStatus
-	Type           SeriesType
+	Status         sources.SeriesStatus
+	Type           sources.SeriesType
 	Author         string
 	Artist         string
 	Description    string
 	Slug           string
 	Title          string
 	AltTitles      []string
-	Genres         []SeriesGenre
+	Genres         []string
 	LatestChapters []SearchResultItemChapter
 	ChapterCount   int
 	ID             int
@@ -314,17 +193,39 @@ type GetInfosBySlugResponse struct {
 	Description   string
 	Title         string
 	Cover         string
-	Status        SeriesStatus
-	Type          SeriesType
+	Status        sources.SeriesStatus
+	Type          sources.SeriesType
 	Author        string
 	Artist        string
 	SourceURL     string
 	PublicURL     string
 	Slug          string
 	AltTitles     []string
-	Genres        []SeriesGenre
+	Genres        []string
 	ChapterCount  int
 	Rating        float64
+}
+
+func (r *GetInfosBySlugResponse) Source() sources.GetInfosBySlugResponse {
+	return sources.GetInfosBySlugResponse{
+		LastChapterAt: r.LastChapterAt,
+		UpdatedAt:     r.UpdatedAt,
+		CreatedAt:     r.CreatedAt,
+		Description:   r.Description,
+		Title:         r.Title,
+		Cover:         r.Cover,
+		Status:        r.Status,
+		Type:          r.Type,
+		Author:        r.Author,
+		Artist:        r.Artist,
+		SourceURL:     r.SourceURL,
+		PublicURL:     r.PublicURL,
+		Slug:          r.Slug,
+		AltTitles:     r.AltTitles,
+		Genres:        r.Genres,
+		ChapterCount:  r.ChapterCount,
+		Rating:        r.Rating,
+	}
 }
 
 type Chapter struct {

--- a/api/pkg/sources/asurascans/pkg/domain/apiclient.go
+++ b/api/pkg/sources/asurascans/pkg/domain/apiclient.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"slices"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type ApiClient interface {
@@ -22,7 +24,6 @@ const (
 	SeriesTypeMangatoon SeriesType = "mangatoon"
 	SeriesTypeManhua    SeriesType = "manhua"
 	SeriesTypeManhwa    SeriesType = "manhwa"
-	SeriesTypeNone      SeriesType = ""
 )
 
 func IsSeriesType(s string) bool {
@@ -31,7 +32,6 @@ func IsSeriesType(s string) bool {
 		SeriesTypeMangatoon,
 		SeriesTypeManhua,
 		SeriesTypeManhwa,
-		SeriesTypeNone,
 	}
 
 	return slices.Contains(values, SeriesType(s))
@@ -183,6 +183,19 @@ func IsSortOrder(s string) bool {
 	return slices.Contains(values, SortOrder(s))
 }
 
+type SearchCacheOpts struct {
+	Search      string
+	Sort        SortType
+	SortOrder   SortOrder
+	Status      SeriesStatus
+	Type        SeriesType
+	Artist      string
+	Genres      []SeriesGenre
+	Offset      int
+	Limit       int
+	MinChapters int
+}
+
 type SearchOpts struct {
 	Search      string
 	Sort        SortType
@@ -194,6 +207,12 @@ type SearchOpts struct {
 	Offset      int
 	Limit       int
 	MinChapters int
+	UserID      uuid.UUID
+}
+
+type SearchCacheResult struct {
+	Items []SearchCacheResultItem
+	Meta  SearchResultMeta
 }
 
 type SearchResult struct {
@@ -228,6 +247,56 @@ type SearchResultItem struct {
 	ID             int
 	Rating         float64
 	ReleaseYear    int
+	IsInLibrary    bool
+}
+
+type SearchCacheResultItem struct {
+	LastChapterAt  time.Time
+	UpdatedAt      time.Time
+	CreatedAt      time.Time
+	PublicURL      string
+	SourceURL      string
+	Cover          string
+	Status         SeriesStatus
+	Type           SeriesType
+	Author         string
+	Artist         string
+	Description    string
+	Slug           string
+	Title          string
+	AltTitles      []string
+	Genres         []SeriesGenre
+	LatestChapters []SearchResultItemChapter
+	ChapterCount   int
+	ID             int
+	Rating         float64
+	ReleaseYear    int
+}
+
+func (i *SearchCacheResultItem) Domain(isInLibrary bool) SearchResultItem {
+	return SearchResultItem{
+		LastChapterAt:  i.LastChapterAt,
+		UpdatedAt:      i.UpdatedAt,
+		CreatedAt:      i.CreatedAt,
+		PublicURL:      i.PublicURL,
+		SourceURL:      i.SourceURL,
+		Cover:          i.Cover,
+		Status:         i.Status,
+		Type:           i.Type,
+		Author:         i.Author,
+		Artist:         i.Artist,
+		Description:    i.Description,
+		Slug:           i.Slug,
+		Title:          i.Title,
+		AltTitles:      i.AltTitles,
+		Genres:         i.Genres,
+		LatestChapters: i.LatestChapters,
+		ChapterCount:   i.ChapterCount,
+		ID:             i.ID,
+		Rating:         i.Rating,
+		ReleaseYear:    i.ReleaseYear,
+		IsInLibrary:    isInLibrary,
+	}
 }
 
 type SearchResultItemChapter struct {

--- a/api/pkg/sources/asurascans/pkg/domain/cachekey_test.go
+++ b/api/pkg/sources/asurascans/pkg/domain/cachekey_test.go
@@ -23,8 +23,8 @@ func TestSearchOptsCacheKeyIsInjective(t *testing.T) {
 		same bool
 	}{
 		"genres split differently": {
-			a: domain.SearchOpts{Genres: []domain.SeriesGenre{"Slice", "of", "Life"}},
-			b: domain.SearchOpts{Genres: []domain.SeriesGenre{"Slice of Life"}},
+			a: domain.SearchOpts{Genres: []string{"Slice", "of", "Life"}},
+			b: domain.SearchOpts{Genres: []string{"Slice of Life"}},
 		},
 		"adjacent text fields offset": {
 			a: domain.SearchOpts{Status: "ongoing", Type: "manga"},
@@ -32,21 +32,21 @@ func TestSearchOptsCacheKeyIsInjective(t *testing.T) {
 		},
 		"empty search vs homonym genre": {
 			a: domain.SearchOpts{Search: testGenreAction},
-			b: domain.SearchOpts{Genres: []domain.SeriesGenre{testGenreAction}},
+			b: domain.SearchOpts{Genres: []string{testGenreAction}},
 		},
 		"genre order irrelevant": {
-			a:    domain.SearchOpts{Genres: []domain.SeriesGenre{testGenreAction, testGenreDrama}},
-			b:    domain.SearchOpts{Genres: []domain.SeriesGenre{testGenreDrama, testGenreAction}},
+			a:    domain.SearchOpts{Genres: []string{testGenreAction, testGenreDrama}},
+			b:    domain.SearchOpts{Genres: []string{testGenreDrama, testGenreAction}},
 			same: true,
 		},
 		"repeated genre irrelevant": {
-			a:    domain.SearchOpts{Genres: []domain.SeriesGenre{testGenreAction, testGenreAction}},
-			b:    domain.SearchOpts{Genres: []domain.SeriesGenre{testGenreAction}},
+			a:    domain.SearchOpts{Genres: []string{testGenreAction, testGenreAction}},
+			b:    domain.SearchOpts{Genres: []string{testGenreAction}},
 			same: true,
 		},
 		"nil and empty slice equivalent": {
 			a:    domain.SearchOpts{Genres: nil},
-			b:    domain.SearchOpts{Genres: []domain.SeriesGenre{}},
+			b:    domain.SearchOpts{Genres: []string{}},
 			same: true,
 		},
 	}
@@ -71,7 +71,7 @@ func TestSearchOptsCacheKeyIsInjective(t *testing.T) {
 func TestSearchOptsCacheKeyDoesNotMutateGenres(t *testing.T) {
 	t.Parallel()
 
-	genres := []domain.SeriesGenre{testGenreDrama, testGenreAction}
+	genres := []string{testGenreDrama, testGenreAction}
 	opts := domain.SearchOpts{Genres: genres}
 
 	_ = opts.CacheKey()
@@ -87,7 +87,7 @@ func TestSearchOptsCacheKeyDistinguishesEveryField(t *testing.T) {
 	base := domain.SearchOpts{
 		Offset: 1, Limit: 2, Search: "s", Sort: domain.SortTypeLatest,
 		SortOrder: domain.SortOrderAsc, Status: "st", Type: "ty", Artist: "ar",
-		Genres: []domain.SeriesGenre{"g"}, MinChapters: 3,
+		Genres: []string{"g"}, MinChapters: 3,
 	}
 
 	variants := map[string]domain.SearchOpts{

--- a/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
+++ b/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
@@ -13,7 +13,11 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
+	coredomain "github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
 	asura "github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/core"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/domain"
 	asurahttp "github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/gateway/http"
@@ -22,23 +26,53 @@ import (
 
 const testExternalCoverURL = "https://external.example/cover.webp"
 
+type stubComicsRepository struct{}
+
+func (stubComicsRepository) GetByID(context.Context, comics.GetByIDOpts) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (stubComicsRepository) GetBySourceSlug(
+	context.Context, comics.GetBySourceSlugOpts,
+) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (stubComicsRepository) Create(context.Context, comics.CreateComicOpts) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (stubComicsRepository) GetBySlugsAndSource(
+	context.Context, sources.SourceName, []string,
+) ([]comics.Comic, error) {
+	return nil, nil
+}
+
+func (stubComicsRepository) Delete(context.Context, uuid.UUID) error {
+	return coredomain.ErrNotFound
+}
+
+func (stubComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]comics.Comic, error) {
+	return nil, nil
+}
+
 func newTestAsuraApp(t *testing.T) *asura.App {
 	t.Helper()
 
 	searchCache, err := fncache.New(
-		fncache.Config[domain.SearchOpts, domain.SearchResult]{
+		fncache.Config[domain.SearchCacheOpts, domain.SearchCacheResult]{
 			Name: "search",
-			Fn: func(context.Context, domain.SearchOpts) (*domain.SearchResult, error) {
-				return &domain.SearchResult{
+			Fn: func(context.Context, domain.SearchCacheOpts) (*domain.SearchCacheResult, error) {
+				return &domain.SearchCacheResult{
 					Meta: domain.SearchResultMeta{Total: 1},
-					Items: []domain.SearchResultItem{{
+					Items: []domain.SearchCacheResultItem{{
 						Slug:  "solo-leveling",
 						Title: "Solo Leveling",
 						Cover: testExternalCoverURL,
 					}},
 				}, nil
 			},
-			Key:           func(domain.SearchOpts) string { return "k" },
+			Key:           func(domain.SearchCacheOpts) string { return "k" },
 			TTL:           time.Minute,
 			ErrorTTL:      time.Minute,
 			FetchTimeout:  time.Minute,
@@ -110,12 +144,13 @@ func newTestAsuraApp(t *testing.T) *asura.App {
 		t.Fatalf("fncache.New(images): %v", err)
 	}
 
-	app, err := asura.New(asura.Dependencies{
+	app, err := asura.New(asura.Config{SourceName: sources.SourceAsuraScans}, asura.Deps{
 		Logger:                       slog.New(slog.DiscardHandler),
 		SearchCache:                  searchCache,
 		GetInfosBySlugCache:          infosCache,
 		GetChaptersListBySeriesCache: chaptersCache,
 		GetImageURLsByChapter:        imagesCache,
+		ComicsRepository:             stubComicsRepository{},
 	})
 	if err != nil {
 		t.Fatalf("asura.New: %v", err)

--- a/api/pkg/sources/asurascans/pkg/gateway/http/dto.go
+++ b/api/pkg/sources/asurascans/pkg/gateway/http/dto.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/domain"
 )
 
@@ -24,15 +25,15 @@ type searchResItemDTO struct {
 	PublicURL      string                    `json:"publicUrl"`
 	SourceURL      string                    `json:"sourceUrl"`
 	Cover          string                    `json:"cover"`
-	Status         domain.SeriesStatus       `json:"status"`
-	Type           domain.SeriesType         `json:"type"`
+	Status         sources.SeriesStatus      `json:"status"`
+	Type           sources.SeriesType        `json:"type"`
 	Author         string                    `json:"author"`
 	Artist         string                    `json:"artist"`
 	Description    string                    `json:"description"`
 	Slug           string                    `json:"slug"`
 	Title          string                    `json:"title"`
 	AltTitles      []string                  `json:"altTitles"`
-	Genres         []domain.SeriesGenre      `json:"genres"`
+	Genres         []string                  `json:"genres"`
 	LatestChapters []searchResItemChapterDTO `json:"latestChapters"`
 	ChapterCount   int                       `json:"chapterCount"`
 	Rating         float64                   `json:"rating"`
@@ -68,18 +69,28 @@ func parseSearchOpts(q url.Values) (domain.SearchOpts, error) {
 	opts.SortOrder = domain.SortOrder(order)
 
 	status := q.Get("status")
-	if !domain.IsSeriesStatus(status) {
-		return domain.SearchOpts{}, fmt.Errorf("invalid status %q", status)
-	}
+	if status == "" {
+		opts.Status = ""
+	} else {
+		parsedStatus, err := sources.ParseSeriesStatus(status)
+		if err != nil {
+			return domain.SearchOpts{}, fmt.Errorf("invalid status %q: %w", status, err)
+		}
 
-	opts.Status = domain.SeriesStatus(status)
+		opts.Status = parsedStatus
+	}
 
 	seriesType := q.Get("type")
-	if !domain.IsSeriesType(seriesType) {
-		return domain.SearchOpts{}, fmt.Errorf("invalid type %q", seriesType)
-	}
+	if seriesType == "" {
+		opts.Type = ""
+	} else {
+		parsedType, err := sources.ParseSeriesType(seriesType)
+		if err != nil {
+			return domain.SearchOpts{}, fmt.Errorf("invalid type %q: %w", seriesType, err)
+		}
 
-	opts.Type = domain.SeriesType(seriesType)
+		opts.Type = parsedType
+	}
 
 	genres, err := parseGenres(q.Get("genres"))
 	if err != nil {
@@ -120,13 +131,13 @@ func parseSearchOpts(q url.Values) (domain.SearchOpts, error) {
 	return opts, nil
 }
 
-func parseGenres(raw string) ([]domain.SeriesGenre, error) {
+func parseGenres(raw string) ([]string, error) {
 	if strings.TrimSpace(raw) == "" {
 		return nil, nil
 	}
 
 	parts := strings.Split(raw, ",")
-	genres := make([]domain.SeriesGenre, 0, len(parts))
+	genres := make([]string, 0, len(parts))
 
 	for _, part := range parts {
 		genre := strings.TrimSpace(part)
@@ -134,11 +145,7 @@ func parseGenres(raw string) ([]domain.SeriesGenre, error) {
 			continue
 		}
 
-		if !domain.IsSeriesGenre(genre) {
-			return nil, fmt.Errorf("invalid genre %q", genre)
-		}
-
-		genres = append(genres, domain.SeriesGenre(genre))
+		genres = append(genres, string(genre))
 	}
 
 	return genres, nil
@@ -162,23 +169,23 @@ func parsePositiveInt(raw string) (int, error) {
 }
 
 type getInfosBySlugResDTO struct {
-	LastChapterAt time.Time            `json:"lastChapterAt"`
-	UpdatedAt     time.Time            `json:"updatedAt"`
-	CreatedAt     time.Time            `json:"createdAt"`
-	Description   string               `json:"description"`
-	Title         string               `json:"title"`
-	Cover         string               `json:"cover"`
-	Status        domain.SeriesStatus  `json:"status"`
-	Type          domain.SeriesType    `json:"type"`
-	Author        string               `json:"author"`
-	Artist        string               `json:"artist"`
-	SourceURL     string               `json:"sourceUrl"`
-	PublicURL     string               `json:"publicUrl"`
-	Slug          string               `json:"slug"`
-	AltTitles     []string             `json:"altTitles"`
-	Genres        []domain.SeriesGenre `json:"genres"`
-	ChapterCount  int                  `json:"chapterCount"`
-	Rating        float64              `json:"rating"`
+	LastChapterAt time.Time          `json:"lastChapterAt"`
+	UpdatedAt     time.Time          `json:"updatedAt"`
+	CreatedAt     time.Time          `json:"createdAt"`
+	Description   string             `json:"description"`
+	Title         string             `json:"title"`
+	Cover         string             `json:"cover"`
+	Status        sources.SeriesStatus `json:"status"`
+	Type          sources.SeriesType   `json:"type"`
+	Author        string             `json:"author"`
+	Artist        string             `json:"artist"`
+	SourceURL     string             `json:"sourceUrl"`
+	PublicURL     string             `json:"publicUrl"`
+	Slug          string             `json:"slug"`
+	AltTitles     []string           `json:"altTitles"`
+	Genres        []string           `json:"genres"`
+	ChapterCount  int                `json:"chapterCount"`
+	Rating        float64            `json:"rating"`
 }
 
 type getChaptersListBySeriesResItemDTO struct {

--- a/api/pkg/sources/asurascans/pkg/gateway/http/dto.go
+++ b/api/pkg/sources/asurascans/pkg/gateway/http/dto.go
@@ -142,10 +142,10 @@ func parseGenres(raw string) ([]string, error) {
 	for _, part := range parts {
 		genre := strings.TrimSpace(part)
 		if genre == "" {
-			continue
+			return nil, fmt.Errorf("genre is empty")
 		}
 
-		genres = append(genres, string(genre))
+		genres = append(genres, genre)
 	}
 
 	return genres, nil
@@ -169,23 +169,23 @@ func parsePositiveInt(raw string) (int, error) {
 }
 
 type getInfosBySlugResDTO struct {
-	LastChapterAt time.Time          `json:"lastChapterAt"`
-	UpdatedAt     time.Time          `json:"updatedAt"`
-	CreatedAt     time.Time          `json:"createdAt"`
-	Description   string             `json:"description"`
-	Title         string             `json:"title"`
-	Cover         string             `json:"cover"`
+	LastChapterAt time.Time            `json:"lastChapterAt"`
+	UpdatedAt     time.Time            `json:"updatedAt"`
+	CreatedAt     time.Time            `json:"createdAt"`
+	Description   string               `json:"description"`
+	Title         string               `json:"title"`
+	Cover         string               `json:"cover"`
 	Status        sources.SeriesStatus `json:"status"`
 	Type          sources.SeriesType   `json:"type"`
-	Author        string             `json:"author"`
-	Artist        string             `json:"artist"`
-	SourceURL     string             `json:"sourceUrl"`
-	PublicURL     string             `json:"publicUrl"`
-	Slug          string             `json:"slug"`
-	AltTitles     []string           `json:"altTitles"`
-	Genres        []string           `json:"genres"`
-	ChapterCount  int                `json:"chapterCount"`
-	Rating        float64            `json:"rating"`
+	Author        string               `json:"author"`
+	Artist        string               `json:"artist"`
+	SourceURL     string               `json:"sourceUrl"`
+	PublicURL     string               `json:"publicUrl"`
+	Slug          string               `json:"slug"`
+	AltTitles     []string             `json:"altTitles"`
+	Genres        []string             `json:"genres"`
+	ChapterCount  int                  `json:"chapterCount"`
+	Rating        float64              `json:"rating"`
 }
 
 type getChaptersListBySeriesResItemDTO struct {

--- a/api/pkg/sources/asurascans/pkg/transport/http/client_test.go
+++ b/api/pkg/sources/asurascans/pkg/transport/http/client_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/domain"
 	asurahttp "github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/transport/http"
 )
@@ -103,7 +104,7 @@ func TestSearchRequestShape(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":[],"meta":{}}`))
 	})
 
-	if _, err := c.Search(context.Background(), domain.SearchOpts{}); err != nil {
+	if _, err := c.Search(context.Background(), domain.SearchCacheOpts{}); err != nil {
 		t.Fatalf("Search: %v", err)
 	}
 
@@ -145,16 +146,16 @@ func TestSearchQueryParameters(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	opts := domain.SearchOpts{
+	opts := domain.SearchCacheOpts{
 		Offset:    40,
 		Limit:     5,
 		Search:    "one piece",
 		Sort:      domain.SortTypeTitle,
 		SortOrder: domain.SortOrderAsc,
-		Status:    domain.SeriesStatusOngoing,
+		Status:    sources.SeriesStatusOngoing,
 		Type:      "manga",
 		Artist:    "oda",
-		Genres:    []domain.SeriesGenre{domain.SeriesGenreAction, domain.SeriesGenreAdventure},
+		Genres:    []string{"action", "adventure"},
 	}
 
 	if _, err := c.Search(context.Background(), opts); err != nil {
@@ -167,7 +168,7 @@ func TestSearchQueryParameters(t *testing.T) {
 		"search": "one piece",
 		"sort":   "title",
 		"order":  "asc",
-		"status": string(domain.SeriesStatusOngoing),
+		"status": string(sources.SeriesStatusOngoing),
 		"type":   "manga",
 		"artist": "oda",
 		"genres": "action,adventure",
@@ -209,7 +210,7 @@ func TestSearchDefaultOrderFollowsSort(t *testing.T) {
 				t.Fatalf("New: %v", err)
 			}
 
-			if _, err := c.Search(context.Background(), domain.SearchOpts{Sort: tc.sort}); err != nil {
+			if _, err := c.Search(context.Background(), domain.SearchCacheOpts{Sort: tc.sort}); err != nil {
 				t.Fatalf("Search: %v", err)
 			}
 
@@ -246,7 +247,7 @@ func TestSearchDecodesResponse(t *testing.T) {
 		_, _ = w.Write([]byte(body))
 	})
 
-	res, err := c.Search(context.Background(), domain.SearchOpts{})
+	res, err := c.Search(context.Background(), domain.SearchCacheOpts{})
 	if err != nil {
 		t.Fatalf("Search: %v", err)
 	}
@@ -264,11 +265,11 @@ func TestSearchDecodesResponse(t *testing.T) {
 		t.Errorf("item = %+v", item)
 	}
 
-	if item.Status != domain.SeriesStatusOngoing {
-		t.Errorf("status = %q, want %q", item.Status, domain.SeriesStatusOngoing)
+	if item.Status != sources.SeriesStatusOngoing {
+		t.Errorf("status = %q, want %q", item.Status, sources.SeriesStatusOngoing)
 	}
 
-	if len(item.Genres) != 1 || item.Genres[0] != domain.SeriesGenre("action") {
+	if len(item.Genres) != 1 || item.Genres[0] != string("action") {
 		t.Errorf("genres = %v", item.Genres)
 	}
 
@@ -294,7 +295,7 @@ func TestSearchServerErrors(t *testing.T) {
 				w.WriteHeader(status)
 			})
 
-			if _, err := c.Search(context.Background(), domain.SearchOpts{}); err == nil {
+			if _, err := c.Search(context.Background(), domain.SearchCacheOpts{}); err == nil {
 				t.Errorf("Search on %d = nil, want error", status)
 			}
 		})
@@ -308,7 +309,7 @@ func TestSearchMalformedJSON(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data": [`))
 	})
 
-	if _, err := c.Search(context.Background(), domain.SearchOpts{}); err == nil {
+	if _, err := c.Search(context.Background(), domain.SearchCacheOpts{}); err == nil {
 		t.Error("Search on truncated JSON = nil, want error")
 	}
 }
@@ -323,7 +324,7 @@ func TestSearchHonoursContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	if _, err := c.Search(ctx, domain.SearchOpts{}); !errors.Is(err, context.Canceled) {
+	if _, err := c.Search(ctx, domain.SearchCacheOpts{}); !errors.Is(err, context.Canceled) {
 		t.Errorf("Search = %v, want context.Canceled", err)
 	}
 }
@@ -527,7 +528,7 @@ func TestSearchNotFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	if _, err := c.Search(context.Background(), domain.SearchOpts{}); !errors.Is(err, domain.ErrNotFound) {
+	if _, err := c.Search(context.Background(), domain.SearchCacheOpts{}); !errors.Is(err, domain.ErrNotFound) {
 		t.Errorf("Search on 404 = %v, want domain.ErrNotFound", err)
 	}
 }

--- a/api/pkg/sources/asurascans/pkg/transport/http/getchapterslistbyserie.go
+++ b/api/pkg/sources/asurascans/pkg/transport/http/getchapterslistbyserie.go
@@ -40,7 +40,7 @@ func (c *Client) GetChaptersListBySerie(ctx context.Context, seriesSlug string) 
 		return nil, fmt.Errorf("json.Decode: %w", err)
 	}
 
-	ch := parsed.ToDomain()
+	ch := parsed.Domain()
 
 	return &ch, nil
 }
@@ -49,7 +49,7 @@ type getSeriesChaptersHttpResponse struct {
 	Chapters []getSeriesChaptersHttpChapter `json:"data"`
 }
 
-func (r *getSeriesChaptersHttpResponse) ToDomain() []domain.Chapter {
+func (r *getSeriesChaptersHttpResponse) Domain() []domain.Chapter {
 	chapters := make([]domain.Chapter, len(r.Chapters))
 	for i, c := range r.Chapters {
 		chapters[i] = domain.Chapter{

--- a/api/pkg/sources/asurascans/pkg/transport/http/getimagesurlsbychapter.go
+++ b/api/pkg/sources/asurascans/pkg/transport/http/getimagesurlsbychapter.go
@@ -46,7 +46,7 @@ func (c *Client) GetImageURLsByChapter(ctx context.Context, opts domain.GetImage
 		return nil, fmt.Errorf("json.Decode: %w", err)
 	}
 
-	urls := parsed.ToDomain()
+	urls := parsed.Domain()
 
 	return &urls, nil
 }
@@ -127,7 +127,7 @@ type getChapterHttpResponse struct {
 	} `json:"data"`
 }
 
-func (c *getChapterHttpResponse) ToDomain() []string {
+func (c *getChapterHttpResponse) Domain() []string {
 	urls := make([]string, len(c.Data.Chapter.Pages))
 	for i, p := range c.Data.Chapter.Pages {
 		urls[i] = p.URL

--- a/api/pkg/sources/asurascans/pkg/transport/http/getinfosbyslug.go
+++ b/api/pkg/sources/asurascans/pkg/transport/http/getinfosbyslug.go
@@ -52,7 +52,7 @@ type getInfosBySlugHttpResponse struct {
 func (r *getInfosBySlugHttpResponse) Domain() *domain.GetInfosBySlugResponse {
 	genres := make([]string, len(r.Series.Genres))
 	for i, g := range r.Series.Genres {
-		genres[i] = string(g.Slug)
+		genres[i] = g.Slug
 	}
 
 	return &domain.GetInfosBySlugResponse{

--- a/api/pkg/sources/asurascans/pkg/transport/http/getinfosbyslug.go
+++ b/api/pkg/sources/asurascans/pkg/transport/http/getinfosbyslug.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/domain"
 )
 
@@ -49,9 +50,9 @@ type getInfosBySlugHttpResponse struct {
 }
 
 func (r *getInfosBySlugHttpResponse) Domain() *domain.GetInfosBySlugResponse {
-	genres := make([]domain.SeriesGenre, len(r.Series.Genres))
+	genres := make([]string, len(r.Series.Genres))
 	for i, g := range r.Series.Genres {
-		genres[i] = domain.SeriesGenre(g.Slug)
+		genres[i] = string(g.Slug)
 	}
 
 	return &domain.GetInfosBySlugResponse{
@@ -60,8 +61,8 @@ func (r *getInfosBySlugHttpResponse) Domain() *domain.GetInfosBySlugResponse {
 		AltTitles:     r.Series.AltTitles,
 		Description:   r.Series.Description,
 		Cover:         r.Series.Cover,
-		Status:        domain.SeriesStatus(r.Series.Status),
-		Type:          domain.SeriesType(r.Series.Type),
+		Status:        sources.SeriesStatus(r.Series.Status),
+		Type:          sources.SeriesType(r.Series.Type),
 		Author:        r.Series.Author,
 		Artist:        r.Series.Artist,
 		Rating:        r.Series.Rating,

--- a/api/pkg/sources/asurascans/pkg/transport/http/getinfosbyslug.go
+++ b/api/pkg/sources/asurascans/pkg/transport/http/getinfosbyslug.go
@@ -40,7 +40,7 @@ func (c *Client) GetInfosBySlug(ctx context.Context, slug string) (*domain.GetIn
 		return nil, fmt.Errorf("json.Decode: %w", err)
 	}
 
-	return parsed.ToDomain(), nil
+	return parsed.Domain(), nil
 }
 
 type getInfosBySlugHttpResponse struct {
@@ -48,7 +48,7 @@ type getInfosBySlugHttpResponse struct {
 	Series            getInfosBySlugHttpSeries              `json:"series"`
 }
 
-func (r *getInfosBySlugHttpResponse) ToDomain() *domain.GetInfosBySlugResponse {
+func (r *getInfosBySlugHttpResponse) Domain() *domain.GetInfosBySlugResponse {
 	genres := make([]domain.SeriesGenre, len(r.Series.Genres))
 	for i, g := range r.Series.Genres {
 		genres[i] = domain.SeriesGenre(g.Slug)

--- a/api/pkg/sources/asurascans/pkg/transport/http/search.go
+++ b/api/pkg/sources/asurascans/pkg/transport/http/search.go
@@ -78,7 +78,7 @@ func (c *Client) builSearchQuery(opts domain.SearchCacheOpts) string {
 		q.Add("genres", strings.Join(utils.MapSlice(
 			withDefaults.Genres,
 			func(g string) string {
-				return string(g)
+				return g
 			}),
 			","))
 	}
@@ -119,7 +119,7 @@ func (r *searchHTTPResponse) Domain() *domain.SearchCacheResult {
 	for i, data := range r.Data {
 		genres := make([]string, len(data.Genres))
 		for j, g := range data.Genres {
-			genres[j] = string(g.Slug)
+			genres[j] = g.Slug
 		}
 
 		latestChapters := make([]domain.SearchResultItemChapter, len(r.Data[i].LatestChapters))

--- a/api/pkg/sources/asurascans/pkg/transport/http/search.go
+++ b/api/pkg/sources/asurascans/pkg/transport/http/search.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils"
 )
@@ -76,7 +77,7 @@ func (c *Client) builSearchQuery(opts domain.SearchCacheOpts) string {
 	if len(withDefaults.Genres) > 0 {
 		q.Add("genres", strings.Join(utils.MapSlice(
 			withDefaults.Genres,
-			func(g domain.SeriesGenre) string {
+			func(g string) string {
 				return string(g)
 			}),
 			","))
@@ -116,9 +117,9 @@ func (r *searchHTTPResponse) Domain() *domain.SearchCacheResult {
 
 	items := make([]domain.SearchCacheResultItem, len(r.Data))
 	for i, data := range r.Data {
-		genres := make([]domain.SeriesGenre, len(data.Genres))
+		genres := make([]string, len(data.Genres))
 		for j, g := range data.Genres {
-			genres[j] = domain.SeriesGenre(g.Slug)
+			genres[j] = string(g.Slug)
 		}
 
 		latestChapters := make([]domain.SearchResultItemChapter, len(r.Data[i].LatestChapters))
@@ -139,8 +140,8 @@ func (r *searchHTTPResponse) Domain() *domain.SearchCacheResult {
 			AltTitles:      data.AltTitles,
 			Description:    data.Description,
 			Cover:          data.Cover,
-			Status:         domain.SeriesStatus(data.Status),
-			Type:           domain.SeriesType(data.Type),
+			Status:         sources.SeriesStatus(data.Status),
+			Type:           sources.SeriesType(data.Type),
 			Author:         data.Author,
 			Artist:         data.Artist,
 			Rating:         data.Rating,

--- a/api/pkg/sources/asurascans/pkg/transport/http/search.go
+++ b/api/pkg/sources/asurascans/pkg/transport/http/search.go
@@ -16,7 +16,7 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils"
 )
 
-func (c *Client) Search(ctx context.Context, opts domain.SearchOpts) (*domain.SearchResult, error) {
+func (c *Client) Search(ctx context.Context, opts domain.SearchCacheOpts) (*domain.SearchCacheResult, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/series", c.cfg.AsuraURL), nil)
 	if err != nil {
 		return nil, fmt.Errorf("http.NewRequestWithContext: %w", err)
@@ -49,7 +49,7 @@ func (c *Client) Search(ctx context.Context, opts domain.SearchOpts) (*domain.Se
 	return parsedResult.Domain(), nil
 }
 
-func (c *Client) builSearchQuery(opts domain.SearchOpts) string {
+func (c *Client) builSearchQuery(opts domain.SearchCacheOpts) string {
 	withDefaults := c.getSearchOptsWithDefaults(opts)
 	q := url.Values{}
 	q.Add("offset", strconv.Itoa(withDefaults.Offset))
@@ -85,7 +85,7 @@ func (c *Client) builSearchQuery(opts domain.SearchOpts) string {
 	return q.Encode()
 }
 
-func (c *Client) getSearchOptsWithDefaults(opts domain.SearchOpts) domain.SearchOpts {
+func (c *Client) getSearchOptsWithDefaults(opts domain.SearchCacheOpts) domain.SearchCacheOpts {
 	withDefaults := opts
 	if withDefaults.Limit == 0 {
 		withDefaults.Limit = 20
@@ -107,14 +107,14 @@ type searchHTTPResponse struct {
 	Meta searchHTTPResponseMeta   `json:"meta"`
 }
 
-func (r *searchHTTPResponse) Domain() *domain.SearchResult {
+func (r *searchHTTPResponse) Domain() *domain.SearchCacheResult {
 	meta := domain.SearchResultMeta{
 		Total:   r.Meta.Total,
 		PerPage: r.Meta.PerPage,
 		HasMore: r.Meta.HasMore,
 	}
 
-	items := make([]domain.SearchResultItem, len(r.Data))
+	items := make([]domain.SearchCacheResultItem, len(r.Data))
 	for i, data := range r.Data {
 		genres := make([]domain.SeriesGenre, len(data.Genres))
 		for j, g := range data.Genres {
@@ -132,7 +132,7 @@ func (r *searchHTTPResponse) Domain() *domain.SearchResult {
 			}
 		}
 
-		items[i] = domain.SearchResultItem{
+		items[i] = domain.SearchCacheResultItem{
 			ID:             data.ID,
 			Slug:           data.Slug,
 			Title:          data.Title,
@@ -152,11 +152,10 @@ func (r *searchHTTPResponse) Domain() *domain.SearchResult {
 			SourceURL:      data.SourceURL,
 			Genres:         genres,
 			LatestChapters: latestChapters,
-			ReleaseYear:    data.ReleaseYear,
 		}
 	}
 
-	return &domain.SearchResult{
+	return &domain.SearchCacheResult{
 		Meta:  meta,
 		Items: items,
 	}

--- a/api/pkg/sources/asurascans/pkg/transport/http/search.go
+++ b/api/pkg/sources/asurascans/pkg/transport/http/search.go
@@ -46,7 +46,7 @@ func (c *Client) Search(ctx context.Context, opts domain.SearchOpts) (*domain.Se
 		return nil, fmt.Errorf("json.Decode: %w", err)
 	}
 
-	return parsedResult.ToDomain(), nil
+	return parsedResult.Domain(), nil
 }
 
 func (c *Client) builSearchQuery(opts domain.SearchOpts) string {
@@ -107,7 +107,7 @@ type searchHTTPResponse struct {
 	Meta searchHTTPResponseMeta   `json:"meta"`
 }
 
-func (r *searchHTTPResponse) ToDomain() *domain.SearchResult {
+func (r *searchHTTPResponse) Domain() *domain.SearchResult {
 	meta := domain.SearchResultMeta{
 		Total:   r.Meta.Total,
 		PerPage: r.Meta.PerPage,
@@ -168,7 +168,7 @@ type searchHTTPResponseMeta struct {
 	HasMore bool `json:"has_more"`
 }
 
-func (meta *searchHTTPResponseMeta) ToDomain() domain.SearchResultMeta {
+func (meta *searchHTTPResponseMeta) Domain() domain.SearchResultMeta {
 	return domain.SearchResultMeta{
 		Total:   meta.Total,
 		PerPage: meta.PerPage,

--- a/api/pkg/sources/domain.go
+++ b/api/pkg/sources/domain.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sources
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+type SourceMap map[SourceName]Source
+
+type SourceName string
+
+const (
+	SourceAsuraScans SourceName = "asurascans"
+)
+
+func ParseSourceName(s string) (SourceName, error) {
+	switch s {
+	case string(SourceAsuraScans):
+		return SourceAsuraScans, nil
+	default:
+		return "", fmt.Errorf("invalid source name: %s", s)
+	}
+}
+
+type SeriesType string
+
+const (
+	SeriesTypeManga     SeriesType = "manga"
+	SeriesTypeMangatoon SeriesType = "mangatoon"
+	SeriesTypeManhua    SeriesType = "manhua"
+	SeriesTypeManhwa    SeriesType = "manhwa"
+)
+
+func ParseSeriesType(s string) (SeriesType, error) {
+	switch s {
+	case "manga":
+		return SeriesTypeManga, nil
+	case "mangatoon":
+		return SeriesTypeMangatoon, nil
+	case "manhua":
+		return SeriesTypeManhua, nil
+	case "manhwa":
+		return SeriesTypeManhwa, nil
+	default:
+		return "", fmt.Errorf("invalid series type: %s", s)
+	}
+}
+
+type SeriesStatus string
+
+const (
+	SeriesStatusOngoing   SeriesStatus = "ongoing"
+	SeriesStatusCompleted SeriesStatus = "completed"
+	SeriesStatusHiatus    SeriesStatus = "hiatus"
+	SeriesStatusCancelled SeriesStatus = "cancelled"
+	SeriesStatusDropped   SeriesStatus = "dropped"
+)
+
+func ParseSeriesStatus(s string) (SeriesStatus, error) {
+	switch s {
+	case "ongoing":
+		return SeriesStatusOngoing, nil
+	case "completed":
+		return SeriesStatusCompleted, nil
+	case "hiatus":
+		return SeriesStatusHiatus, nil
+	case "cancelled":
+		return SeriesStatusCancelled, nil
+	case "dropped":
+		return SeriesStatusDropped, nil
+	default:
+		return "", fmt.Errorf("invalid series status: %s", s)
+	}
+}
+
+type Source interface {
+	GetInfosBySlug(context.Context, string) (*GetInfosBySlugResponse, error)
+}
+
+type GetInfosBySlugResponse struct {
+	LastChapterAt time.Time
+	UpdatedAt     time.Time
+	CreatedAt     time.Time
+	Description   string
+	Title         string
+	Cover         string
+	Status        SeriesStatus
+	Type          SeriesType
+	Author        string
+	Artist        string
+	SourceURL     string
+	PublicURL     string
+	Slug          string
+	AltTitles     []string
+	Genres        []string
+	ChapterCount  int
+	Rating        float64
+}

--- a/api/pkg/utils/slices.go
+++ b/api/pkg/utils/slices.go
@@ -22,3 +22,13 @@ func FilterSlice[T any](s []T, f func(T) bool) []T {
 
 	return filtered
 }
+
+func ContainsSlice[T any](s []T, f func(T) bool) bool {
+	for _, i := range s {
+		if f(i) {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
## Summary

Implements the Comics bounded context as the public HTTP surface for library management (closes #20).

- **`POST /api/comics`** — add a comic by `source` + `slug`; fetches metadata from the source, creates the comic and library entry in a transaction; idempotent when the comic is already in the user's library
- **`GET /api/comics`** — list the authenticated user's comics with optional filters (`source`, `type`, `status`, `limit`, `offset`)
- **`GET /api/comics/{id}`** — get one comic owned by the authenticated user
- **`DELETE /api/comics/{id}`** — remove the user's library link; comic record is deleted only when no other users reference it

Also refactors the comic and library data models, adds `Domain()` methods on all `pgmodels`, and aligns the AsuraScans source client with the shared `sources` domain types.

## Test plan

- [x] `go test ./pkg/core/comics/...`
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Manual: `POST /api/comics` with a valid Asura slug while authenticated
- [x] Manual: `GET /api/comics` returns the added comic
- [x] Manual: `DELETE /api/comics/{id}` removes it from the user's library