### PR TITLE
feat(chapters): add chapters data model

### DIFF
--- a/api/pkg/core/chapters/domain.go
+++ b/api/pkg/core/chapters/domain.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package chapters
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Chapter struct {
+	PublishedAt       time.Time
+	EarlyAccessUntil  time.Time
+	SourceChapterSlug string
+	Title             string
+	Number            float64
+	PagesNb           int
+	Download          int
+	ID                uuid.UUID
+	ComicID           uuid.UUID
+}
+
+type ChaptersRepository interface {
+	Create(context.Context, CreateOpts) (*Chapter, error)
+	ListByComicID(context.Context, uuid.UUID) ([]Chapter, error)
+}
+
+type CreateOpts struct {
+	PublishedAt       time.Time
+	EarlyAccessUntil  time.Time
+	SourceChapterSlug string
+	Title             string
+	Number            float64
+	PagesNb           int
+	ComicID           uuid.UUID
+}

--- a/api/pkg/core/chapters/repository/pg/repository.go
+++ b/api/pkg/core/chapters/repository/pg/repository.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package pg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/repository/pgmodels"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/transaction/pgtx"
+	"gorm.io/gorm"
+)
+
+var _ chapters.ChaptersRepository = (*PGChaptersRepository)(nil)
+
+type Deps struct {
+	DB *gorm.DB
+}
+
+func (deps *Deps) Validate() error {
+	if deps.DB == nil {
+		return errors.New("db is required")
+	}
+
+	return nil
+}
+
+type PGChaptersRepository struct {
+	deps Deps
+}
+
+func New(deps Deps) (*PGChaptersRepository, error) {
+	if err := deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	r := &PGChaptersRepository{deps: deps}
+
+	return r, nil
+}
+
+func (r *PGChaptersRepository) db(ctx context.Context) gorm.Interface[pgmodels.Chapter] {
+	return gorm.G[pgmodels.Chapter](pgtx.From(ctx, r.deps.DB))
+}
+
+func (r *PGChaptersRepository) Create(ctx context.Context, opts chapters.CreateOpts) (*chapters.Chapter, error) {
+	model := &pgmodels.Chapter{
+		ID:                uuid.New(),
+		ComicID:           opts.ComicID,
+		SourceChapterSlug: opts.SourceChapterSlug,
+		Number:            opts.Number,
+		Title:             opts.Title,
+		PagesNb:           opts.PagesNb,
+		PublishedAt:       opts.PublishedAt,
+		EarlyAccessUntil:  opts.EarlyAccessUntil,
+	}
+
+	err := r.db(ctx).Create(ctx, model)
+	if err != nil {
+		if errors.Is(err, gorm.ErrDuplicatedKey) {
+			return nil, domain.ErrAlreadyExists
+		}
+
+		return nil, fmt.Errorf("r.db(ctx).Create: %w", err)
+	}
+
+	ret := model.Domain()
+
+	return &ret, nil
+}
+
+func (r *PGChaptersRepository) ListByComicID(ctx context.Context, comicID uuid.UUID) ([]chapters.Chapter, error) {
+	models, err := r.db(ctx).Where("comic_id = ?", comicID).Order("number ASC").Find(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
+	}
+
+	ret := make([]chapters.Chapter, 0, len(models))
+	for _, model := range models {
+		ret = append(ret, model.Domain())
+	}
+
+	return ret, nil
+}

