### PR TITLE
feat(chapters): add chapter download worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,4 @@ docs/design
 api/uchiyomiserver
 .cursor
 CONTEXT.md
-./.data
+.data

--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,4 @@ docs/design
 api/uchiyomiserver
 .cursor
 CONTEXT.md
-./covers
+./.data

--- a/api/cmd/uchiyomiserver/config.go
+++ b/api/cmd/uchiyomiserver/config.go
@@ -18,7 +18,11 @@ type cfg struct {
 		Level logging.LogLevel `env:"LOG_LEVEL" envDefault:"info"`
 	}
 	Covers struct {
-		Dir string `env:"COVERS_DIR" envDefault:"covers"`
+		Dir string `env:"COVERS_DIR" envDefault:"data/cache/covers"`
+	}
+	Downloads struct {
+		Dir       string        `env:"DOWNLOADS_DIR" envDefault:"data/downloads"`
+		RateLimit time.Duration `env:"CHAPTER_DOWNLOAD_RATE_LIMIT" envDefault:"500ms"`
 	}
 	PG struct {
 		Host        string `env:"DB_HOST,required"`

--- a/api/cmd/uchiyomiserver/setup.go
+++ b/api/cmd/uchiyomiserver/setup.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//nolint:goconst,lll
 package main
 
 import (

--- a/api/cmd/uchiyomiserver/setup.go
+++ b/api/cmd/uchiyomiserver/setup.go
@@ -39,6 +39,7 @@ import (
 	httpsession "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/gateway/http"
 	pgsessions "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/repository/pg"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters/download"
 	pgchapters "github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters/repository/pg"
 	pgcomics "github.com/kharente-deuh/uchiyomi-server/pkg/core/comics/repository/pg"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
@@ -59,10 +60,12 @@ const oidcCallbackPath = core.APIPrefix + "/auth/oidc/callback"
 func setupApp(cfg *cfg) (*core.App, error) {
 	logger := logging.New(logging.Config{Level: cfg.Logger.Level})
 
-	coversDir, err := utils.PrepareDataDir(logger, cfg.Covers.Dir, cfg.Runtime.UID, cfg.Runtime.GID)
-	if err != nil {
-		return nil, fmt.Errorf("utils.PrepareDataDir: %w", err)
+	if err := utils.PrepareDataDirs(logger, cfg.Runtime.UID, cfg.Runtime.GID, cfg.Covers.Dir, cfg.Downloads.Dir); err != nil {
+		return nil, fmt.Errorf("utils.PrepareDataDirs: %w", err)
 	}
+
+	coversDir := cfg.Covers.Dir
+	downloadsDir := cfg.Downloads.Dir
 
 	dbr, err := setupDBRelated(cfg, logger)
 	if err != nil {
@@ -108,11 +111,16 @@ func setupApp(cfg *cfg) (*core.App, error) {
 		return nil, err
 	}
 
-	chaptersSvc, err := chapters.NewService(chapters.Deps{
-		Repository: dbr.ChaptersRepository,
+	chaptersSvc, downloadApp, err := setupChapters(chaptersDeps{
+		Logger:             logger,
+		ChaptersRepository: dbr.ChaptersRepository,
+		ComicsRepository:   dbr.ComicsRepository,
+		Sources:            sources.SourceMap{sources.SourceAsuraScans: asuraApp},
+		DownloadsDir:       downloadsDir,
+		RateLimit:          cfg.Downloads.RateLimit,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to init chaptersSvc: %w", err)
+		return nil, fmt.Errorf("failed to init chapters: %w", err)
 	}
 
 	comicsSvc, err := comics.NewService(comics.Deps{
@@ -167,6 +175,7 @@ func setupApp(cfg *cfg) (*core.App, error) {
 			DB:               dbr.PGDB,
 			Asura:            apps.Asura,
 			Covers:           apps.Covers,
+			Downloads:        downloadApp,
 			Sessions:         apps.Sessions,
 			OIDCRevalidation: apps.OIDCRevalidation,
 		})
@@ -799,4 +808,58 @@ func setupCtrls(deps ctrlsDeps) (*ctrls, error) {
 	}
 
 	return c, nil
+}
+
+type chaptersDeps struct {
+	Logger             *slog.Logger
+	ChaptersRepository chapters.ChaptersRepository
+	ComicsRepository   comics.ComicsRepository
+	Sources            sources.SourceMap
+	DownloadsDir       string
+	RateLimit          time.Duration
+}
+
+func setupChapters(deps chaptersDeps) (*chapters.Service, *download.App, error) {
+	fetchTimeout := time.Minute
+
+	httpClient := &http.Client{
+		Timeout: fetchTimeout,
+		Transport: &http.Transport{
+			MaxIdleConns:        100,
+			MaxIdleConnsPerHost: 10,
+			IdleConnTimeout:     90 * time.Second,
+		},
+	}
+
+	worker, err := download.New(
+		download.Config{
+			Dir:       deps.DownloadsDir,
+			RateLimit: deps.RateLimit,
+		},
+		download.Deps{
+			ChaptersRepository: deps.ChaptersRepository,
+			ComicsRepository:   deps.ComicsRepository,
+			Sources:            deps.Sources,
+			HTTPClient:         httpClient,
+			Logger:             deps.Logger,
+		},
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("download.New: %w", err)
+	}
+
+	app, err := download.NewApp(worker)
+	if err != nil {
+		return nil, nil, fmt.Errorf("download.NewApp: %w", err)
+	}
+
+	svc, err := chapters.NewService(chapters.Deps{
+		Repository:        deps.ChaptersRepository,
+		ChapterDownloader: worker,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("chapters.NewService: %w", err)
+	}
+
+	return svc, app, nil
 }

--- a/api/cmd/uchiyomiserver/setup_internal_test.go
+++ b/api/cmd/uchiyomiserver/setup_internal_test.go
@@ -27,6 +27,10 @@ func (stubComicsRepository) GetByID(context.Context, comics.GetByIDOpts) (*comic
 	return nil, coredomain.ErrNotFound
 }
 
+func (stubComicsRepository) FindByID(context.Context, uuid.UUID) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
 func (stubComicsRepository) GetBySourceSlug(
 	context.Context, comics.GetBySourceSlugOpts,
 ) (*comics.Comic, error) {

--- a/api/pkg/core/app.go
+++ b/api/pkg/core/app.go
@@ -79,6 +79,7 @@ type Deps struct {
 
 	Asura            *asura.App
 	Covers           *covers.App
+	Downloads        interface{ Run(context.Context) error }
 	Sessions         *sessions.App
 	OIDCRevalidation interface{ Run(context.Context) error }
 }
@@ -110,6 +111,10 @@ func (deps *Deps) Validate() error {
 
 	if deps.Covers == nil {
 		return errors.New("covers is required")
+	}
+
+	if deps.Downloads == nil {
+		return errors.New("downloads is required")
 	}
 
 	if deps.Sessions == nil {
@@ -196,6 +201,7 @@ func (a *App) startup(ctx context.Context, errG *errgroup.Group) func() error {
 
 		errG.Go(a.runComponent(ctx, componentAsura, a.deps.Asura.Run))
 		errG.Go(a.runComponent(ctx, componentCovers, a.deps.Covers.Run))
+		errG.Go(a.runComponent(ctx, componentDownloads, a.deps.Downloads.Run))
 		errG.Go(a.runComponent(ctx, componentSessions, a.deps.Sessions.Run))
 		errG.Go(a.runComponent(ctx, componentOIDCRevalidation, a.deps.OIDCRevalidation.Run))
 

--- a/api/pkg/core/app_internal_test.go
+++ b/api/pkg/core/app_internal_test.go
@@ -141,7 +141,7 @@ func TestRunReportsEverythingOKOnceMigrationCompletes(t *testing.T) {
 
 	body := decodeReadyz(t, raw)
 	components := []string{
-		componentMigrations, componentAsura, componentSessions, componentOIDCRevalidation, componentDB,
+		componentMigrations, componentAsura, componentCovers, componentDownloads, componentSessions, componentOIDCRevalidation, componentDB,
 	}
 	for _, name := range components {
 		if got := body.Components[name].Status; got != string(health.StatusOK) {

--- a/api/pkg/core/app_internal_test.go
+++ b/api/pkg/core/app_internal_test.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//nolint:goconst,lll
 package core
 
 import (

--- a/api/pkg/core/chapters/domain.go
+++ b/api/pkg/core/chapters/domain.go
@@ -26,6 +26,13 @@ type ChaptersRepository interface {
 	Create(context.Context, CreateOpts) (*Chapter, error)
 	CreateMany(context.Context, []CreateOpts) ([]Chapter, error)
 	ListByComicID(context.Context, uuid.UUID) ([]Chapter, error)
+	GetByID(context.Context, uuid.UUID) (*Chapter, error)
+	UpdateDownload(context.Context, uuid.UUID, int) error
+	UpdatePagesNb(context.Context, uuid.UUID, int) error
+}
+
+type ChapterDownloader interface {
+	Enqueue(context.Context, []Chapter) error
 }
 
 type ChaptersService interface {

--- a/api/pkg/core/chapters/download/app.go
+++ b/api/pkg/core/chapters/download/app.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package download
+
+import "context"
+
+type App struct {
+	worker *Worker
+}
+
+func NewApp(worker *Worker) (*App, error) {
+	if worker == nil {
+		return nil, ErrWorkerRequired
+	}
+
+	return &App{worker: worker}, nil
+}
+
+func (a *App) Run(ctx context.Context) error {
+	//nolint:wrapcheck
+	return a.worker.Run(ctx)
+}

--- a/api/pkg/core/chapters/download/domain.go
+++ b/api/pkg/core/chapters/download/domain.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package download
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+type ProgressStatus string
+
+const (
+	ProgressStatusDownloading ProgressStatus = "downloading"
+	ProgressStatusCompleted   ProgressStatus = "completed"
+	ProgressStatusError       ProgressStatus = "error"
+)
+
+type ProgressEvent struct {
+	Status   ProgressStatus
+	Download int
+}
+
+type ProgressPublisher interface {
+	Publish(context.Context, uuid.UUID, ProgressEvent)
+}
+
+type noopPublisher struct{}
+
+func (noopPublisher) Publish(context.Context, uuid.UUID, ProgressEvent) {}

--- a/api/pkg/core/chapters/download/errors.go
+++ b/api/pkg/core/chapters/download/errors.go
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package download
+
+import "errors"
+
+var ErrWorkerRequired = errors.New("worker is required")

--- a/api/pkg/core/chapters/download/queue.go
+++ b/api/pkg/core/chapters/download/queue.go
@@ -122,15 +122,6 @@ func (q *queue) removeComicChapters(chapterIDs map[uuid.UUID]struct{}) {
 	}
 }
 
-func (q *queue) contains(chapterID uuid.UUID) bool {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-
-	_, ok := q.pending[chapterID]
-
-	return ok
-}
-
 func (q *queue) pendingCount() int {
 	q.mu.Lock()
 	defer q.mu.Unlock()

--- a/api/pkg/core/chapters/download/queue.go
+++ b/api/pkg/core/chapters/download/queue.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package download
+
+import (
+	"context"
+	"slices"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+)
+
+type queueItem struct {
+	ChapterID uuid.UUID
+	Number    float64
+}
+
+type queue struct {
+	pending map[uuid.UUID]struct{}
+	items   map[sources.SourceName][]queueItem
+	notify  map[sources.SourceName]chan struct{}
+	mu      sync.Mutex
+}
+
+func newQueue() *queue {
+	return &queue{
+		pending: make(map[uuid.UUID]struct{}),
+		items:   make(map[sources.SourceName][]queueItem),
+		notify:  make(map[sources.SourceName]chan struct{}),
+	}
+}
+
+func (q *queue) enqueue(source sources.SourceName, chapterList []chapters.Chapter) int {
+	sorted := slices.Clone(chapterList)
+	slices.SortFunc(sorted, func(a, b chapters.Chapter) int {
+		switch {
+		case a.Number < b.Number:
+			return -1
+		case a.Number > b.Number:
+			return 1
+		default:
+			return 0
+		}
+	})
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	added := 0
+	for _, chapter := range sorted {
+		if _, ok := q.pending[chapter.ID]; ok {
+			continue
+		}
+
+		q.pending[chapter.ID] = struct{}{}
+		q.items[source] = append(q.items[source], queueItem{
+			ChapterID: chapter.ID,
+			Number:    chapter.Number,
+		})
+		added++
+	}
+
+	if added > 0 {
+		q.signalLocked(source)
+	}
+
+	return added
+}
+
+func (q *queue) pop(ctx context.Context, source sources.SourceName) (queueItem, bool) {
+	for {
+		q.mu.Lock()
+		items := q.items[source]
+		if len(items) > 0 {
+			item := items[0]
+			q.items[source] = items[1:]
+			q.mu.Unlock()
+
+			return item, true
+		}
+
+		notify := q.notifyChannelLocked(source)
+		q.mu.Unlock()
+
+		select {
+		case <-notify:
+		case <-ctx.Done():
+			return queueItem{}, false
+		}
+	}
+}
+
+func (q *queue) done(chapterID uuid.UUID) {
+	q.mu.Lock()
+	delete(q.pending, chapterID)
+	q.mu.Unlock()
+}
+
+func (q *queue) removeComicChapters(chapterIDs map[uuid.UUID]struct{}) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	for source, items := range q.items {
+		filtered := items[:0]
+		for _, item := range items {
+			if _, belongs := chapterIDs[item.ChapterID]; belongs {
+				delete(q.pending, item.ChapterID)
+
+				continue
+			}
+
+			filtered = append(filtered, item)
+		}
+
+		if len(filtered) == 0 {
+			delete(q.items, source)
+		} else {
+			q.items[source] = filtered
+		}
+	}
+}
+
+func (q *queue) contains(chapterID uuid.UUID) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	_, ok := q.pending[chapterID]
+
+	return ok
+}
+
+func (q *queue) pendingCount() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	return len(q.pending)
+}
+
+func (q *queue) notifyChannelLocked(source sources.SourceName) chan struct{} {
+	if ch, ok := q.notify[source]; ok {
+		return ch
+	}
+
+	ch := make(chan struct{}, 1)
+	q.notify[source] = ch
+
+	return ch
+}
+
+func (q *queue) signalLocked(source sources.SourceName) {
+	ch := q.notifyChannelLocked(source)
+
+	select {
+	case ch <- struct{}{}:
+	default:
+	}
+}

--- a/api/pkg/core/chapters/download/queue_internal_test.go
+++ b/api/pkg/core/chapters/download/queue_internal_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package download
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+)
+
+func TestQueueEnqueueIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	q := newQueue()
+	chapterID := uuid.New()
+
+	added := q.enqueue(sources.SourceAsuraScans, []chapters.Chapter{
+		{ID: chapterID, Number: 2},
+		{ID: chapterID, Number: 2},
+	})
+	if added != 1 {
+		t.Fatalf("added = %d, want 1", added)
+	}
+
+	added = q.enqueue(sources.SourceAsuraScans, []chapters.Chapter{{ID: chapterID, Number: 2}})
+	if added != 0 {
+		t.Fatalf("second enqueue added = %d, want 0", added)
+	}
+
+	if q.pendingCount() != 1 {
+		t.Fatalf("pending = %d, want 1", q.pendingCount())
+	}
+}
+
+func TestQueueOrdersChaptersByNumber(t *testing.T) {
+	t.Parallel()
+
+	q := newQueue()
+	firstID := uuid.New()
+	secondID := uuid.New()
+
+	q.enqueue(sources.SourceAsuraScans, []chapters.Chapter{
+		{ID: secondID, Number: 2},
+		{ID: firstID, Number: 1},
+	})
+
+	item, ok := q.popNoWait(sources.SourceAsuraScans)
+	if !ok || item.ChapterID != firstID {
+		t.Fatalf("first item = %+v, ok = %v", item, ok)
+	}
+
+	item, ok = q.popNoWait(sources.SourceAsuraScans)
+	if !ok || item.ChapterID != secondID {
+		t.Fatalf("second item = %+v, ok = %v", item, ok)
+	}
+}
+
+func (q *queue) popNoWait(source sources.SourceName) (queueItem, bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	items := q.items[source]
+	if len(items) == 0 {
+		return queueItem{}, false
+	}
+
+	item := items[0]
+	q.items[source] = items[1:]
+
+	return item, true
+}

--- a/api/pkg/core/chapters/download/storage.go
+++ b/api/pkg/core/chapters/download/storage.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package download
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+func chapterDir(baseDir string, comicID uuid.UUID, chapterNumber float64) string {
+	return filepath.Join(baseDir, comicID.String(), formatChapterNumber(chapterNumber))
+}
+
+func formatChapterNumber(number float64) string {
+	return strconv.FormatFloat(number, 'f', -1, 64)
+}
+
+func pageFilename(pageIndex int, ext string) string {
+	return fmt.Sprintf("%03d%s", pageIndex, ext)
+}
+
+func pageExtension(imageURL string) string {
+	parsed, err := url.Parse(imageURL)
+	if err != nil {
+		return ".webp"
+	}
+
+	ext := strings.ToLower(path.Ext(parsed.Path))
+	if ext == "" {
+		return ".webp"
+	}
+
+	return ext
+}
+
+func listDownloadedPageIndices(dir string) (map[int]struct{}, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[int]struct{}{}, nil
+		}
+
+		return nil, fmt.Errorf("os.ReadDir %s: %w", dir, err)
+	}
+
+	indices := make(map[int]struct{}, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		index, ok := parsePageIndex(entry.Name())
+		if !ok {
+			continue
+		}
+
+		indices[index] = struct{}{}
+	}
+
+	return indices, nil
+}
+
+func parsePageIndex(name string) (int, bool) {
+	if len(name) < 4 {
+		return 0, false
+	}
+
+	indexPart := name[:3]
+	extPart := name[3:]
+	if extPart == "" || !strings.HasPrefix(extPart, ".") {
+		return 0, false
+	}
+
+	index, err := strconv.Atoi(indexPart)
+	if err != nil || index <= 0 {
+		return 0, false
+	}
+
+	return index, true
+}
+
+func deleteChapterDir(dir string) error {
+	err := os.RemoveAll(dir)
+	if err != nil {
+		return fmt.Errorf("os.RemoveAll %s: %w", dir, err)
+	}
+
+	return nil
+}
+
+func downloadPage(ctx context.Context, client *http.Client, imageURL, destPath string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil)
+	if err != nil {
+		return fmt.Errorf("http.NewRequestWithContext: %w", err)
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("client.Do: %w", err)
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d", res.StatusCode)
+	}
+
+	if err = os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return fmt.Errorf("os.MkdirAll %s: %w", destPath, err)
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(destPath), ".dl-*")
+	if err != nil {
+		return fmt.Errorf("os.CreateTemp %s: %w", destPath, err)
+	}
+
+	tmpName := tmp.Name()
+	defer func() {
+		tmp.Close()
+		os.Remove(tmpName)
+	}()
+
+	if _, err = io.Copy(tmp, res.Body); err != nil {
+		return fmt.Errorf("io.Copy %s: %w", tmpName, err)
+	}
+
+	if err = tmp.Sync(); err != nil {
+		return fmt.Errorf("tmp.Sync %s: %w", tmpName, err)
+	}
+
+	if err = tmp.Close(); err != nil {
+		return fmt.Errorf("tmp.Close %s: %w", tmpName, err)
+	}
+
+	if err = os.Rename(tmpName, destPath); err != nil {
+		return fmt.Errorf("os.Rename %s: %w", tmpName, err)
+	}
+
+	return nil
+}
+
+func progressPercent(downloadedPages, pagesNb int) int {
+	if pagesNb <= 0 {
+		return 0
+	}
+
+	progress := downloadedPages * 100 / pagesNb
+	if progress > 100 {
+		return 100
+	}
+
+	return progress
+}

--- a/api/pkg/core/chapters/download/storage_internal_test.go
+++ b/api/pkg/core/chapters/download/storage_internal_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package download
+
+import (
+	"testing"
+)
+
+func TestProgressPercent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		downloaded int
+		pagesNb    int
+		want       int
+	}{
+		{name: "zero pages", downloaded: 0, pagesNb: 0, want: 0},
+		{name: "half", downloaded: 1, pagesNb: 2, want: 50},
+		{name: "complete", downloaded: 3, pagesNb: 3, want: 100},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := progressPercent(tt.downloaded, tt.pagesNb); got != tt.want {
+				t.Fatalf("progressPercent(%d, %d) = %d, want %d", tt.downloaded, tt.pagesNb, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParsePageIndex(t *testing.T) {
+	t.Parallel()
+
+	index, ok := parsePageIndex("001.webp")
+	if !ok || index != 1 {
+		t.Fatalf("parsePageIndex(001.webp) = (%d, %v), want (1, true)", index, ok)
+	}
+
+	if _, ok := parsePageIndex("bad-name.webp"); ok {
+		t.Fatal("parsePageIndex accepted invalid file name")
+	}
+}

--- a/api/pkg/core/chapters/download/throttle.go
+++ b/api/pkg/core/chapters/download/throttle.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package download
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+	"golang.org/x/time/rate"
+)
+
+type sourceThrottle struct {
+	limiter *rate.Limiter
+}
+
+func newSourceThrottle(interval time.Duration) *sourceThrottle {
+	return &sourceThrottle{
+		limiter: rate.NewLimiter(rate.Every(interval), 1),
+	}
+}
+
+func (t *sourceThrottle) wait(ctx context.Context) error {
+	if err := t.limiter.Wait(ctx); err != nil {
+		return fmt.Errorf("t.limiter.Wait: %w", err)
+	}
+
+	return nil
+}
+
+func buildSourceThrottles(
+	sourceMap sources.SourceMap,
+	defaultInterval time.Duration,
+	overrides map[sources.SourceName]time.Duration,
+) map[sources.SourceName]*sourceThrottle {
+	throttles := make(map[sources.SourceName]*sourceThrottle, len(sourceMap))
+
+	for name := range sourceMap {
+		interval := defaultInterval
+		if override, ok := overrides[name]; ok && override > 0 {
+			interval = override
+		}
+
+		throttles[name] = newSourceThrottle(interval)
+	}
+
+	return throttles
+}

--- a/api/pkg/core/chapters/download/throttle_internal_test.go
+++ b/api/pkg/core/chapters/download/throttle_internal_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package download
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+	"golang.org/x/time/rate"
+)
+
+func TestSourceThrottleRespectsRateLimit(t *testing.T) {
+	t.Parallel()
+
+	const minInterval = 50 * time.Millisecond
+
+	throttle := newSourceThrottle(minInterval)
+	start := time.Now()
+
+	for range 3 {
+		if err := throttle.wait(context.Background()); err != nil {
+			t.Fatalf("throttle.wait: %v", err)
+		}
+	}
+
+	if elapsed := time.Since(start); elapsed < 2*minInterval {
+		t.Fatalf("3 waits in %v, want at least %v", elapsed, 2*minInterval)
+	}
+}
+
+func TestBuildSourceThrottlesUsesPerSourceOverrides(t *testing.T) {
+	t.Parallel()
+
+	sourcesMap := sources.SourceMap{
+		"fast": nil,
+		"slow": nil,
+	}
+
+	throttles := buildSourceThrottles(
+		sourcesMap,
+		500*time.Millisecond,
+		map[sources.SourceName]time.Duration{
+			"slow": time.Second,
+		},
+	)
+
+	if got := throttles["fast"].limiter.Limit(); got != rate.Limit(2) {
+		t.Fatalf("fast source limit = %v, want 2 req/s", got)
+	}
+
+	if got := throttles["slow"].limiter.Limit(); got != rate.Limit(1) {
+		t.Fatalf("slow source limit = %v, want 1 req/s", got)
+	}
+}

--- a/api/pkg/core/chapters/download/worker.go
+++ b/api/pkg/core/chapters/download/worker.go
@@ -23,9 +23,9 @@ import (
 const defaultPageRetries = 3
 
 type Config struct {
-	Dir            string
-	RateLimit        time.Duration
 	SourceRateLimits map[sources.SourceName]time.Duration
+	Dir              string
+	RateLimit        time.Duration
 }
 
 func (cfg *Config) Validate() error {
@@ -78,8 +78,8 @@ func (deps *Deps) Validate() error {
 type Worker struct {
 	deps      Deps
 	queue     *queue
-	cfg       Config
 	throttles map[sources.SourceName]*sourceThrottle
+	cfg       Config
 }
 
 func New(cfg Config, deps Deps) (*Worker, error) {

--- a/api/pkg/core/chapters/download/worker.go
+++ b/api/pkg/core/chapters/download/worker.go
@@ -1,0 +1,392 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package download
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils"
+	"golang.org/x/sync/errgroup"
+)
+
+const defaultPageRetries = 3
+
+type Config struct {
+	Dir            string
+	RateLimit        time.Duration
+	SourceRateLimits map[sources.SourceName]time.Duration
+}
+
+func (cfg *Config) Validate() error {
+	if cfg.Dir == "" {
+		return errors.New("dir is required")
+	}
+
+	if cfg.RateLimit <= 0 {
+		return errors.New("rateLimit must be greater than 0")
+	}
+
+	return nil
+}
+
+type Deps struct {
+	ChaptersRepository chapters.ChaptersRepository
+	ComicsRepository   comics.ComicsRepository
+	Sources            sources.SourceMap
+	HTTPClient         *http.Client
+	Logger             *slog.Logger
+	Publisher          ProgressPublisher
+}
+
+func (deps *Deps) Validate() error {
+	if deps.ChaptersRepository == nil {
+		return errors.New("chaptersRepository is required")
+	}
+
+	if deps.ComicsRepository == nil {
+		return errors.New("comicsRepository is required")
+	}
+
+	if deps.Sources == nil {
+		return errors.New("sources is required")
+	}
+
+	for _, source := range deps.Sources {
+		if source == nil {
+			return errors.New("source is required")
+		}
+	}
+
+	if deps.HTTPClient == nil {
+		return errors.New("httpClient is required")
+	}
+
+	return nil
+}
+
+type Worker struct {
+	deps      Deps
+	queue     *queue
+	cfg       Config
+	throttles map[sources.SourceName]*sourceThrottle
+}
+
+func New(cfg Config, deps Deps) (*Worker, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("cfg.Validate: %w", err)
+	}
+
+	if err := deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	if deps.Logger == nil {
+		deps.Logger = slog.Default()
+	}
+
+	if deps.Publisher == nil {
+		deps.Publisher = noopPublisher{}
+	}
+
+	deps.Logger = deps.Logger.With("component", "chapters.download")
+
+	return &Worker{
+		cfg:       cfg,
+		deps:      deps,
+		queue:     newQueue(),
+		throttles: buildSourceThrottles(deps.Sources, cfg.RateLimit, cfg.SourceRateLimits),
+	}, nil
+}
+
+func (w *Worker) Enqueue(ctx context.Context, chapterList []chapters.Chapter) error {
+	byComic := make(map[uuid.UUID][]chapters.Chapter)
+	for _, chapter := range chapterList {
+		byComic[chapter.ComicID] = append(byComic[chapter.ComicID], chapter)
+	}
+
+	for comicID, comicChapters := range byComic {
+		comic, err := w.deps.ComicsRepository.FindByID(ctx, comicID)
+		if err != nil {
+			return fmt.Errorf("w.deps.ComicsRepository.FindByID: %w", err)
+		}
+
+		w.queue.enqueue(comic.Source, comicChapters)
+	}
+
+	return nil
+}
+
+func (w *Worker) ResetAndEnqueue(ctx context.Context, chapterID uuid.UUID) error {
+	chapter, err := w.deps.ChaptersRepository.GetByID(ctx, chapterID)
+	if err != nil {
+		return fmt.Errorf("w.deps.ChaptersRepository.GetByID: %w", err)
+	}
+
+	dir := chapterDir(w.cfg.Dir, chapter.ComicID, chapter.Number)
+	if err = deleteChapterDir(dir); err != nil {
+		return fmt.Errorf("deleteChapterDir: %w", err)
+	}
+
+	if err = w.deps.ChaptersRepository.UpdateDownload(ctx, chapterID, 0); err != nil {
+		return fmt.Errorf("w.deps.ChaptersRepository.UpdateDownload: %w", err)
+	}
+
+	return w.Enqueue(ctx, []chapters.Chapter{*chapter})
+}
+
+func (w *Worker) Resume(ctx context.Context, chapterID uuid.UUID) error {
+	chapter, err := w.deps.ChaptersRepository.GetByID(ctx, chapterID)
+	if err != nil {
+		return fmt.Errorf("w.deps.ChaptersRepository.GetByID: %w", err)
+	}
+
+	return w.Enqueue(ctx, []chapters.Chapter{*chapter})
+}
+
+func (w *Worker) RemoveComicChapters(_ context.Context, comicID uuid.UUID, chapterList []chapters.Chapter) {
+	ids := make(map[uuid.UUID]struct{}, len(chapterList))
+	for _, chapter := range chapterList {
+		if chapter.ComicID != comicID {
+			continue
+		}
+
+		ids[chapter.ID] = struct{}{}
+	}
+
+	w.queue.removeComicChapters(ids)
+}
+
+func (w *Worker) Run(ctx context.Context) error {
+	if err := utils.EnsureDir(w.cfg.Dir); err != nil {
+		return fmt.Errorf("utils.EnsureDir: %w", err)
+	}
+
+	errG, errCtx := errgroup.WithContext(ctx)
+	for source := range w.deps.Sources {
+		errG.Go(func() error {
+			return w.runSource(errCtx, source)
+		})
+	}
+
+	w.deps.Logger.Info("worker started")
+
+	//nolint:wrapcheck
+	return errG.Wait()
+}
+
+func (w *Worker) runSource(ctx context.Context, source sources.SourceName) error {
+	for {
+		item, ok := w.queue.pop(ctx, source)
+		if !ok {
+			return nil
+		}
+
+		w.processChapter(ctx, source, item.ChapterID)
+		w.queue.done(item.ChapterID)
+	}
+}
+
+func (w *Worker) processChapter(ctx context.Context, source sources.SourceName, chapterID uuid.UUID) {
+	chapter, err := w.deps.ChaptersRepository.GetByID(ctx, chapterID)
+	if err != nil {
+		w.deps.Logger.ErrorContext(ctx, "failed to load chapter", "chapterID", chapterID, loggingErr(err))
+
+		return
+	}
+
+	if chapter.Download >= 100 {
+		return
+	}
+
+	comic, err := w.deps.ComicsRepository.FindByID(ctx, chapter.ComicID)
+	if err != nil {
+		w.deps.Logger.ErrorContext(ctx, "failed to load comic", "chapterID", chapterID, loggingErr(err))
+
+		return
+	}
+
+	src, ok := w.deps.Sources[source]
+	if !ok {
+		w.deps.Logger.ErrorContext(ctx, "source not configured", "source", source)
+
+		return
+	}
+
+	pageURLs, err := src.GetPageURLsByChapter(ctx, sources.GetPageURLsByChapterOpts{
+		SeriesSlug:  comic.Slug,
+		ChapterSlug: chapter.SourceChapterSlug,
+	})
+	if err != nil {
+		w.markError(ctx, chapterID, err)
+
+		return
+	}
+
+	pagesNb := len(pageURLs)
+	if pagesNb == 0 {
+		w.markError(ctx, chapterID, errors.New("source returned no pages"))
+
+		return
+	}
+
+	if pagesNb != chapter.PagesNb {
+		if err = w.deps.ChaptersRepository.UpdatePagesNb(ctx, chapterID, pagesNb); err != nil {
+			w.deps.Logger.ErrorContext(ctx, "failed to update pages_nb", "chapterID", chapterID, loggingErr(err))
+
+			return
+		}
+
+		chapter.PagesNb = pagesNb
+	}
+
+	dir := chapterDir(w.cfg.Dir, chapter.ComicID, chapter.Number)
+	downloaded, err := listDownloadedPageIndices(dir)
+	if err != nil {
+		w.markError(ctx, chapterID, err)
+
+		return
+	}
+
+	if len(downloaded) == pagesNb {
+		w.markCompleted(ctx, chapterID)
+
+		return
+	}
+
+	if err = w.publishProgress(ctx, chapterID, progressPercent(len(downloaded), pagesNb)); err != nil {
+		return
+	}
+
+	throttle, ok := w.throttles[source]
+	if !ok {
+		w.deps.Logger.ErrorContext(ctx, "source throttle not configured", "source", source)
+		w.markError(ctx, chapterID, errors.New("source throttle not configured"))
+
+		return
+	}
+
+	var progressMu sync.Mutex
+	downloadedCount := len(downloaded)
+
+	missing := make([]int, 0, pagesNb-len(downloaded))
+	for pageIndex := 1; pageIndex <= pagesNb; pageIndex++ {
+		if _, ok := downloaded[pageIndex]; !ok {
+			missing = append(missing, pageIndex)
+		}
+	}
+
+	errG, errCtx := errgroup.WithContext(ctx)
+	for _, pageIndex := range missing {
+		errG.Go(func() error {
+			imageURL := pageURLs[pageIndex-1]
+			ext := pageExtension(imageURL)
+			destPath := filepath.Join(dir, pageFilename(pageIndex, ext))
+
+			if err := w.downloadPageWithRetries(errCtx, throttle, imageURL, destPath); err != nil {
+				return err
+			}
+
+			progressMu.Lock()
+			downloadedCount++
+			current := downloadedCount
+			progressMu.Unlock()
+
+			return w.publishProgress(errCtx, chapterID, progressPercent(current, pagesNb))
+		})
+	}
+
+	if err = errG.Wait(); err != nil {
+		w.markError(ctx, chapterID, err)
+
+		return
+	}
+
+	w.markCompleted(ctx, chapterID)
+}
+
+func (w *Worker) downloadPageWithRetries(
+	ctx context.Context,
+	throttle *sourceThrottle,
+	imageURL, destPath string,
+) error {
+	var lastErr error
+
+	for attempt := 1; attempt <= defaultPageRetries; attempt++ {
+		if err := throttle.wait(ctx); err != nil {
+			return fmt.Errorf("throttle.wait: %w", err)
+		}
+
+		lastErr = downloadPage(ctx, w.deps.HTTPClient, imageURL, destPath)
+		if lastErr == nil {
+			return nil
+		}
+
+		w.deps.Logger.WarnContext(
+			ctx,
+			"page download failed",
+			"url", imageURL,
+			"attempt", attempt,
+			loggingErr(lastErr),
+		)
+	}
+
+	return fmt.Errorf("page download failed after %d attempts: %w", defaultPageRetries, lastErr)
+}
+
+func (w *Worker) publishProgress(ctx context.Context, chapterID uuid.UUID, download int) error {
+	if err := w.deps.ChaptersRepository.UpdateDownload(ctx, chapterID, download); err != nil {
+		w.deps.Logger.ErrorContext(ctx, "failed to update download progress", "chapterID", chapterID, loggingErr(err))
+
+		return fmt.Errorf("w.deps.ChaptersRepository.UpdateDownload: %w", err)
+	}
+
+	w.deps.Publisher.Publish(ctx, chapterID, ProgressEvent{
+		Status:   ProgressStatusDownloading,
+		Download: download,
+	})
+
+	return nil
+}
+
+func (w *Worker) markCompleted(ctx context.Context, chapterID uuid.UUID) {
+	if err := w.deps.ChaptersRepository.UpdateDownload(ctx, chapterID, 100); err != nil {
+		w.deps.Logger.ErrorContext(ctx, "failed to mark chapter completed", "chapterID", chapterID, loggingErr(err))
+
+		return
+	}
+
+	w.deps.Publisher.Publish(ctx, chapterID, ProgressEvent{
+		Status:   ProgressStatusCompleted,
+		Download: 100,
+	})
+}
+
+func (w *Worker) markError(ctx context.Context, chapterID uuid.UUID, err error) {
+	w.deps.Logger.ErrorContext(ctx, "chapter download failed", "chapterID", chapterID, loggingErr(err))
+
+	if updateErr := w.deps.ChaptersRepository.UpdateDownload(ctx, chapterID, -1); updateErr != nil {
+		w.deps.Logger.ErrorContext(ctx, "failed to mark chapter error", "chapterID", chapterID, loggingErr(updateErr))
+
+		return
+	}
+
+	w.deps.Publisher.Publish(ctx, chapterID, ProgressEvent{
+		Status:   ProgressStatusError,
+		Download: -1,
+	})
+}
+
+func loggingErr(err error) slog.Attr {
+	return slog.Any("error", err)
+}

--- a/api/pkg/core/chapters/download/worker_test.go
+++ b/api/pkg/core/chapters/download/worker_test.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//nolint:goconst,lll
 package download_test
 
 import (
@@ -213,10 +214,15 @@ func TestWorkerEnqueueIsIdempotent(t *testing.T) {
 		Slug:   "series-slug",
 	}
 
-	worker, _, _ := newTestWorker(t, chapter, comic, []string{""}, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("ok"))
-	}))
+	worker, _, _ := newTestWorker(
+		t,
+		chapter,
+		comic,
+		[]string{""},
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		}))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/api/pkg/core/chapters/download/worker_test.go
+++ b/api/pkg/core/chapters/download/worker_test.go
@@ -1,0 +1,369 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package download_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters/download"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+)
+
+type fakeChaptersRepository struct {
+	chapters map[uuid.UUID]chapters.Chapter
+}
+
+func (f *fakeChaptersRepository) Create(context.Context, chapters.CreateOpts) (*chapters.Chapter, error) {
+	panic("not implemented")
+}
+
+func (f *fakeChaptersRepository) CreateMany(context.Context, []chapters.CreateOpts) ([]chapters.Chapter, error) {
+	panic("not implemented")
+}
+
+func (f *fakeChaptersRepository) ListByComicID(context.Context, uuid.UUID) ([]chapters.Chapter, error) {
+	panic("not implemented")
+}
+
+func (f *fakeChaptersRepository) GetByID(_ context.Context, id uuid.UUID) (*chapters.Chapter, error) {
+	chapter, ok := f.chapters[id]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+
+	return &chapter, nil
+}
+
+func (f *fakeChaptersRepository) UpdateDownload(_ context.Context, id uuid.UUID, value int) error {
+	chapter, ok := f.chapters[id]
+	if !ok {
+		return errors.New("not found")
+	}
+
+	chapter.Download = value
+	f.chapters[id] = chapter
+
+	return nil
+}
+
+func (f *fakeChaptersRepository) UpdatePagesNb(_ context.Context, id uuid.UUID, pagesNb int) error {
+	chapter, ok := f.chapters[id]
+	if !ok {
+		return errors.New("not found")
+	}
+
+	chapter.PagesNb = pagesNb
+	f.chapters[id] = chapter
+
+	return nil
+}
+
+type fakeComicsRepository struct {
+	comics map[uuid.UUID]comics.Comic
+}
+
+func (f *fakeComicsRepository) GetByID(context.Context, comics.GetByIDOpts) (*comics.Comic, error) {
+	panic("not implemented")
+}
+
+func (f *fakeComicsRepository) FindByID(_ context.Context, id uuid.UUID) (*comics.Comic, error) {
+	comic, ok := f.comics[id]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+
+	return &comic, nil
+}
+
+func (f *fakeComicsRepository) GetBySourceSlug(context.Context, comics.GetBySourceSlugOpts) (*comics.Comic, error) {
+	panic("not implemented")
+}
+
+func (f *fakeComicsRepository) FindBySourceSlug(context.Context, comics.FindBySourceSlugOpts) (*comics.Comic, error) {
+	panic("not implemented")
+}
+
+func (f *fakeComicsRepository) Create(context.Context, comics.CreateComicOpts) (*comics.Comic, error) {
+	panic("not implemented")
+}
+
+func (f *fakeComicsRepository) GetBySlugsAndSource(context.Context, comics.GetBySlugsAndSource) ([]comics.Comic, error) {
+	panic("not implemented")
+}
+
+func (f *fakeComicsRepository) Delete(context.Context, uuid.UUID) error {
+	panic("not implemented")
+}
+
+func (f *fakeComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]comics.Comic, error) {
+	panic("not implemented")
+}
+
+type fakeSource struct {
+	pageURLs []string
+}
+
+func (f *fakeSource) GetInfosBySlug(context.Context, sources.GetInfosBySlugOpts) (*sources.GetInfosBySlugResponse, error) {
+	panic("not implemented")
+}
+
+func (f *fakeSource) GetChaptersBySlug(context.Context, string) ([]sources.SourceChapter, error) {
+	panic("not implemented")
+}
+
+func (f *fakeSource) GetPageURLsByChapter(context.Context, sources.GetPageURLsByChapterOpts) ([]string, error) {
+	return f.pageURLs, nil
+}
+
+func newTestWorkerWithConfig(
+	t *testing.T,
+	chapter chapters.Chapter,
+	comic comics.Comic,
+	pageURLs []string,
+	httpHandler http.Handler,
+	cfg download.Config,
+) (*download.Worker, string, *fakeChaptersRepository) {
+	t.Helper()
+
+	server := httptest.NewServer(httpHandler)
+	t.Cleanup(server.Close)
+
+	for i := range pageURLs {
+		pageURLs[i] = server.URL + fmt.Sprintf("/page-%d", i+1)
+	}
+
+	if cfg.Dir == "" {
+		cfg.Dir = t.TempDir()
+	}
+
+	chaptersRepo := &fakeChaptersRepository{chapters: map[uuid.UUID]chapters.Chapter{
+		chapter.ID: chapter,
+	}}
+	comicsRepo := &fakeComicsRepository{comics: map[uuid.UUID]comics.Comic{
+		comic.ID: comic,
+	}}
+
+	worker, err := download.New(
+		cfg,
+		download.Deps{
+			ChaptersRepository: chaptersRepo,
+			ComicsRepository:   comicsRepo,
+			Sources: sources.SourceMap{
+				comic.Source: &fakeSource{pageURLs: pageURLs},
+			},
+			HTTPClient: server.Client(),
+		},
+	)
+	if err != nil {
+		t.Fatalf("download.New: %v", err)
+	}
+
+	return worker, cfg.Dir, chaptersRepo
+}
+
+func newTestWorker(
+	t *testing.T,
+	chapter chapters.Chapter,
+	comic comics.Comic,
+	pageURLs []string,
+	httpHandler http.Handler,
+) (*download.Worker, string, *fakeChaptersRepository) {
+	t.Helper()
+
+	return newTestWorkerWithConfig(
+		t,
+		chapter,
+		comic,
+		pageURLs,
+		httpHandler,
+		download.Config{
+			Dir:       t.TempDir(),
+			RateLimit: time.Millisecond,
+		},
+	)
+}
+
+func TestWorkerEnqueueIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chapterID := uuid.New()
+	chapter := chapters.Chapter{
+		ID:                chapterID,
+		ComicID:           comicID,
+		SourceChapterSlug: "chapter-1",
+		Number:            1,
+		PagesNb:           1,
+	}
+	comic := comics.Comic{
+		ID:     comicID,
+		Source: sources.SourceAsuraScans,
+		Slug:   "series-slug",
+	}
+
+	worker, _, _ := newTestWorker(t, chapter, comic, []string{""}, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = worker.Run(ctx)
+	}()
+
+	err := worker.Enqueue(context.Background(), []chapters.Chapter{chapter, chapter})
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	err = worker.Enqueue(context.Background(), []chapters.Chapter{chapter})
+	if err != nil {
+		t.Fatalf("Enqueue second call: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestWorkerRetriesPageUntilExhausted(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chapterID := uuid.New()
+	chapter := chapters.Chapter{
+		ID:                chapterID,
+		ComicID:           comicID,
+		SourceChapterSlug: "chapter-1",
+		Number:            1,
+		PagesNb:           1,
+	}
+	comic := comics.Comic{
+		ID:     comicID,
+		Source: sources.SourceAsuraScans,
+		Slug:   "series-slug",
+	}
+
+	var calls atomic.Int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	worker, _, chaptersRepo := newTestWorker(t, chapter, comic, []string{""}, handler)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = worker.Run(ctx)
+	}()
+
+	err := worker.Enqueue(context.Background(), []chapters.Chapter{chapter})
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		updated, err := chaptersRepo.GetByID(context.Background(), chapterID)
+		if err == nil && updated.Download == -1 {
+			if calls.Load() != 3 {
+				t.Fatalf("download attempts = %d, want 3", calls.Load())
+			}
+
+			return
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatal("chapter was not marked as failed")
+}
+
+func TestWorkerResumesIncrementally(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chapterID := uuid.New()
+	chapter := chapters.Chapter{
+		ID:                chapterID,
+		ComicID:           comicID,
+		SourceChapterSlug: "chapter-1",
+		Number:            1,
+		PagesNb:           2,
+	}
+	comic := comics.Comic{
+		ID:     comicID,
+		Source: sources.SourceAsuraScans,
+		Slug:   "series-slug",
+	}
+
+	var calls atomic.Int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("page-2"))
+	})
+
+	worker, dir, chaptersRepo := newTestWorker(
+		t,
+		chapter,
+		comic,
+		[]string{"", ""},
+		handler,
+	)
+
+	chapterDir := filepath.Join(dir, comicID.String(), "1")
+	if err := os.MkdirAll(chapterDir, 0o755); err != nil {
+		t.Fatalf("os.MkdirAll: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(chapterDir, "001.webp"), []byte("page-1"), 0o644); err != nil {
+		t.Fatalf("os.WriteFile: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = worker.Run(ctx)
+	}()
+
+	err := worker.Enqueue(context.Background(), []chapters.Chapter{chapter})
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		updated, err := chaptersRepo.GetByID(context.Background(), chapterID)
+		if err == nil && updated.Download == 100 {
+			if calls.Load() != 1 {
+				t.Fatalf("download attempts for missing page = %d, want 1", calls.Load())
+			}
+
+			if _, err := os.Stat(filepath.Join(chapterDir, "002.webp")); err != nil {
+				t.Fatalf("second page not saved: %v", err)
+			}
+
+			return
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatal("chapter was not completed")
+}

--- a/api/pkg/core/chapters/download/worker_test.go
+++ b/api/pkg/core/chapters/download/worker_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -24,6 +25,7 @@ import (
 
 type fakeChaptersRepository struct {
 	chapters map[uuid.UUID]chapters.Chapter
+	mu       sync.Mutex
 }
 
 func (f *fakeChaptersRepository) Create(context.Context, chapters.CreateOpts) (*chapters.Chapter, error) {
@@ -39,6 +41,9 @@ func (f *fakeChaptersRepository) ListByComicID(context.Context, uuid.UUID) ([]ch
 }
 
 func (f *fakeChaptersRepository) GetByID(_ context.Context, id uuid.UUID) (*chapters.Chapter, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
 	chapter, ok := f.chapters[id]
 	if !ok {
 		return nil, errors.New("not found")
@@ -48,6 +53,9 @@ func (f *fakeChaptersRepository) GetByID(_ context.Context, id uuid.UUID) (*chap
 }
 
 func (f *fakeChaptersRepository) UpdateDownload(_ context.Context, id uuid.UUID, value int) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
 	chapter, ok := f.chapters[id]
 	if !ok {
 		return errors.New("not found")
@@ -60,6 +68,9 @@ func (f *fakeChaptersRepository) UpdateDownload(_ context.Context, id uuid.UUID,
 }
 
 func (f *fakeChaptersRepository) UpdatePagesNb(_ context.Context, id uuid.UUID, pagesNb int) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
 	chapter, ok := f.chapters[id]
 	if !ok {
 		return errors.New("not found")

--- a/api/pkg/core/chapters/repository/pg/repository.go
+++ b/api/pkg/core/chapters/repository/pg/repository.go
@@ -114,3 +114,44 @@ func (r *PGChaptersRepository) CreateMany(ctx context.Context, opts []chapters.C
 
 	return ret, nil
 }
+
+func (r *PGChaptersRepository) GetByID(ctx context.Context, id uuid.UUID) (*chapters.Chapter, error) {
+	model, err := r.db(ctx).Where("id = ?", id).First(ctx)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrNotFound
+		}
+
+		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
+	}
+
+	ret := model.Domain()
+
+	return &ret, nil
+}
+
+func (r *PGChaptersRepository) UpdateDownload(ctx context.Context, id uuid.UUID, download int) error {
+	affected, err := r.db(ctx).Where("id = ?", id).Update(ctx, "download", download)
+	if err != nil {
+		return fmt.Errorf("r.db(ctx).Where: %w", err)
+	}
+
+	if affected == 0 {
+		return domain.ErrNotFound
+	}
+
+	return nil
+}
+
+func (r *PGChaptersRepository) UpdatePagesNb(ctx context.Context, id uuid.UUID, pagesNb int) error {
+	affected, err := r.db(ctx).Where("id = ?", id).Update(ctx, "pages_nb", pagesNb)
+	if err != nil {
+		return fmt.Errorf("r.db(ctx).Where: %w", err)
+	}
+
+	if affected == 0 {
+		return domain.ErrNotFound
+	}
+
+	return nil
+}

--- a/api/pkg/core/chapters/service.go
+++ b/api/pkg/core/chapters/service.go
@@ -15,12 +15,17 @@ import (
 var _ ChaptersService = (*Service)(nil)
 
 type Deps struct {
-	Repository ChaptersRepository
+	Repository       ChaptersRepository
+	ChapterDownloader ChapterDownloader
 }
 
 func (deps *Deps) Validate() error {
 	if deps.Repository == nil {
 		return errors.New("repository is required")
+	}
+
+	if deps.ChapterDownloader == nil {
+		return errors.New("chapterDownloader is required")
 	}
 
 	return nil
@@ -75,13 +80,23 @@ func (s *Service) ListByComicID(ctx context.Context, comicID uuid.UUID) ([]Chapt
 
 func (s *Service) EnqueueDownloadable(ctx context.Context, chapters []Chapter) error {
 	now := time.Now()
+	downloadable := make([]Chapter, 0, len(chapters))
 
 	for _, chapter := range chapters {
 		if !isDownloadable(chapter, now) {
 			continue
 		}
 
-		// TODO(#36): enqueue chapter in the per-source download queue.
+		downloadable = append(downloadable, chapter)
+	}
+
+	if len(downloadable) == 0 {
+		return nil
+	}
+
+	err := s.deps.ChapterDownloader.Enqueue(ctx, downloadable)
+	if err != nil {
+		return fmt.Errorf("s.deps.ChapterDownloader.Enqueue: %w", err)
 	}
 
 	return nil

--- a/api/pkg/core/chapters/service.go
+++ b/api/pkg/core/chapters/service.go
@@ -15,7 +15,7 @@ import (
 var _ ChaptersService = (*Service)(nil)
 
 type Deps struct {
-	Repository       ChaptersRepository
+	Repository        ChaptersRepository
 	ChapterDownloader ChapterDownloader
 }
 

--- a/api/pkg/core/chapters/service_test.go
+++ b/api/pkg/core/chapters/service_test.go
@@ -46,11 +46,38 @@ func (f *fakeChaptersRepository) ListByComicID(context.Context, uuid.UUID) ([]ch
 	panic("ListByComicID must not be called")
 }
 
+func (f *fakeChaptersRepository) GetByID(context.Context, uuid.UUID) (*chapters.Chapter, error) {
+	panic("GetByID must not be called")
+}
+
+func (f *fakeChaptersRepository) UpdateDownload(context.Context, uuid.UUID, int) error {
+	panic("UpdateDownload must not be called")
+}
+
+func (f *fakeChaptersRepository) UpdatePagesNb(context.Context, uuid.UUID, int) error {
+	panic("UpdatePagesNb must not be called")
+}
+
+type fakeChapterDownloader struct {
+	lastEnqueueChapters []chapters.Chapter
+	enqueueCalls        int
+}
+
+func (f *fakeChapterDownloader) Enqueue(_ context.Context, chapterList []chapters.Chapter) error {
+	f.enqueueCalls++
+	f.lastEnqueueChapters = chapterList
+
+	return nil
+}
+
 func TestServiceCreateAll(t *testing.T) {
 	t.Parallel()
 
 	repo := &fakeChaptersRepository{}
-	svc, err := chapters.NewService(chapters.Deps{Repository: repo})
+	svc, err := chapters.NewService(chapters.Deps{
+		Repository:        repo,
+		ChapterDownloader: &fakeChapterDownloader{},
+	})
 	if err != nil {
 		t.Fatalf("NewService: %v", err)
 	}
@@ -87,8 +114,12 @@ func TestServiceCreateAll(t *testing.T) {
 func TestServiceEnqueueDownloadableRunsWithoutError(t *testing.T) {
 	t.Parallel()
 
+	downloader := &fakeChapterDownloader{}
 	repo := &fakeChaptersRepository{}
-	svc, err := chapters.NewService(chapters.Deps{Repository: repo})
+	svc, err := chapters.NewService(chapters.Deps{
+		Repository:        repo,
+		ChapterDownloader: downloader,
+	})
 	if err != nil {
 		t.Fatalf("NewService: %v", err)
 	}
@@ -102,5 +133,13 @@ func TestServiceEnqueueDownloadableRunsWithoutError(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("EnqueueDownloadable: %v", err)
+	}
+
+	if downloader.enqueueCalls != 1 {
+		t.Errorf("Enqueue called %d times, want 1", downloader.enqueueCalls)
+	}
+
+	if len(downloader.lastEnqueueChapters) != 1 {
+		t.Fatalf("enqueued chapters = %+v, want one downloadable chapter", downloader.lastEnqueueChapters)
 	}
 }

--- a/api/pkg/core/comics/domain.go
+++ b/api/pkg/core/comics/domain.go
@@ -40,6 +40,7 @@ type FindBySourceSlugOpts struct {
 
 type ComicsRepository interface {
 	GetByID(context.Context, GetByIDOpts) (*Comic, error)
+	FindByID(context.Context, uuid.UUID) (*Comic, error)
 	GetBySourceSlug(context.Context, GetBySourceSlugOpts) (*Comic, error)
 	FindBySourceSlug(context.Context, FindBySourceSlugOpts) (*Comic, error)
 	Create(context.Context, CreateComicOpts) (*Comic, error)

--- a/api/pkg/core/comics/repository/pg/repository.go
+++ b/api/pkg/core/comics/repository/pg/repository.go
@@ -70,6 +70,21 @@ func (r *PGComicsRepository) GetByID(ctx context.Context, opts comics.GetByIDOpt
 	return &ret, nil
 }
 
+func (r *PGComicsRepository) FindByID(ctx context.Context, id uuid.UUID) (*comics.Comic, error) {
+	model, err := r.db(ctx).Where("comics.id = ?", id).First(ctx)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrNotFound
+		}
+
+		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
+	}
+
+	ret := model.Domain()
+
+	return &ret, nil
+}
+
 //nolint:lll
 func (r *PGComicsRepository) GetBySourceSlug(ctx context.Context, opts comics.GetBySourceSlugOpts) (*comics.Comic, error) {
 	model, err := r.db(ctx).

--- a/api/pkg/core/comics/service_test.go
+++ b/api/pkg/core/comics/service_test.go
@@ -63,6 +63,10 @@ func (f *fakeComicsRepository) GetByID(_ context.Context, _ comics.GetByIDOpts) 
 	return f.getByIDResult, f.getByIDErr
 }
 
+func (f *fakeComicsRepository) FindByID(context.Context, uuid.UUID) (*comics.Comic, error) {
+	panic("FindByID must not be called by the comics service")
+}
+
 func (f *fakeComicsRepository) GetBySourceSlug(context.Context, comics.GetBySourceSlugOpts) (*comics.Comic, error) {
 	panic("GetBySourceSlug must not be called by the comics service")
 }
@@ -258,6 +262,10 @@ func (f *fakeSource) GetChaptersBySlug(_ context.Context, slug string) ([]source
 	}
 
 	return f.chapters, nil
+}
+
+func (f *fakeSource) GetPageURLsByChapter(context.Context, sources.GetPageURLsByChapterOpts) ([]string, error) {
+	return nil, nil
 }
 
 func validServiceDeps() comics.Deps {

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -172,6 +172,14 @@ func (fakeOIDCRevalidationApp) Run(ctx context.Context) error {
 	return fmt.Errorf("context done: %w", ctx.Err())
 }
 
+type fakeDownloadsApp struct{}
+
+func (fakeDownloadsApp) Run(ctx context.Context) error {
+	<-ctx.Done()
+
+	return fmt.Errorf("context done: %w", ctx.Err())
+}
+
 func (fakeSessionsRepository) DeleteByUserAndProvider(context.Context, uuid.UUID, uuid.UUID) error {
 	return errors.New(notImplemented)
 }
@@ -255,6 +263,10 @@ func (fakeOIDCProvidersService) Probe(context.Context, string) (*oidcproviders.P
 type stubComicsRepository struct{}
 
 func (stubComicsRepository) GetByID(context.Context, comics.GetByIDOpts) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (stubComicsRepository) FindByID(context.Context, uuid.UUID) (*comics.Comic, error) {
 	return nil, coredomain.ErrNotFound
 }
 
@@ -477,6 +489,7 @@ func newTestApp(t *testing.T, db Database, port int) (*App, *health.Registry) {
 			Health:            registry,
 			Asura:             asuraApp,
 			Covers:            coversApp,
+			Downloads:         fakeDownloadsApp{},
 			Sessions:          sessionsApp,
 			OIDCRevalidation:  fakeOIDCRevalidationApp{},
 		})

--- a/api/pkg/core/health.go
+++ b/api/pkg/core/health.go
@@ -13,6 +13,7 @@ const (
 	componentMigrations       = "migrations"
 	componentAsura            = "asura"
 	componentCovers           = "covers"
+	componentDownloads        = "downloads"
 	componentSessions         = "sessions"
 	componentOIDCRevalidation = "oidc-revalidation"
 	componentDB               = "db"
@@ -25,6 +26,7 @@ func NewHealthRegistry(db Database) *health.Registry {
 		componentMigrations,
 		componentAsura,
 		componentCovers,
+		componentDownloads,
 		componentSessions,
 		componentOIDCRevalidation,
 	)

--- a/api/pkg/core/health_internal_test.go
+++ b/api/pkg/core/health_internal_test.go
@@ -45,6 +45,7 @@ func TestNewHealthRegistryDeclaresTheLatchesAndTheDBProbe(t *testing.T) {
 		componentMigrations,
 		componentAsura,
 		componentCovers,
+		componentDownloads,
 		componentSessions,
 		componentOIDCRevalidation,
 	}

--- a/api/pkg/sources/asurascans/pkg/core/app.go
+++ b/api/pkg/sources/asurascans/pkg/core/app.go
@@ -243,3 +243,15 @@ func (a *App) GetImageURLsByChapter(ctx context.Context, opts domain.GetImageURL
 
 	return slices.Clone(*res), nil
 }
+
+func (a *App) GetPageURLsByChapter(ctx context.Context, opts sources.GetPageURLsByChapterOpts) ([]string, error) {
+	urls, err := a.GetImageURLsByChapter(ctx, domain.GetImageURLsByChapterOpts{
+		SeriesSlug: opts.SeriesSlug,
+		ChapterID:  opts.ChapterSlug,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("a.GetImageURLsByChapter: %w", err)
+	}
+
+	return urls, nil
+}

--- a/api/pkg/sources/asurascans/pkg/core/app_test.go
+++ b/api/pkg/sources/asurascans/pkg/core/app_test.go
@@ -24,6 +24,10 @@ func (stubComicsRepository) GetByID(context.Context, comics.GetByIDOpts) (*comic
 	return nil, coredomain.ErrNotFound
 }
 
+func (stubComicsRepository) FindByID(context.Context, uuid.UUID) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
 func (stubComicsRepository) GetBySourceSlug(
 	context.Context, comics.GetBySourceSlugOpts,
 ) (*comics.Comic, error) {
@@ -60,6 +64,10 @@ type libraryComicsRepository struct {
 }
 
 func (r libraryComicsRepository) GetByID(context.Context, comics.GetByIDOpts) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (r libraryComicsRepository) FindByID(context.Context, uuid.UUID) (*comics.Comic, error) {
 	return nil, coredomain.ErrNotFound
 }
 

--- a/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
+++ b/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
@@ -35,6 +35,10 @@ func (stubComicsRepository) GetByID(context.Context, comics.GetByIDOpts) (*comic
 	return nil, coredomain.ErrNotFound
 }
 
+func (stubComicsRepository) FindByID(context.Context, uuid.UUID) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
 func (stubComicsRepository) GetBySourceSlug(
 	context.Context, comics.GetBySourceSlugOpts,
 ) (*comics.Comic, error) {

--- a/api/pkg/sources/domain.go
+++ b/api/pkg/sources/domain.go
@@ -81,6 +81,12 @@ func ParseSeriesStatus(s string) (SeriesStatus, error) {
 type Source interface {
 	GetInfosBySlug(context.Context, GetInfosBySlugOpts) (*GetInfosBySlugResponse, error)
 	GetChaptersBySlug(context.Context, string) ([]SourceChapter, error)
+	GetPageURLsByChapter(context.Context, GetPageURLsByChapterOpts) ([]string, error)
+}
+
+type GetPageURLsByChapterOpts struct {
+	SeriesSlug  string
+	ChapterSlug string
 }
 
 type SourceChapter struct {

--- a/api/pkg/utils/database/gormlogger.go
+++ b/api/pkg/utils/database/gormlogger.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package database
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+type gormLogger struct {
+	gormlogger.Interface
+}
+
+func newGormLogger(log *slog.Logger) gormlogger.Interface {
+	level := gormlogger.Warn
+	if log.Enabled(context.Background(), slog.LevelDebug) {
+		level = gormlogger.Info
+	}
+
+	return gormLogger{
+		Interface: gormlogger.NewSlogLogger(log, gormlogger.Config{
+			SlowThreshold:             200 * time.Millisecond,
+			LogLevel:                  level,
+			IgnoreRecordNotFoundError: true,
+		}),
+	}
+}
+
+func (l gormLogger) LogMode(level gormlogger.LogLevel) gormlogger.Interface {
+	return gormLogger{Interface: l.Interface.LogMode(level)}
+}
+
+func (l gormLogger) Trace(
+	ctx context.Context,
+	begin time.Time,
+	fc func() (sql string, rowsAffected int64),
+	err error,
+) {
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		err = nil
+	}
+
+	l.Interface.Trace(ctx, begin, fc, err)
+}

--- a/api/pkg/utils/database/gormlogger_internal_test.go
+++ b/api/pkg/utils/database/gormlogger_internal_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package database
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+func newTestGormLogger(buf *bytes.Buffer, level slog.Level) gormlogger.Interface {
+	log := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: level}))
+
+	return newGormLogger(log)
+}
+
+func TestGormLoggerOmitsHandledErrors(t *testing.T) {
+	var buf bytes.Buffer
+	l := newTestGormLogger(&buf, slog.LevelInfo)
+	fc := func() (string, int64) { return "SELECT 1", int64(0) }
+
+	l.Trace(context.Background(), time.Now(), fc, gorm.ErrRecordNotFound)
+	l.Trace(context.Background(), time.Now(), fc, gorm.ErrDuplicatedKey)
+
+	if buf.Len() != 0 {
+		t.Errorf("handled errors were logged: %s", buf.String())
+	}
+}
+
+func TestGormLoggerLogsUnexpectedErrors(t *testing.T) {
+	var buf bytes.Buffer
+	l := newTestGormLogger(&buf, slog.LevelInfo)
+	fc := func() (string, int64) { return "SELECT 1", int64(0) }
+
+	l.Trace(context.Background(), time.Now(), fc, errors.New("connection reset"))
+
+	if !strings.Contains(buf.String(), "connection reset") {
+		t.Errorf("unexpected error was not logged: %s", buf.String())
+	}
+}

--- a/api/pkg/utils/database/pgdb.go
+++ b/api/pkg/utils/database/pgdb.go
@@ -77,7 +77,7 @@ func NewPGDatabase(cfg PGConfig, deps PGDeps) (*PGDB, error) {
 	}
 
 	deps.Logger = deps.Logger.With("component", "db.postgres")
-	db, err := createPGDatabase(cfg)
+	db, err := createPGDatabase(cfg, deps.Logger)
 	if err != nil {
 		return nil, fmt.Errorf("createPGDatabase: %w", err)
 	}
@@ -87,7 +87,7 @@ func NewPGDatabase(cfg PGConfig, deps PGDeps) (*PGDB, error) {
 	return &PGDB{DB: db, deps: deps}, nil
 }
 
-func createPGDatabase(cfg PGConfig) (*gorm.DB, error) {
+func createPGDatabase(cfg PGConfig, log *slog.Logger) (*gorm.DB, error) {
 	dsn := fmt.Sprintf("host=%s port=%d dbname=%s user=%s password=%s sslmode=%s",
 		cfg.Host,
 		cfg.Port,
@@ -96,7 +96,10 @@ func createPGDatabase(cfg PGConfig) (*gorm.DB, error) {
 		cfg.Password,
 		utils.Ternary(cfg.SSLRequired, "require", "disable"))
 
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{TranslateError: true})
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
+		TranslateError: true,
+		Logger:         newGormLogger(log),
+	})
 	if err != nil {
 		return nil, fmt.Errorf("gorm.Open: %w", err)
 	}

--- a/api/pkg/utils/dirs.go
+++ b/api/pkg/utils/dirs.go
@@ -49,18 +49,20 @@ func ensureDirWritable(path string) error {
 	return nil
 }
 
-func PrepareDataDir(logger *slog.Logger, path string, uid, gid int) (string, error) {
+func PrepareDataDirs(logger *slog.Logger, uid, gid int, paths ...string) error {
 	if os.Geteuid() == 0 {
-		if err := os.MkdirAll(path, 0o755); err != nil {
-			return "", fmt.Errorf("os.MkdirAll %s: %w", path, err)
-		}
+		for _, path := range paths {
+			if err := os.MkdirAll(path, 0o755); err != nil {
+				return fmt.Errorf("os.MkdirAll %s: %w", path, err)
+			}
 
-		if err := os.Chown(path, uid, gid); err != nil {
-			return "", fmt.Errorf("os.Chown %s: %w", path, err)
+			if err := os.Chown(path, uid, gid); err != nil {
+				return fmt.Errorf("os.Chown %s: %w", path, err)
+			}
 		}
 
 		if err := dropPrivileges(uid, gid); err != nil {
-			return "", fmt.Errorf("dropPrivileges: %w", err)
+			return fmt.Errorf("dropPrivileges: %w", err)
 		}
 
 		if logger != nil {
@@ -68,12 +70,22 @@ func PrepareDataDir(logger *slog.Logger, path string, uid, gid int) (string, err
 		}
 	}
 
-	if err := EnsureDir(path); err != nil {
-		return "", err
+	for _, path := range paths {
+		if err := EnsureDir(path); err != nil {
+			return err
+		}
+
+		if logger != nil {
+			logger.Debug("data directory ready", "dir", path)
+		}
 	}
 
-	if logger != nil {
-		logger.Debug("cache directory ready", "dir", path)
+	return nil
+}
+
+func PrepareDataDir(logger *slog.Logger, path string, uid, gid int) (string, error) {
+	if err := PrepareDataDirs(logger, uid, gid, path); err != nil {
+		return "", err
 	}
 
 	return path, nil

--- a/api/pkg/utils/dirs_test.go
+++ b/api/pkg/utils/dirs_test.go
@@ -76,3 +76,25 @@ func TestPrepareDataDirAsUnprivilegedUser(t *testing.T) {
 		t.Fatalf("got %q, want %q", got, dir)
 	}
 }
+
+func TestPrepareDataDirsAsUnprivilegedUser(t *testing.T) {
+	t.Parallel()
+
+	if os.Geteuid() == 0 {
+		t.Skip("skipped when running as root")
+	}
+
+	root := t.TempDir()
+	coversDir := filepath.Join(root, "covers")
+	downloadsDir := filepath.Join(root, "downloads")
+
+	if err := utils.PrepareDataDirs(nil, 65532, 65532, coversDir, downloadsDir); err != nil {
+		t.Fatalf("PrepareDataDirs: %v", err)
+	}
+
+	for _, dir := range []string{coversDir, downloadsDir} {
+		if err := os.WriteFile(filepath.Join(dir, "probe.txt"), []byte("ok"), 0o600); err != nil {
+			t.Fatalf("directory %s not writable: %v", dir, err)
+		}
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       PORT: 3000
       CORS_ORIGINS: ${CORS_ORIGINS:-}
       PUBLIC_URL: ${PUBLIC_URL:-http://localhost:3000}
-      COVERS_DIR: /covers
+      CHAPTER_DOWNLOAD_RATE_LIMIT: ${CHAPTER_DOWNLOAD_RATE_LIMIT:-500ms}
       OIDC_ENCRYPTION_KEY: "${OIDC_ENCRYPTION_KEY:?set OIDC_ENCRYPTION_KEY, e.g. openssl rand -base64 32}"
     healthcheck:
       test: ["CMD", "/uchiyomiserver", "-healthcheck"]
@@ -52,9 +52,8 @@ services:
       start_period: 15s
     read_only: true
     volumes:
-      - covers:/covers
+      - ./.data:/data
     stop_grace_period: 15s
 
 volumes:
   pgdata:
-  covers:


### PR DESCRIPTION
## Summary

- Add a per-source FIFO chapter download worker that processes one chapter at a time, with pages downloaded in parallel and throttled by `CHAPTER_DOWNLOAD_RATE_LIMIT`.
- Store files at `downloads/{comicId}/{chapterNumber}/001.webp`, update `pages_nb` when the source count differs, and persist progress (`floor(downloadedPages / pagesNb * 100)`, `100` on success, `-1` after 3 page retries).
- Resume interrupted downloads by skipping files already on disk; `ResetAndEnqueue` deletes the chapter folder and resets `download` to 0 for failed retries.
- Wire `chapters.Service.EnqueueDownloadable` to the real worker (replacing the #36 stub).

Closes #36

## Test plan

- [x] `go test ./...` in `api/`
- [x] Unit tests: incremental resume, page retry exhaustion, idempotent enqueue, queue order by chapter number
- [x] Manual: add an AsuraScans comic to the library → chapters enqueue and download one at a time
- [x] Manual: interrupt a download, restart the server → resume skips existing page files
- [x] Manual: force a page failure until retries exhaust → `download = -1`; retry deletes the folder and re-enqueues
- [x] Manual: files land at `data/downloads/{comicId}/{chapterNumber}/001.webp` (or `DOWNLOADS_DIR`)