### PR TITLE
feat(chapters): cleanup downloaded chapters on comic deletion

### DIFF
--- a/api/pkg/core/chapters/domain.go
+++ b/api/pkg/core/chapters/domain.go
@@ -33,12 +33,14 @@ type ChaptersRepository interface {
 
 type ChapterDownloader interface {
 	Enqueue(context.Context, []Chapter) error
+	CleanupComic(context.Context, uuid.UUID, []Chapter) error
 }
 
 type ChaptersService interface {
 	CreateAll(context.Context, uuid.UUID, []sources.SourceChapter) ([]Chapter, error)
 	ListByComicID(context.Context, uuid.UUID) ([]Chapter, error)
 	EnqueueDownloadable(context.Context, []Chapter) error
+	CleanupComic(context.Context, uuid.UUID, []Chapter) error
 }
 
 type CreateOpts struct {

--- a/api/pkg/core/chapters/download/comic_lifecycle.go
+++ b/api/pkg/core/chapters/download/comic_lifecycle.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package download
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+type comicTracker struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	active int
+}
+
+func (w *Worker) beginComic(parent context.Context, comicID uuid.UUID) (context.Context, func()) {
+	w.comicMu.Lock()
+
+	tracker, ok := w.comicTrackers[comicID]
+	if !ok {
+		comicCtx, cancel := context.WithCancel(parent)
+		tracker = &comicTracker{
+			ctx:    comicCtx,
+			cancel: cancel,
+		}
+		w.comicTrackers[comicID] = tracker
+	}
+
+	tracker.active++
+	comicCtx := tracker.ctx
+	w.comicMu.Unlock()
+
+	return comicCtx, func() {
+		w.comicMu.Lock()
+		defer w.comicMu.Unlock()
+
+		tracker, ok := w.comicTrackers[comicID]
+		if !ok {
+			return
+		}
+
+		tracker.active--
+		if tracker.active == 0 {
+			delete(w.comicTrackers, comicID)
+		}
+
+		w.comicCond.Broadcast()
+	}
+}
+
+func (w *Worker) cancelComicWork(comicID uuid.UUID) {
+	w.comicMu.Lock()
+	defer w.comicMu.Unlock()
+
+	tracker, ok := w.comicTrackers[comicID]
+	if !ok {
+		return
+	}
+
+	tracker.cancel()
+}
+
+func (w *Worker) waitComicWorkDone(comicID uuid.UUID) {
+	w.comicMu.Lock()
+	defer w.comicMu.Unlock()
+
+	for {
+		tracker, ok := w.comicTrackers[comicID]
+		if !ok || tracker.active == 0 {
+			return
+		}
+
+		w.comicCond.Wait()
+	}
+}

--- a/api/pkg/core/chapters/download/queue_internal_test.go
+++ b/api/pkg/core/chapters/download/queue_internal_test.go
@@ -72,8 +72,8 @@ func TestQueueRemoveComicChapters(t *testing.T) {
 	})
 
 	q.removeComicChapters(map[uuid.UUID]struct{}{
-		firstID:  struct{}{},
-		secondID: struct{}{},
+		firstID:  {},
+		secondID: {},
 	})
 
 	if q.pendingCount() != 1 {

--- a/api/pkg/core/chapters/download/queue_internal_test.go
+++ b/api/pkg/core/chapters/download/queue_internal_test.go
@@ -57,6 +57,35 @@ func TestQueueOrdersChaptersByNumber(t *testing.T) {
 	}
 }
 