--- a/api/pkg/core/chapters/repository/pg/repository_test.go
+++ b/api/pkg/core/chapters/repository/pg/repository_test.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package pg_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters/repository/pg"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/repository/pgtest"
+)
+
+const (
+	chapterSlug  = "chapter-1"
+	chapterTitle = "Chapter 1"
+)
+
+func duplicateChapterKeyErr() error {
+	return &pgconn.PgError{
+		Code:    "23505",
+		Message: `duplicate key value violates unique constraint "idx_chapter_comic_source_slug"`,
+	}
+}
+
+func newChaptersRepo(t *testing.T) (*pg.PGChaptersRepository, sqlmock.Sqlmock) {
+	t.Helper()
+
+	db, mock := pgtest.New(t)
+
+	r, err := pg.New(pg.Deps{DB: db})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	return r, mock
+}
+
+func TestChaptersNewValidatesDeps(t *testing.T) {
+	t.Parallel()
+
+	r, err := pg.New(pg.Deps{})
+	if err == nil {
+		t.Fatal("New without DB must fail")
+	}
+
+	if r != nil {
+		t.Error("New returned a repository in addition to the error")
+	}
+
+	if want := "deps.Validate: db is required"; err.Error() != want {
+		t.Errorf("err = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestChaptersCreate(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newChaptersRepo(t)
+
+	comicID := uuid.New()
+	publishedAt := time.Now().Add(-24 * time.Hour).UTC().Truncate(time.Second)
+	earlyAccessUntil := time.Now().Add(24 * time.Hour).UTC().Truncate(time.Second)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`INSERT INTO "chapters"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+	mock.ExpectCommit()
+
+	got, err := r.Create(context.Background(), chapters.CreateOpts{
+		ComicID:           comicID,
+		SourceChapterSlug: chapterSlug,
+		Number:            1,
+		Title:             chapterTitle,
+		PagesNb:           42,
+		PublishedAt:       publishedAt,
+		EarlyAccessUntil:  earlyAccessUntil,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if got.ComicID != comicID || got.SourceChapterSlug != chapterSlug {
+		t.Errorf("Create() = %+v", got)
+	}
+
+	if got.Number != 1 || got.Title != chapterTitle || got.PagesNb != 42 {
+		t.Errorf("Create() = %+v", got)
+	}
+
+	if got.PublishedAt != publishedAt || got.EarlyAccessUntil != earlyAccessUntil {
+		t.Errorf("Create() timestamps = published %v early %v", got.PublishedAt, got.EarlyAccessUntil)
+	}
+
+	if got.ID == uuid.Nil {
+		t.Error("Create did not generate ID")
+	}
+
+	if got.Download != 0 {
+		t.Errorf("Create() download = %d, want 0", got.Download)
+	}
+}
+
+func TestChaptersCreateDuplicateKey(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newChaptersRepo(t)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`INSERT INTO "chapters"`).WillReturnError(duplicateChapterKeyErr())
+	mock.ExpectRollback()
+
+	got, err := r.Create(context.Background(), chapters.CreateOpts{
+		ComicID:           uuid.New(),
+		SourceChapterSlug: chapterSlug,
+		Number:            1,
+		Title:             chapterTitle,
+		PublishedAt:       time.Now(),
+	})
+	if !errors.Is(err, domain.ErrAlreadyExists) {
+		t.Errorf("Create = %v, want domain.ErrAlreadyExists", err)
+	}
+
+	if got != nil {
+		t.Errorf("Create returned %+v in addition to the error", got)
+	}
+}
+
+func TestChaptersListByComicID(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newChaptersRepo(t)
+
+	comicID := uuid.New()
+	id := uuid.New()
+	publishedAt := time.Now().UTC().Truncate(time.Second)
+
+	mock.ExpectQuery(`FROM "chapters".*comic_id = \$1`).
+		WithArgs(comicID).
+		WillReturnRows(
+			sqlmock.NewRows([]string{
+				"id", "comic_id", "source_chapter_slug", "number", "title",
+				"pages_nb", "published_at", "early_access_until", "download",
+			}).AddRow(
+				id, comicID, chapterSlug, 1.0, chapterTitle,
+				42, publishedAt, publishedAt, 0,
+			),
+		)
+
+	got, err := r.ListByComicID(context.Background(), comicID)
+	if err != nil {
+		t.Fatalf("ListByComicID: %v", err)
+	}
+
+	if len(got) != 1 || got[0].ID != id || got[0].ComicID != comicID {
+		t.Errorf("ListByComicID() = %+v", got)
+	}
+}

--- a/api/pkg/repository/pgmodels/chapter.go
+++ b/api/pkg/repository/pgmodels/chapter.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package pgmodels
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
+)
+
+type Chapter struct {
+	PublishedAt      time.Time `gorm:"not null"`
+	EarlyAccessUntil time.Time `gorm:"not null"`
+	//nolint:lll
+	SourceChapterSlug string    `gorm:"column:source_chapter_slug;type:text;not null;uniqueIndex:idx_chapter_comic_source_slug,priority:2"`
+	Title             string    `gorm:"type:text"`
+	Comic             Comic     `gorm:"foreignKey:ComicID;constraint:OnDelete:CASCADE"`
+	Number            float64   `gorm:"not null"`
+	PagesNb           int       `gorm:"column:pages_nb;not null;default:0"`
+	Download          int       `gorm:"not null;default:0"`
+	ID                uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+	ComicID           uuid.UUID `gorm:"type:uuid;not null;uniqueIndex:idx_chapter_comic_source_slug,priority:1;index"`
+}
+
+func (Chapter) TableName() string {
+	return "chapters"
+}
+
+func (c *Chapter) Domain() chapters.Chapter {
+	return chapters.Chapter{
+		ID:                c.ID,
+		ComicID:           c.ComicID,
+		SourceChapterSlug: c.SourceChapterSlug,
+		Number:            c.Number,
+		Title:             c.Title,
+		PagesNb:           c.PagesNb,
+		PublishedAt:       c.PublishedAt,
+		EarlyAccessUntil:  c.EarlyAccessUntil,
+		Download:          c.Download,
+	}
+}

--- a/api/pkg/repository/pgmodels/comic.go
+++ b/api/pkg/repository/pgmodels/comic.go
@@ -30,6 +30,7 @@ type Comic struct {
 	Genres         pq.StringArray     `gorm:"type:text[];not null;default:'{}'"`
 	AltTitles      pq.StringArray     `gorm:"type:text[];not null;default:'{}'"`
 	LibraryEntries []LibraryEntry     `gorm:"foreignKey:ComicID"`
+	Chapters       []Chapter          `gorm:"foreignKey:ComicID;constraint:OnDelete:CASCADE"`
 	ChapterCount   int
 	ID             uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
 }

--- a/api/pkg/utils/database/pgdb.go
+++ b/api/pkg/utils/database/pgdb.go
@@ -108,6 +108,7 @@ func (pgdb *PGDB) Migrate() error {
 	models := []any{
 		&pgmodels.User{},
 		&pgmodels.Comic{},
+		&pgmodels.Chapter{},
 		&pgmodels.FederatedIdentity{},
 		&pgmodels.OIDCProvider{},
 		&pgmodels.Session{},


### PR DESCRIPTION
## Summary

Closes #33

- Add `chapters` GORM model with unique constraint on `(comic_id, source_chapter_slug)` and cascade delete when a comic is removed
- Introduce `chapters` bounded context with domain types, repository interface, and PostgreSQL implementation (`Create`, `ListByComicID`)
- Register the model in GORM AutoMigrate and link chapters to comics in `pgmodels`

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Repository tests via `pkg/repository/pgtest` (create, duplicate key, list by comic ID)


Made with [Cursor](https://cursor.com)