### PR TITLE
feat(chapters): worker lifecycle and startup

### DIFF
--- a/api/cmd/uchiyomiserver/config.go
+++ b/api/cmd/uchiyomiserver/config.go
@@ -21,8 +21,9 @@ type cfg struct {
 		Dir string `env:"COVERS_DIR" envDefault:"data/cache/covers"`
 	}
 	Downloads struct {
-		Dir       string        `env:"DOWNLOADS_DIR" envDefault:"data/downloads"`
-		RateLimit time.Duration `env:"CHAPTER_DOWNLOAD_RATE_LIMIT" envDefault:"500ms"`
+		Dir          string        `env:"DOWNLOADS_DIR" envDefault:"data/downloads"`
+		RateLimit    time.Duration `env:"CHAPTER_DOWNLOAD_RATE_LIMIT" envDefault:"500ms"`
+		ScanInterval time.Duration `env:"CHAPTER_DOWNLOAD_SCAN_INTERVAL" envDefault:"15m"`
 	}
 	PG struct {
 		Host        string `env:"DB_HOST,required"`

--- a/api/cmd/uchiyomiserver/setup.go
+++ b/api/cmd/uchiyomiserver/setup.go
@@ -119,6 +119,7 @@ func setupApp(cfg *cfg) (*core.App, error) {
 		Sources:            sources.SourceMap{sources.SourceAsuraScans: asuraApp},
 		DownloadsDir:       downloadsDir,
 		RateLimit:          cfg.Downloads.RateLimit,
+		ScanInterval:       cfg.Downloads.ScanInterval,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to init chapters: %w", err)
@@ -818,6 +819,7 @@ type chaptersDeps struct {
 	Sources            sources.SourceMap
 	DownloadsDir       string
 	RateLimit          time.Duration
+	ScanInterval       time.Duration
 }
 
 func setupChapters(deps chaptersDeps) (*chapters.Service, *download.App, error) {
@@ -849,17 +851,24 @@ func setupChapters(deps chaptersDeps) (*chapters.Service, *download.App, error) 
 		return nil, nil, fmt.Errorf("download.New: %w", err)
 	}
 
-	app, err := download.NewApp(worker)
-	if err != nil {
-		return nil, nil, fmt.Errorf("download.NewApp: %w", err)
-	}
-
 	svc, err := chapters.NewService(chapters.Deps{
 		Repository:        deps.ChaptersRepository,
 		ChapterDownloader: worker,
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("chapters.NewService: %w", err)
+	}
+
+	app, err := download.NewApp(
+		download.AppConfig{ScanInterval: deps.ScanInterval},
+		download.AppDeps{
+			Worker:          worker,
+			ChaptersService: svc,
+			Logger:          deps.Logger,
+		},
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("download.NewApp: %w", err)
 	}
 
 	return svc, app, nil

--- a/api/pkg/core/chapters/domain.go
+++ b/api/pkg/core/chapters/domain.go
@@ -26,6 +26,8 @@ type ChaptersRepository interface {
 	Create(context.Context, CreateOpts) (*Chapter, error)
 	CreateMany(context.Context, []CreateOpts) ([]Chapter, error)
 	ListByComicID(context.Context, uuid.UUID) ([]Chapter, error)
+	ListResumable(context.Context) ([]Chapter, error)
+	ListEarlyAccessUnlocked(context.Context, time.Time) ([]Chapter, error)
 	GetByID(context.Context, uuid.UUID) (*Chapter, error)
 	UpdateDownload(context.Context, uuid.UUID, int) error
 	UpdatePagesNb(context.Context, uuid.UUID, int) error
@@ -40,6 +42,8 @@ type ChaptersService interface {
 	CreateAll(context.Context, uuid.UUID, []sources.SourceChapter) ([]Chapter, error)
 	ListByComicID(context.Context, uuid.UUID) ([]Chapter, error)
 	EnqueueDownloadable(context.Context, []Chapter) error
+	EnqueueResumable(context.Context) error
+	ScanEarlyAccess(context.Context) error
 	CleanupComic(context.Context, uuid.UUID, []Chapter) error
 }
 

--- a/api/pkg/core/chapters/download/app.go
+++ b/api/pkg/core/chapters/download/app.go
@@ -2,21 +2,105 @@
 
 package download
 
-import "context"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
 
-type App struct {
-	worker *Worker
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils"
+	"golang.org/x/sync/errgroup"
+)
+
+type AppConfig struct {
+	ScanInterval time.Duration
 }
 
-func NewApp(worker *Worker) (*App, error) {
-	if worker == nil {
-		return nil, ErrWorkerRequired
+func (cfg *AppConfig) Validate() error {
+	if cfg.ScanInterval < time.Minute {
+		return errors.New("scanInterval must be at least 1 minute")
 	}
 
-	return &App{worker: worker}, nil
+	return nil
+}
+
+type WorkerRunner interface {
+	Run(context.Context) error
+}
+
+type AppDeps struct {
+	Worker          WorkerRunner
+	ChaptersService chapters.ChaptersService
+	Logger          *slog.Logger
+}
+
+func (deps *AppDeps) Validate() error {
+	if deps.Worker == nil {
+		return ErrWorkerRequired
+	}
+
+	if deps.ChaptersService == nil {
+		return errors.New("chaptersService is required")
+	}
+
+	return nil
+}
+
+type App struct {
+	deps AppDeps
+	cfg  AppConfig
+}
+
+func NewApp(cfg AppConfig, deps AppDeps) (*App, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("cfg.Validate: %w", err)
+	}
+
+	if err := deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	if deps.Logger == nil {
+		deps.Logger = slog.Default()
+	}
+
+	deps.Logger = deps.Logger.With("component", "chapters.download.app")
+
+	return &App{deps: deps, cfg: cfg}, nil
 }
 
 func (a *App) Run(ctx context.Context) error {
+	if err := a.deps.ChaptersService.EnqueueResumable(ctx); err != nil {
+		return fmt.Errorf("a.deps.ChaptersService.EnqueueResumable: %w", err)
+	}
+
+	errG, errCtx := errgroup.WithContext(ctx)
+
+	errG.Go(func() error {
+		//nolint:wrapcheck
+		return a.deps.Worker.Run(errCtx)
+	})
+
+	errG.Go(func() error {
+		//nolint:wrapcheck // Run delegates unchanged to utils.Loop, like sessions and oidc revalidation.
+		return utils.Loop(errCtx, utils.LoopOpts{
+			Interval: a.cfg.ScanInterval,
+			Fn:       a.scanEarlyAccess,
+		})
+	})
+
+	a.deps.Logger.Info("download app started")
+
 	//nolint:wrapcheck
-	return a.worker.Run(ctx)
+	return errG.Wait()
+}
+
+func (a *App) scanEarlyAccess(ctx context.Context) error {
+	if err := a.deps.ChaptersService.ScanEarlyAccess(ctx); err != nil {
+		a.deps.Logger.ErrorContext(ctx, "early-access scan failed", loggingErr(err))
+	}
+
+	return nil
 }

--- a/api/pkg/core/chapters/download/app_test.go
+++ b/api/pkg/core/chapters/download/app_test.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//nolint:goconst,lll
 package download_test
 
 import (
@@ -15,11 +16,11 @@ import (
 )
 
 type fakeChaptersService struct {
-	enqueueResumableCalls int
-	scanEarlyAccessCalls  int
 	enqueueResumableErr   error
 	scanEarlyAccessErr    error
 	scanDone              chan struct{}
+	enqueueResumableCalls int
+	scanEarlyAccessCalls  int
 }
 
 func (f *fakeChaptersService) CreateAll(context.Context, uuid.UUID, []sources.SourceChapter) ([]chapters.Chapter, error) {

--- a/api/pkg/core/chapters/download/app_test.go
+++ b/api/pkg/core/chapters/download/app_test.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package download_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters/download"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+)
+
+type fakeChaptersService struct {
+	enqueueResumableCalls int
+	scanEarlyAccessCalls  int
+	enqueueResumableErr   error
+	scanEarlyAccessErr    error
+	scanDone              chan struct{}
+}
+
+func (f *fakeChaptersService) CreateAll(context.Context, uuid.UUID, []sources.SourceChapter) ([]chapters.Chapter, error) {
+	panic("CreateAll must not be called")
+}
+
+func (f *fakeChaptersService) ListByComicID(context.Context, uuid.UUID) ([]chapters.Chapter, error) {
+	panic("ListByComicID must not be called")
+}
+
+func (f *fakeChaptersService) EnqueueDownloadable(context.Context, []chapters.Chapter) error {
+	panic("EnqueueDownloadable must not be called")
+}
+
+func (f *fakeChaptersService) EnqueueResumable(context.Context) error {
+	f.enqueueResumableCalls++
+
+	return f.enqueueResumableErr
+}
+
+func (f *fakeChaptersService) ScanEarlyAccess(context.Context) error {
+	f.scanEarlyAccessCalls++
+
+	if f.scanDone != nil {
+		close(f.scanDone)
+	}
+
+	return f.scanEarlyAccessErr
+}
+
+func (f *fakeChaptersService) CleanupComic(context.Context, uuid.UUID, []chapters.Chapter) error {
+	panic("CleanupComic must not be called")
+}
+
+type blockingWorker struct {
+	started chan struct{}
+}
+
+func (b *blockingWorker) Run(ctx context.Context) error {
+	close(b.started)
+
+	<-ctx.Done()
+
+	return context.Canceled
+}
+
+func TestAppRunEnqueuesResumableOnBoot(t *testing.T) {
+	t.Parallel()
+
+	chaptersSvc := &fakeChaptersService{}
+	worker := &blockingWorker{started: make(chan struct{})}
+
+	app, err := download.NewApp(
+		download.AppConfig{ScanInterval: time.Hour},
+		download.AppDeps{
+			Worker:          worker,
+			ChaptersService: chaptersSvc,
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewApp: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- app.Run(ctx)
+	}()
+
+	select {
+	case <-worker.started:
+	case <-time.After(time.Second):
+		t.Fatal("worker did not start")
+	}
+
+	if chaptersSvc.enqueueResumableCalls != 1 {
+		t.Errorf("EnqueueResumable called %d times, want 1", chaptersSvc.enqueueResumableCalls)
+	}
+
+	cancel()
+
+	if err := <-errCh; err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
+func TestAppRunScansEarlyAccessOnStartup(t *testing.T) {
+	t.Parallel()
+
+	chaptersSvc := &fakeChaptersService{scanDone: make(chan struct{})}
+	worker := &blockingWorker{started: make(chan struct{})}
+
+	app, err := download.NewApp(
+		download.AppConfig{ScanInterval: time.Hour},
+		download.AppDeps{
+			Worker:          worker,
+			ChaptersService: chaptersSvc,
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewApp: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- app.Run(ctx)
+	}()
+
+	select {
+	case <-chaptersSvc.scanDone:
+	case <-time.After(time.Second):
+		t.Fatal("early-access scan did not run on startup")
+	}
+
+	if chaptersSvc.scanEarlyAccessCalls != 1 {
+		t.Errorf("ScanEarlyAccess called %d times, want 1 on startup", chaptersSvc.scanEarlyAccessCalls)
+	}
+
+	cancel()
+
+	if err := <-errCh; err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
+func TestAppRunReturnsEnqueueResumableError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("enqueue failed")
+	chaptersSvc := &fakeChaptersService{enqueueResumableErr: wantErr}
+	worker := &blockingWorker{started: make(chan struct{})}
+
+	app, err := download.NewApp(
+		download.AppConfig{ScanInterval: time.Hour},
+		download.AppDeps{
+			Worker:          worker,
+			ChaptersService: chaptersSvc,
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewApp: %v", err)
+	}
+
+	err = app.Run(context.Background())
+	if err == nil {
+		t.Fatal("Run: error expected")
+	}
+
+	if !errors.Is(err, wantErr) {
+		t.Errorf("Run error = %v, want it to wrap %v", err, wantErr)
+	}
+}

--- a/api/pkg/core/chapters/download/worker_test.go
+++ b/api/pkg/core/chapters/download/worker_test.go
@@ -40,6 +40,14 @@ func (f *fakeChaptersRepository) ListByComicID(context.Context, uuid.UUID) ([]ch
 	panic("not implemented")
 }
 
+func (f *fakeChaptersRepository) ListResumable(context.Context) ([]chapters.Chapter, error) {
+	panic("not implemented")
+}
+
+func (f *fakeChaptersRepository) ListEarlyAccessUnlocked(context.Context, time.Time) ([]chapters.Chapter, error) {
+	panic("not implemented")
+}
+
 func (f *fakeChaptersRepository) GetByID(_ context.Context, id uuid.UUID) (*chapters.Chapter, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/api/pkg/core/chapters/repository/pg/repository.go
+++ b/api/pkg/core/chapters/repository/pg/repository.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
@@ -75,6 +76,38 @@ func (r *PGChaptersRepository) Create(ctx context.Context, opts chapters.CreateO
 
 func (r *PGChaptersRepository) ListByComicID(ctx context.Context, comicID uuid.UUID) ([]chapters.Chapter, error) {
 	models, err := r.db(ctx).Where("comic_id = ?", comicID).Order("number ASC").Find(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
+	}
+
+	ret := make([]chapters.Chapter, 0, len(models))
+	for _, model := range models {
+		ret = append(ret, model.Domain())
+	}
+
+	return ret, nil
+}
+
+func (r *PGChaptersRepository) ListResumable(ctx context.Context) ([]chapters.Chapter, error) {
+	models, err := r.db(ctx).
+		Where("(download > 0 AND download < 100) OR download = -1").
+		Find(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
+	}
+
+	ret := make([]chapters.Chapter, 0, len(models))
+	for _, model := range models {
+		ret = append(ret, model.Domain())
+	}
+
+	return ret, nil
+}
+
+func (r *PGChaptersRepository) ListEarlyAccessUnlocked(ctx context.Context, now time.Time) ([]chapters.Chapter, error) {
+	models, err := r.db(ctx).
+		Where("download = 0 AND early_access_until <= ?", now).
+		Find(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
 	}

--- a/api/pkg/core/chapters/repository/pg/repository_test.go
+++ b/api/pkg/core/chapters/repository/pg/repository_test.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//nolint:goconst,lll
 package pg_test
 
 import (

--- a/api/pkg/core/chapters/repository/pg/repository_test.go
+++ b/api/pkg/core/chapters/repository/pg/repository_test.go
@@ -213,3 +213,64 @@ func TestChaptersListByComicID(t *testing.T) {
 		t.Errorf("ListByComicID() = %+v", got)
 	}
 }
+
+func TestChaptersListResumable(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newChaptersRepo(t)
+
+	comicID := uuid.New()
+	id := uuid.New()
+	publishedAt := time.Now().UTC().Truncate(time.Second)
+
+	mock.ExpectQuery(`FROM "chapters".*download > 0 AND download < 100\) OR download = -1`).
+		WillReturnRows(
+			sqlmock.NewRows([]string{
+				"id", "comic_id", "source_chapter_slug", "number", "title",
+				"pages_nb", "published_at", "early_access_until", "download",
+			}).AddRow(
+				id, comicID, chapterSlug, 1.0, chapterTitle,
+				42, publishedAt, publishedAt, 42,
+			),
+		)
+
+	got, err := r.ListResumable(context.Background())
+	if err != nil {
+		t.Fatalf("ListResumable: %v", err)
+	}
+
+	if len(got) != 1 || got[0].ID != id || got[0].Download != 42 {
+		t.Errorf("ListResumable() = %+v", got)
+	}
+}
+
+func TestChaptersListEarlyAccessUnlocked(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newChaptersRepo(t)
+
+	comicID := uuid.New()
+	id := uuid.New()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	mock.ExpectQuery(`FROM "chapters".*download = 0 AND early_access_until <= \$1`).
+		WithArgs(now).
+		WillReturnRows(
+			sqlmock.NewRows([]string{
+				"id", "comic_id", "source_chapter_slug", "number", "title",
+				"pages_nb", "published_at", "early_access_until", "download",
+			}).AddRow(
+				id, comicID, chapterSlug, 1.0, chapterTitle,
+				42, now, now.Add(-time.Hour), 0,
+			),
+		)
+
+	got, err := r.ListEarlyAccessUnlocked(context.Background(), now)
+	if err != nil {
+		t.Fatalf("ListEarlyAccessUnlocked: %v", err)
+	}
+
+	if len(got) != 1 || got[0].ID != id || got[0].Download != 0 {
+		t.Errorf("ListEarlyAccessUnlocked() = %+v", got)
+	}
+}

--- a/api/pkg/core/chapters/service.go
+++ b/api/pkg/core/chapters/service.go
@@ -102,6 +102,35 @@ func (s *Service) EnqueueDownloadable(ctx context.Context, chapters []Chapter) e
 	return nil
 }
 
+func (s *Service) EnqueueResumable(ctx context.Context) error {
+	chapterList, err := s.deps.Repository.ListResumable(ctx)
+	if err != nil {
+		return fmt.Errorf("s.deps.Repository.ListResumable: %w", err)
+	}
+
+	if len(chapterList) == 0 {
+		return nil
+	}
+
+	err = s.deps.ChapterDownloader.Enqueue(ctx, chapterList)
+	if err != nil {
+		return fmt.Errorf("s.deps.ChapterDownloader.Enqueue: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Service) ScanEarlyAccess(ctx context.Context) error {
+	now := time.Now()
+
+	chapterList, err := s.deps.Repository.ListEarlyAccessUnlocked(ctx, now)
+	if err != nil {
+		return fmt.Errorf("s.deps.Repository.ListEarlyAccessUnlocked: %w", err)
+	}
+
+	return s.EnqueueDownloadable(ctx, chapterList)
+}
+
 func (s *Service) CleanupComic(ctx context.Context, comicID uuid.UUID, chapterList []Chapter) error {
 	err := s.deps.ChapterDownloader.CleanupComic(ctx, comicID, chapterList)
 	if err != nil {

--- a/api/pkg/core/chapters/service_test.go
+++ b/api/pkg/core/chapters/service_test.go
@@ -14,8 +14,13 @@ import (
 )
 
 type fakeChaptersRepository struct {
-	lastCreateMany  []chapters.CreateOpts
-	createManyCalls int
+	lastCreateMany           []chapters.CreateOpts
+	createManyCalls          int
+	listResumableResult      []chapters.Chapter
+	listEarlyAccessResult    []chapters.Chapter
+	listResumableCalls       int
+	listEarlyAccessCalls     int
+	lastListEarlyAccessUntil time.Time
 }
 
 func (f *fakeChaptersRepository) Create(context.Context, chapters.CreateOpts) (*chapters.Chapter, error) {
@@ -45,6 +50,19 @@ func (f *fakeChaptersRepository) CreateMany(_ context.Context, opts []chapters.C
 
 func (f *fakeChaptersRepository) ListByComicID(context.Context, uuid.UUID) ([]chapters.Chapter, error) {
 	panic("ListByComicID must not be called")
+}
+
+func (f *fakeChaptersRepository) ListResumable(context.Context) ([]chapters.Chapter, error) {
+	f.listResumableCalls++
+
+	return f.listResumableResult, nil
+}
+
+func (f *fakeChaptersRepository) ListEarlyAccessUnlocked(_ context.Context, now time.Time) ([]chapters.Chapter, error) {
+	f.listEarlyAccessCalls++
+	f.lastListEarlyAccessUntil = now
+
+	return f.listEarlyAccessResult, nil
 }
 
 func (f *fakeChaptersRepository) GetByID(context.Context, uuid.UUID) (*chapters.Chapter, error) {
@@ -153,6 +171,80 @@ func TestServiceEnqueueDownloadableRunsWithoutError(t *testing.T) {
 
 	if len(downloader.lastEnqueueChapters) != 1 {
 		t.Fatalf("enqueued chapters = %+v, want one downloadable chapter", downloader.lastEnqueueChapters)
+	}
+}
+
+func TestServiceEnqueueResumable(t *testing.T) {
+	t.Parallel()
+
+	downloader := &fakeChapterDownloader{}
+	repo := &fakeChaptersRepository{
+		listResumableResult: []chapters.Chapter{
+			{ID: uuid.New(), Download: 42},
+			{ID: uuid.New(), Download: -1},
+		},
+	}
+	svc, err := chapters.NewService(chapters.Deps{
+		Repository:        repo,
+		ChapterDownloader: downloader,
+	})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	err = svc.EnqueueResumable(context.Background())
+	if err != nil {
+		t.Fatalf("EnqueueResumable: %v", err)
+	}
+
+	if repo.listResumableCalls != 1 {
+		t.Errorf("ListResumable called %d times, want 1", repo.listResumableCalls)
+	}
+
+	if downloader.enqueueCalls != 1 {
+		t.Errorf("Enqueue called %d times, want 1", downloader.enqueueCalls)
+	}
+
+	if len(downloader.lastEnqueueChapters) != 2 {
+		t.Fatalf("enqueued chapters = %+v, want 2 resumable chapters", downloader.lastEnqueueChapters)
+	}
+}
+
+func TestServiceScanEarlyAccess(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	downloader := &fakeChapterDownloader{}
+	repo := &fakeChaptersRepository{
+		listEarlyAccessResult: []chapters.Chapter{
+			{Download: 100},
+			{EarlyAccessUntil: now.Add(time.Hour)},
+			{Download: 0, EarlyAccessUntil: now.Add(-time.Hour)},
+		},
+	}
+	svc, err := chapters.NewService(chapters.Deps{
+		Repository:        repo,
+		ChapterDownloader: downloader,
+	})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	err = svc.ScanEarlyAccess(context.Background())
+	if err != nil {
+		t.Fatalf("ScanEarlyAccess: %v", err)
+	}
+
+	if repo.listEarlyAccessCalls != 1 {
+		t.Errorf("ListEarlyAccessUnlocked called %d times, want 1", repo.listEarlyAccessCalls)
+	}
+
+	if downloader.enqueueCalls != 1 {
+		t.Errorf("Enqueue called %d times, want 1", downloader.enqueueCalls)
+	}
+
+	if len(downloader.lastEnqueueChapters) != 1 {
+		t.Fatalf("enqueued chapters = %+v, want one unlocked chapter", downloader.lastEnqueueChapters)
 	}
 }
 

--- a/api/pkg/core/chapters/service_test.go
+++ b/api/pkg/core/chapters/service_test.go
@@ -14,13 +14,13 @@ import (
 )
 
 type fakeChaptersRepository struct {
+	lastListEarlyAccessUntil time.Time
 	lastCreateMany           []chapters.CreateOpts
-	createManyCalls          int
 	listResumableResult      []chapters.Chapter
 	listEarlyAccessResult    []chapters.Chapter
+	createManyCalls          int
 	listResumableCalls       int
 	listEarlyAccessCalls     int
-	lastListEarlyAccessUntil time.Time
 }
 
 func (f *fakeChaptersRepository) Create(context.Context, chapters.CreateOpts) (*chapters.Chapter, error) {

--- a/api/pkg/core/comics/service_test.go
+++ b/api/pkg/core/comics/service_test.go
@@ -233,6 +233,14 @@ func (f *fakeChaptersService) EnqueueDownloadable(_ context.Context, chapterList
 	return f.enqueueDownloadableErr
 }
 
+func (f *fakeChaptersService) EnqueueResumable(context.Context) error {
+	return nil
+}
+
+func (f *fakeChaptersService) ScanEarlyAccess(context.Context) error {
+	return nil
+}
+
 func (f *fakeChaptersService) CleanupComic(_ context.Context, comicID uuid.UUID, chapterList []chapters.Chapter) error {
 	f.cleanupComicCalls++
 	f.lastCleanupComicID = comicID


### PR DESCRIPTION
## Summary

Closes #37.

- Turn `download.App` into a full background app: on boot it enqueues resumable chapters (`0 < download < 100` or `download = -1`), runs the download worker, and periodically scans for newly unlocked early-access chapters.
- Add `EnqueueResumable` / `ScanEarlyAccess` to the chapters service, with repository queries `ListResumable` and `ListEarlyAccessUnlocked`.
- Wire the app in `setup.go` and expose `CHAPTER_DOWNLOAD_SCAN_INTERVAL` (default `15m`) alongside the existing rate-limit config.

## Test plan

- [x] `go test ./pkg/core/chapters/...`
- [x] Boot enqueue: resumable chapters are enqueued before the worker starts
- [x] Early-access scan: unlocked chapters are enqueued on startup and on each scan tick
- [x] Repository queries covered with sqlmock tests
- [x] `go build ./...` and `go test ./...` on CI