+func TestQueueRemoveComicChapters(t *testing.T) {
+	t.Parallel()
+
+	q := newQueue()
+	firstID := uuid.New()
+	secondID := uuid.New()
+	otherComicChapterID := uuid.New()
+
+	q.enqueue(sources.SourceAsuraScans, []chapters.Chapter{
+		{ID: firstID, Number: 1},
+		{ID: secondID, Number: 2},
+		{ID: otherComicChapterID, Number: 3},
+	})
+
+	q.removeComicChapters(map[uuid.UUID]struct{}{
+		firstID:  struct{}{},
+		secondID: struct{}{},
+	})
+
+	if q.pendingCount() != 1 {
+		t.Fatalf("pending = %d, want 1", q.pendingCount())
+	}
+
+	item, ok := q.popNoWait(sources.SourceAsuraScans)
+	if !ok || item.ChapterID != otherComicChapterID {
+		t.Fatalf("remaining item = %+v, ok = %v", item, ok)
+	}
+}
+
 func (q *queue) popNoWait(source sources.SourceName) (queueItem, bool) {
 	q.mu.Lock()
 	defer q.mu.Unlock()

--- a/api/pkg/core/chapters/download/storage.go
+++ b/api/pkg/core/chapters/download/storage.go
@@ -17,8 +17,12 @@ import (
 	"github.com/google/uuid"
 )
 
+func comicDir(baseDir string, comicID uuid.UUID) string {
+	return filepath.Join(baseDir, comicID.String())
+}
+
 func chapterDir(baseDir string, comicID uuid.UUID, chapterNumber float64) string {
-	return filepath.Join(baseDir, comicID.String(), formatChapterNumber(chapterNumber))
+	return filepath.Join(comicDir(baseDir, comicID), formatChapterNumber(chapterNumber))
 }
 
 func formatChapterNumber(number float64) string {
@@ -90,6 +94,15 @@ func parsePageIndex(name string) (int, bool) {
 }
 
 func deleteChapterDir(dir string) error {
+	err := os.RemoveAll(dir)
+	if err != nil {
+		return fmt.Errorf("os.RemoveAll %s: %w", dir, err)
+	}
+
+	return nil
+}
+
+func deleteComicDir(dir string) error {
 	err := os.RemoveAll(dir)
 	if err != nil {
 		return fmt.Errorf("os.RemoveAll %s: %w", dir, err)

--- a/api/pkg/core/chapters/download/worker.go
+++ b/api/pkg/core/chapters/download/worker.go
@@ -76,10 +76,13 @@ func (deps *Deps) Validate() error {
 }
 
 type Worker struct {
-	deps      Deps
-	queue     *queue
-	throttles map[sources.SourceName]*sourceThrottle
-	cfg       Config
+	deps           Deps
+	queue          *queue
+	throttles      map[sources.SourceName]*sourceThrottle
+	comicTrackers  map[uuid.UUID]*comicTracker
+	comicMu        sync.Mutex
+	comicCond      sync.Cond
+	cfg            Config
 }
 
 func New(cfg Config, deps Deps) (*Worker, error) {
@@ -101,12 +104,16 @@ func New(cfg Config, deps Deps) (*Worker, error) {
 
 	deps.Logger = deps.Logger.With("component", "chapters.download")
 
-	return &Worker{
-		cfg:       cfg,
-		deps:      deps,
-		queue:     newQueue(),
-		throttles: buildSourceThrottles(deps.Sources, cfg.RateLimit, cfg.SourceRateLimits),
-	}, nil
+	worker := &Worker{
+		cfg:           cfg,
+		deps:          deps,
+		queue:         newQueue(),
+		throttles:     buildSourceThrottles(deps.Sources, cfg.RateLimit, cfg.SourceRateLimits),
+		comicTrackers: make(map[uuid.UUID]*comicTracker),
+	}
+	worker.comicCond.L = &worker.comicMu
+
+	return worker, nil
 }
 
 func (w *Worker) Enqueue(ctx context.Context, chapterList []chapters.Chapter) error {
@@ -154,7 +161,7 @@ func (w *Worker) Resume(ctx context.Context, chapterID uuid.UUID) error {
 	return w.Enqueue(ctx, []chapters.Chapter{*chapter})
 }
 
-func (w *Worker) RemoveComicChapters(_ context.Context, comicID uuid.UUID, chapterList []chapters.Chapter) {
+func (w *Worker) CleanupComic(ctx context.Context, comicID uuid.UUID, chapterList []chapters.Chapter) error {
 	ids := make(map[uuid.UUID]struct{}, len(chapterList))
 	for _, chapter := range chapterList {
 		if chapter.ComicID != comicID {
@@ -165,6 +172,20 @@ func (w *Worker) RemoveComicChapters(_ context.Context, comicID uuid.UUID, chapt
 	}
 
 	w.queue.removeComicChapters(ids)
+	w.cancelComicWork(comicID)
+	w.waitComicWorkDone(comicID)
+
+	dir := comicDir(w.cfg.Dir, comicID)
+	if err := deleteComicDir(dir); err != nil {
+		w.deps.Logger.ErrorContext(
+			ctx,
+			"failed to delete comic download dir",
+			"comicID", comicID,
+			loggingErr(err),
+		)
+	}
+
+	return nil
 }
 
 func (w *Worker) Run(ctx context.Context) error {
@@ -205,44 +226,59 @@ func (w *Worker) processChapter(ctx context.Context, source sources.SourceName, 
 		return
 	}
 
+	comicCtx, releaseComic := w.beginComic(ctx, chapter.ComicID)
+	defer releaseComic()
+
+	if comicCtx.Err() != nil {
+		return
+	}
+
 	if chapter.Download >= 100 {
 		return
 	}
 
-	comic, err := w.deps.ComicsRepository.FindByID(ctx, chapter.ComicID)
+	comic, err := w.deps.ComicsRepository.FindByID(comicCtx, chapter.ComicID)
 	if err != nil {
-		w.deps.Logger.ErrorContext(ctx, "failed to load comic", "chapterID", chapterID, loggingErr(err))
+		w.deps.Logger.ErrorContext(comicCtx, "failed to load comic", "chapterID", chapterID, loggingErr(err))
 
 		return
 	}
 
 	src, ok := w.deps.Sources[source]
 	if !ok {
-		w.deps.Logger.ErrorContext(ctx, "source not configured", "source", source)
+		w.deps.Logger.ErrorContext(comicCtx, "source not configured", "source", source)
 
 		return
 	}
 
-	pageURLs, err := src.GetPageURLsByChapter(ctx, sources.GetPageURLsByChapterOpts{
+	pageURLs, err := src.GetPageURLsByChapter(comicCtx, sources.GetPageURLsByChapterOpts{
 		SeriesSlug:  comic.Slug,
 		ChapterSlug: chapter.SourceChapterSlug,
 	})
 	if err != nil {
-		w.markError(ctx, chapterID, err)
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+
+		w.markError(comicCtx, chapterID, err)
 
 		return
 	}
 
 	pagesNb := len(pageURLs)
 	if pagesNb == 0 {
-		w.markError(ctx, chapterID, errors.New("source returned no pages"))
+		w.markError(comicCtx, chapterID, errors.New("source returned no pages"))
 
 		return
 	}
 
 	if pagesNb != chapter.PagesNb {
-		if err = w.deps.ChaptersRepository.UpdatePagesNb(ctx, chapterID, pagesNb); err != nil {
-			w.deps.Logger.ErrorContext(ctx, "failed to update pages_nb", "chapterID", chapterID, loggingErr(err))
+		if err = w.deps.ChaptersRepository.UpdatePagesNb(comicCtx, chapterID, pagesNb); err != nil {
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+
+			w.deps.Logger.ErrorContext(comicCtx, "failed to update pages_nb", "chapterID", chapterID, loggingErr(err))
 
 			return
 		}
@@ -253,25 +289,29 @@ func (w *Worker) processChapter(ctx context.Context, source sources.SourceName, 
 	dir := chapterDir(w.cfg.Dir, chapter.ComicID, chapter.Number)
 	downloaded, err := listDownloadedPageIndices(dir)
 	if err != nil {
-		w.markError(ctx, chapterID, err)
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+
+		w.markError(comicCtx, chapterID, err)
 
 		return
 	}
 
 	if len(downloaded) == pagesNb {
-		w.markCompleted(ctx, chapterID)
+		w.markCompleted(comicCtx, chapterID)
 
 		return
 	}
 
-	if err = w.publishProgress(ctx, chapterID, progressPercent(len(downloaded), pagesNb)); err != nil {
+	if err = w.publishProgress(comicCtx, chapterID, progressPercent(len(downloaded), pagesNb)); err != nil {
 		return
 	}
 
 	throttle, ok := w.throttles[source]
 	if !ok {
-		w.deps.Logger.ErrorContext(ctx, "source throttle not configured", "source", source)
-		w.markError(ctx, chapterID, errors.New("source throttle not configured"))
+		w.deps.Logger.ErrorContext(comicCtx, "source throttle not configured", "source", source)
+		w.markError(comicCtx, chapterID, errors.New("source throttle not configured"))
 
 		return
 	}
@@ -286,7 +326,7 @@ func (w *Worker) processChapter(ctx context.Context, source sources.SourceName, 
 		}
 	}
 
-	errG, errCtx := errgroup.WithContext(ctx)
+	errG, errCtx := errgroup.WithContext(comicCtx)
 	for _, pageIndex := range missing {
 		errG.Go(func() error {
 			imageURL := pageURLs[pageIndex-1]
@@ -307,12 +347,16 @@ func (w *Worker) processChapter(ctx context.Context, source sources.SourceName, 
 	}
 
 	if err = errG.Wait(); err != nil {
-		w.markError(ctx, chapterID, err)
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+
+		w.markError(comicCtx, chapterID, err)
 
 		return
 	}
 
-	w.markCompleted(ctx, chapterID)
+	w.markCompleted(comicCtx, chapterID)
 }
 
 func (w *Worker) downloadPageWithRetries(

--- a/api/pkg/core/chapters/download/worker.go
+++ b/api/pkg/core/chapters/download/worker.go
@@ -76,13 +76,13 @@ func (deps *Deps) Validate() error {
 }
 
 type Worker struct {
-	deps           Deps
-	queue          *queue
-	throttles      map[sources.SourceName]*sourceThrottle
-	comicTrackers  map[uuid.UUID]*comicTracker
-	comicMu        sync.Mutex
-	comicCond      sync.Cond
-	cfg            Config
+	deps          Deps
+	queue         *queue
+	throttles     map[sources.SourceName]*sourceThrottle
+	comicTrackers map[uuid.UUID]*comicTracker
+	comicCond     sync.Cond
+	cfg           Config
+	comicMu       sync.Mutex
 }
 
 func New(cfg Config, deps Deps) (*Worker, error) {

--- a/api/pkg/core/chapters/download/worker_test.go
+++ b/api/pkg/core/chapters/download/worker_test.go
@@ -384,3 +384,133 @@ func TestWorkerResumesIncrementally(t *testing.T) {
 
 	t.Fatal("chapter was not completed")
 }
+
+func TestWorkerCleanupComicDeletesDownloadDir(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chapterID := uuid.New()
+	chapter := chapters.Chapter{
+		ID:      chapterID,
+		ComicID: comicID,
+		Number:  1,
+	}
+	comic := comics.Comic{
+		ID:     comicID,
+		Source: sources.SourceAsuraScans,
+		Slug:   "series-slug",
+	}
+
+	worker, dir, _ := newTestWorker(
+		t,
+		chapter,
+		comic,
+		[]string{""},
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	chapterDir := filepath.Join(dir, comicID.String(), "1")
+	if err := os.MkdirAll(chapterDir, 0o755); err != nil {
+		t.Fatalf("os.MkdirAll: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(chapterDir, "001.webp"), []byte("page-1"), 0o644); err != nil {
+		t.Fatalf("os.WriteFile: %v", err)
+	}
+
+	err := worker.Enqueue(context.Background(), []chapters.Chapter{chapter})
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	err = worker.CleanupComic(context.Background(), comicID, []chapters.Chapter{chapter})
+	if err != nil {
+		t.Fatalf("CleanupComic: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, comicID.String())); !os.IsNotExist(err) {
+		t.Fatalf("comic download dir still exists: %v", err)
+	}
+}
+
+func TestWorkerCleanupComicStopsInFlightDownloads(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chapterID := uuid.New()
+	chapter := chapters.Chapter{
+		ID:                chapterID,
+		ComicID:           comicID,
+		SourceChapterSlug: "chapter-1",
+		Number:            1,
+		PagesNb:           2,
+	}
+	comic := comics.Comic{
+		ID:     comicID,
+		Source: sources.SourceAsuraScans,
+		Slug:   "series-slug",
+	}
+
+	downloadStarted := make(chan struct{})
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		select {
+		case downloadStarted <- struct{}{}:
+		default:
+		}
+
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("page"))
+	})
+
+	worker, dir, chaptersRepo := newTestWorker(
+		t,
+		chapter,
+		comic,
+		[]string{"", ""},
+		handler,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = worker.Run(ctx)
+	}()
+
+	err := worker.Enqueue(context.Background(), []chapters.Chapter{chapter})
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	select {
+	case <-downloadStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("download did not start")
+	}
+
+	err = worker.CleanupComic(context.Background(), comicID, []chapters.Chapter{chapter})
+	if err != nil {
+		t.Fatalf("CleanupComic: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, comicID.String())); !os.IsNotExist(err) {
+		t.Fatalf("comic download dir still exists after cleanup: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		updated, err := chaptersRepo.GetByID(context.Background(), chapterID)
+		if err == nil && updated.Download == 100 {
+			t.Fatal("chapter was marked completed after cleanup")
+		}
+
+		if _, err := os.Stat(filepath.Join(dir, comicID.String())); err == nil {
+			t.Fatal("comic download dir was recreated by in-flight worker")
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}
+}

--- a/api/pkg/core/chapters/service.go
+++ b/api/pkg/core/chapters/service.go
@@ -102,6 +102,15 @@ func (s *Service) EnqueueDownloadable(ctx context.Context, chapters []Chapter) e
 	return nil
 }
 
+func (s *Service) CleanupComic(ctx context.Context, comicID uuid.UUID, chapterList []Chapter) error {
+	err := s.deps.ChapterDownloader.CleanupComic(ctx, comicID, chapterList)
+	if err != nil {
+		return fmt.Errorf("s.deps.ChapterDownloader.CleanupComic: %w", err)
+	}
+
+	return nil
+}
+
 func isDownloadable(chapter Chapter, now time.Time) bool {
 	if chapter.Download >= 100 {
 		return false

--- a/api/pkg/core/chapters/service_test.go
+++ b/api/pkg/core/chapters/service_test.go
@@ -59,13 +59,24 @@ func (f *fakeChaptersRepository) UpdatePagesNb(context.Context, uuid.UUID, int) 
 }
 
 type fakeChapterDownloader struct {
-	lastEnqueueChapters []chapters.Chapter
-	enqueueCalls        int
+	lastEnqueueChapters  []chapters.Chapter
+	lastCleanupChapters  []chapters.Chapter
+	enqueueCalls         int
+	cleanupComicCalls    int
+	lastCleanupComicID   uuid.UUID
 }
 
 func (f *fakeChapterDownloader) Enqueue(_ context.Context, chapterList []chapters.Chapter) error {
 	f.enqueueCalls++
 	f.lastEnqueueChapters = chapterList
+
+	return nil
+}
+
+func (f *fakeChapterDownloader) CleanupComic(_ context.Context, comicID uuid.UUID, chapterList []chapters.Chapter) error {
+	f.cleanupComicCalls++
+	f.lastCleanupComicID = comicID
+	f.lastCleanupChapters = chapterList
 
 	return nil
 }
@@ -141,5 +152,36 @@ func TestServiceEnqueueDownloadableRunsWithoutError(t *testing.T) {
 
 	if len(downloader.lastEnqueueChapters) != 1 {
 		t.Fatalf("enqueued chapters = %+v, want one downloadable chapter", downloader.lastEnqueueChapters)
+	}
+}
+
+func TestServiceCleanupComic(t *testing.T) {
+	t.Parallel()
+
+	downloader := &fakeChapterDownloader{}
+	svc, err := chapters.NewService(chapters.Deps{
+		Repository:        &fakeChaptersRepository{},
+		ChapterDownloader: downloader,
+	})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	comicID := uuid.New()
+	chapterList := []chapters.Chapter{
+		{ID: uuid.New(), ComicID: comicID, Number: 1},
+	}
+
+	err = svc.CleanupComic(context.Background(), comicID, chapterList)
+	if err != nil {
+		t.Fatalf("CleanupComic: %v", err)
+	}
+
+	if downloader.cleanupComicCalls != 1 || downloader.lastCleanupComicID != comicID {
+		t.Errorf("CleanupComic comic ID = %s, want %s", downloader.lastCleanupComicID, comicID)
+	}
+
+	if len(downloader.lastCleanupChapters) != 1 {
+		t.Errorf("CleanupComic chapters = %+v", downloader.lastCleanupChapters)
 	}
 }

--- a/api/pkg/core/chapters/service_test.go
+++ b/api/pkg/core/chapters/service_test.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//nolint:goconst,lll
 package chapters_test
 
 import (
@@ -59,11 +60,11 @@ func (f *fakeChaptersRepository) UpdatePagesNb(context.Context, uuid.UUID, int) 
 }
 
 type fakeChapterDownloader struct {
-	lastEnqueueChapters  []chapters.Chapter
-	lastCleanupChapters  []chapters.Chapter
-	enqueueCalls         int
-	cleanupComicCalls    int
-	lastCleanupComicID   uuid.UUID
+	lastEnqueueChapters []chapters.Chapter
+	lastCleanupChapters []chapters.Chapter
+	enqueueCalls        int
+	cleanupComicCalls   int
+	lastCleanupComicID  uuid.UUID
 }
 
 func (f *fakeChapterDownloader) Enqueue(_ context.Context, chapterList []chapters.Chapter) error {

--- a/api/pkg/core/comics/service.go
+++ b/api/pkg/core/comics/service.go
@@ -203,6 +203,9 @@ func (s *Service) GetMany(ctx context.Context, opts GetManyOpts) ([]Comic, error
 }
 
 func (s *Service) Delete(ctx context.Context, opts DeleteOpts) error {
+	var comicDeleted bool
+	var chaptersToCleanup []chapters.Chapter
+
 	err := s.deps.Transactor.WithinTx(ctx, transaction.TxOpts{}, func(ctx context.Context) error {
 		err := s.deps.LibraryRepository.Delete(ctx, library.DeleteOpts{
 			UserID:  opts.UserID,
@@ -221,14 +224,32 @@ func (s *Service) Delete(ctx context.Context, opts DeleteOpts) error {
 			return nil
 		}
 
+		chapterList, err := s.deps.ChaptersService.ListByComicID(ctx, opts.ID)
+		if err != nil {
+			return fmt.Errorf("s.deps.ChaptersService.ListByComicID: %w", err)
+		}
+
 		err = s.deps.ComicsRepository.Delete(ctx, opts.ID)
 		if err != nil && !errors.Is(err, domain.ErrNotFound) {
 			return fmt.Errorf("s.deps.ComicsRepository.Delete: %w", err)
 		}
 
+		chaptersToCleanup = chapterList
+		comicDeleted = true
+
 		return nil
 	})
+	if err != nil {
+		//nolint:wrapcheck
+		return err
+	}
 
-	//nolint:wrapcheck
-	return err
+	if comicDeleted {
+		err = s.deps.ChaptersService.CleanupComic(ctx, opts.ID, chaptersToCleanup)
+		if err != nil {
+			return fmt.Errorf("s.deps.ChaptersService.CleanupComic: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/api/pkg/core/comics/service_test.go
+++ b/api/pkg/core/comics/service_test.go
@@ -166,15 +166,19 @@ type fakeChaptersService struct {
 	createAllErr             error
 	listByComicIDErr         error
 	enqueueDownloadableErr   error
+	cleanupComicErr          error
 	lastCreateAllChapters    []sources.SourceChapter
 	lastEnqueueChapters      []chapters.Chapter
+	lastCleanupChapters      []chapters.Chapter
 	listByComicIDResult      []chapters.Chapter
 	createAllResult          []chapters.Chapter
 	createAllCalls           int
 	listByComicIDCalls       int
 	enqueueDownloadableCalls int
+	cleanupComicCalls        int
 	lastCreateAllComicID     uuid.UUID
 	lastListByComicID        uuid.UUID
+	lastCleanupComicID       uuid.UUID
 }
 
 func (f *fakeChaptersService) CreateAll(
@@ -227,6 +231,14 @@ func (f *fakeChaptersService) EnqueueDownloadable(_ context.Context, chapterList
 	f.lastEnqueueChapters = chapterList
 
 	return f.enqueueDownloadableErr
+}
+
+func (f *fakeChaptersService) CleanupComic(_ context.Context, comicID uuid.UUID, chapterList []chapters.Chapter) error {
+	f.cleanupComicCalls++
+	f.lastCleanupComicID = comicID
+	f.lastCleanupChapters = chapterList
+
+	return f.cleanupComicErr
 }
 
 type fakeSource struct {
@@ -655,13 +667,19 @@ func TestDeleteRemovesLibraryEntryAndComic(t *testing.T) {
 
 	userID := uuid.New()
 	comicID := uuid.New()
+	chapterID := uuid.New()
+	comicChapters := []chapters.Chapter{
+		{ID: chapterID, ComicID: comicID, Number: 1},
+	}
 	comicsRepo := &fakeComicsRepository{}
 	libraryRepo := &fakeLibraryRepository{}
+	chaptersSvc := &fakeChaptersService{listByComicIDResult: comicChapters}
 	tx := &fakeTransactor{}
 
 	deps := validServiceDeps()
 	deps.ComicsRepository = comicsRepo
 	deps.LibraryRepository = libraryRepo
+	deps.ChaptersService = chaptersSvc
 	deps.Transactor = tx
 
 	svc, err := comics.NewService(deps)
@@ -689,12 +707,24 @@ func TestDeleteRemovesLibraryEntryAndComic(t *testing.T) {
 		t.Errorf("library DeleteOpts = %+v", libraryRepo.lastDelete)
 	}
 
+	if chaptersSvc.listByComicIDCalls != 1 || chaptersSvc.lastListByComicID != comicID {
+		t.Errorf("ListByComicID comic ID = %s, want %s", chaptersSvc.lastListByComicID, comicID)
+	}
+
 	if comicsRepo.deleteCalls != 1 || comicsRepo.lastDeleteID != comicID {
 		t.Errorf("ComicsRepository.Delete comic ID = %s, want %s", comicsRepo.lastDeleteID, comicID)
 	}
 
 	if libraryRepo.existsByComicIDCalls != 1 || libraryRepo.lastExistsComicID != comicID {
 		t.Errorf("ExistsByComicID comic ID = %s, want %s", libraryRepo.lastExistsComicID, comicID)
+	}
+
+	if chaptersSvc.cleanupComicCalls != 1 || chaptersSvc.lastCleanupComicID != comicID {
+		t.Errorf("CleanupComic comic ID = %s, want %s", chaptersSvc.lastCleanupComicID, comicID)
+	}
+
+	if len(chaptersSvc.lastCleanupChapters) != 1 || chaptersSvc.lastCleanupChapters[0].ID != chapterID {
+		t.Errorf("CleanupComic chapters = %+v", chaptersSvc.lastCleanupChapters)
 	}
 }
 
@@ -705,11 +735,13 @@ func TestDeleteKeepsComicWhenOtherUsersHaveLibraryEntry(t *testing.T) {
 	comicID := uuid.New()
 	comicsRepo := &fakeComicsRepository{}
 	libraryRepo := &fakeLibraryRepository{existsByComicID: true}
+	chaptersSvc := &fakeChaptersService{}
 	tx := &fakeTransactor{}
 
 	deps := validServiceDeps()
 	deps.ComicsRepository = comicsRepo
 	deps.LibraryRepository = libraryRepo
+	deps.ChaptersService = chaptersSvc
 	deps.Transactor = tx
 
 	svc, err := comics.NewService(deps)
@@ -735,6 +767,14 @@ func TestDeleteKeepsComicWhenOtherUsersHaveLibraryEntry(t *testing.T) {
 
 	if comicsRepo.deleteCalls != 0 {
 		t.Errorf("ComicsRepository.Delete called %d times, want 0", comicsRepo.deleteCalls)
+	}
+
+	if chaptersSvc.listByComicIDCalls != 0 {
+		t.Errorf("ListByComicID called %d times, want 0", chaptersSvc.listByComicIDCalls)
+	}
+
+	if chaptersSvc.cleanupComicCalls != 0 {
+		t.Errorf("CleanupComic called %d times, want 0", chaptersSvc.cleanupComicCalls)
 	}
 }
 


### PR DESCRIPTION
Closes #35

## Summary

- Integrate chapter cleanup into the comic delete flow: when the last user removes a comic, pending queue items are dropped, in-flight downloads are cancelled, and `downloads/{comicId}/` is removed from disk (best-effort, errors are logged)
- Add `CleanupComic` to the chapters service and download worker, with per-comic context tracking to stop active downloads before deleting files
- Partial library removal (other users still have the comic) leaves chapter records and files untouched

## Test plan

- [x] `go test ./pkg/core/chapters/... ./pkg/core/comics/...`
- [x] Worker: `CleanupComic` deletes the comic download directory
- [x] Worker: `CleanupComic` stops in-flight downloads
- [x] Queue: `removeComicChapters` drops only the targeted chapters
- [x] Comics service: last-user delete triggers cleanup; partial remove does not