### PR TITLE
Enrich Asura chapters list with download status

### DIFF
--- a/api/cmd/uchiyomiserver/setup.go
+++ b/api/cmd/uchiyomiserver/setup.go
@@ -125,6 +125,8 @@ func setupApp(cfg *cfg) (*core.App, error) {
 		return nil, fmt.Errorf("failed to init chapters: %w", err)
 	}
 
+	asuraApp.BindChaptersService(chaptersSvc)
+
 	comicsSvc, err := comics.NewService(comics.Deps{
 		ComicsRepository:  dbr.ComicsRepository,
 		Transactor:        dbr.Txor,

--- a/api/pkg/sources/asurascans/pkg/core/app.go
+++ b/api/pkg/sources/asurascans/pkg/core/app.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 
 	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
 	coredomain "github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
@@ -40,6 +41,7 @@ type Deps struct {
 	GetChaptersListBySeriesCache *fncache.Cache[string, []domain.Chapter]
 	GetImageURLsByChapter        *fncache.Cache[domain.GetImageURLsByChapterOpts, []string]
 	ComicsRepository             comics.ComicsRepository
+	ChaptersService              chapters.ChaptersService
 }
 
 func (deps *Deps) Validate() error {
@@ -89,6 +91,10 @@ func New(cfg Config, deps Deps) (*App, error) {
 	}
 
 	return app, nil
+}
+
+func (a *App) BindChaptersService(svc chapters.ChaptersService) {
+	a.deps.ChaptersService = svc
 }
 
 func (a *App) Run(ctx context.Context) error {
@@ -195,7 +201,7 @@ func (a *App) GetInfosBySlug(
 }
 
 func (a *App) GetChaptersBySlug(ctx context.Context, slug string) ([]sources.SourceChapter, error) {
-	chs, err := a.GetChaptersListBySeries(ctx, slug)
+	chs, err := a.GetChaptersListBySeries(ctx, slug, uuid.Nil)
 	if err != nil {
 		//nolint:wrapcheck
 		return nil, err
@@ -216,7 +222,11 @@ func (a *App) GetChaptersBySlug(ctx context.Context, slug string) ([]sources.Sou
 	return result, nil
 }
 
-func (a *App) GetChaptersListBySeries(ctx context.Context, slug string) ([]domain.Chapter, error) {
+func (a *App) GetChaptersListBySeries(
+	ctx context.Context,
+	slug string,
+	userID uuid.UUID,
+) ([]domain.Chapter, error) {
 	res, err := a.deps.GetChaptersListBySeriesCache.Get(ctx, slug)
 	if err != nil {
 		//nolint:wrapcheck
@@ -227,7 +237,48 @@ func (a *App) GetChaptersListBySeries(ctx context.Context, slug string) ([]domai
 		return nil, nil
 	}
 
-	return slices.Clone(*res), nil
+	chapterList := slices.Clone(*res)
+
+	if userID == uuid.Nil || a.deps.ChaptersService == nil {
+		return chapterList, nil
+	}
+
+	comic, err := a.deps.ComicsRepository.GetBySourceSlug(ctx, comics.GetBySourceSlugOpts{
+		Source: a.cfg.SourceName,
+		Slug:   slug,
+		UserID: userID,
+	})
+	if err != nil && !errors.Is(err, coredomain.ErrNotFound) {
+		return nil, fmt.Errorf("a.deps.ComicsRepository.GetBySourceSlug: %w", err)
+	}
+
+	if comic == nil {
+		return chapterList, nil
+	}
+
+	dbChapters, err := a.deps.ChaptersService.ListByComicID(ctx, comic.ID)
+	if err != nil {
+		return nil, fmt.Errorf("a.deps.ChaptersService.ListByComicID: %w", err)
+	}
+
+	bySlug := make(map[string]chapters.Chapter, len(dbChapters))
+	for _, chapter := range dbChapters {
+		bySlug[chapter.SourceChapterSlug] = chapter
+	}
+
+	for i := range chapterList {
+		dbChapter, ok := bySlug[chapterList[i].ID]
+		if !ok {
+			continue
+		}
+
+		internalID := dbChapter.ID
+		download := dbChapter.Download
+		chapterList[i].InternalID = &internalID
+		chapterList[i].Download = &download
+	}
+
+	return chapterList, nil
 }
 
 func (a *App) GetImageURLsByChapter(ctx context.Context, opts domain.GetImageURLsByChapterOpts) ([]string, error) {

--- a/api/pkg/sources/asurascans/pkg/core/app_test.go
+++ b/api/pkg/sources/asurascans/pkg/core/app_test.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//nolint:goconst,lll
 package core_test
 
 import (
@@ -150,8 +151,8 @@ func (r inLibraryComicsRepository) GetMany(context.Context, comics.GetManyOpts) 
 }
 
 type libraryChaptersService struct {
-	chapters []chapters.Chapter
 	err      error
+	chapters []chapters.Chapter
 }
 
 func (s libraryChaptersService) CreateAll(

--- a/api/pkg/sources/asurascans/pkg/core/app_test.go
+++ b/api/pkg/sources/asurascans/pkg/core/app_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
 	coredomain "github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
@@ -99,6 +100,86 @@ func (r libraryComicsRepository) Delete(context.Context, uuid.UUID) error {
 
 func (r libraryComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]comics.Comic, error) {
 	return nil, nil
+}
+
+type inLibraryComicsRepository struct {
+	comic *comics.Comic
+	err   error
+}
+
+func (r inLibraryComicsRepository) GetByID(context.Context, comics.GetByIDOpts) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (r inLibraryComicsRepository) FindByID(context.Context, uuid.UUID) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (r inLibraryComicsRepository) GetBySourceSlug(
+	_ context.Context, _ comics.GetBySourceSlugOpts,
+) (*comics.Comic, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+
+	return r.comic, nil
+}
+
+func (r inLibraryComicsRepository) FindBySourceSlug(
+	context.Context, comics.FindBySourceSlugOpts,
+) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (r inLibraryComicsRepository) Create(context.Context, comics.CreateComicOpts) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (r inLibraryComicsRepository) GetBySlugsAndSource(
+	context.Context, comics.GetBySlugsAndSource,
+) ([]comics.Comic, error) {
+	return nil, nil
+}
+
+func (r inLibraryComicsRepository) Delete(context.Context, uuid.UUID) error {
+	return coredomain.ErrNotFound
+}
+
+func (r inLibraryComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]comics.Comic, error) {
+	return nil, nil
+}
+
+type libraryChaptersService struct {
+	chapters []chapters.Chapter
+	err      error
+}
+
+func (s libraryChaptersService) CreateAll(
+	context.Context, uuid.UUID, []sources.SourceChapter,
+) ([]chapters.Chapter, error) {
+	return nil, nil
+}
+
+func (s libraryChaptersService) ListByComicID(
+	context.Context, uuid.UUID,
+) ([]chapters.Chapter, error) {
+	return s.chapters, s.err
+}
+
+func (s libraryChaptersService) EnqueueDownloadable(context.Context, []chapters.Chapter) error {
+	return nil
+}
+
+func (s libraryChaptersService) EnqueueResumable(context.Context) error {
+	return nil
+}
+
+func (s libraryChaptersService) ScanEarlyAccess(context.Context) error {
+	return nil
+}
+
+func (s libraryChaptersService) CleanupComic(context.Context, uuid.UUID, []chapters.Chapter) error {
+	return nil
 }
 
 func newCache[P any, T any](
@@ -297,7 +378,7 @@ func TestAppGetChaptersListBySeriesReturnsACopy(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	first, err := app.GetChaptersListBySeries(context.Background(), "slug")
+	first, err := app.GetChaptersListBySeries(context.Background(), "slug", uuid.Nil)
 	if err != nil {
 		t.Fatalf("GetChaptersListBySeries: %v", err)
 	}
@@ -308,7 +389,7 @@ func TestAppGetChaptersListBySeriesReturnsACopy(t *testing.T) {
 
 	first[0].ID = "corrompu"
 
-	second, err := app.GetChaptersListBySeries(context.Background(), "slug")
+	second, err := app.GetChaptersListBySeries(context.Background(), "slug", uuid.Nil)
 	if err != nil {
 		t.Fatalf("GetChaptersListBySeries (2nd call): %v", err)
 	}
@@ -435,6 +516,106 @@ func TestAppSearchLibraryLookupFailure(t *testing.T) {
 	_, err = app.Search(context.Background(), domain.SearchOpts{})
 	if err == nil {
 		t.Fatal("Search must fail when the library lookup fails")
+	}
+}
+
+func TestAppGetChaptersListBySeriesEnrichesLibraryChapters(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chapterID := uuid.New()
+	userID := uuid.New()
+	seriesSlug := "solo-leveling"
+	sourceChapterSlug := "solo-leveling-chapter-1"
+	download := 42
+
+	deps := fullDeps(t)
+	deps.GetChaptersListBySeriesCache = newCache(t, identityKey,
+		func(context.Context, string) (*[]domain.Chapter, error) {
+			chapterList := []domain.Chapter{{
+				ID:     sourceChapterSlug,
+				Number: 1,
+				Title:  "Chapter 1",
+			}, {
+				ID:     "unknown-chapter",
+				Number: 2,
+				Title:  "Chapter 2",
+			}}
+
+			return &chapterList, nil
+		})
+	deps.ComicsRepository = inLibraryComicsRepository{
+		comic: &comics.Comic{ID: comicID, Slug: seriesSlug},
+	}
+	deps.ChaptersService = libraryChaptersService{chapters: []chapters.Chapter{{
+		ID:                chapterID,
+		ComicID:           comicID,
+		SourceChapterSlug: sourceChapterSlug,
+		Download:          download,
+	}}}
+
+	app, err := core.New(testConfig(), deps)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	res, err := app.GetChaptersListBySeries(context.Background(), seriesSlug, userID)
+	if err != nil {
+		t.Fatalf("GetChaptersListBySeries: %v", err)
+	}
+
+	if len(res) != 2 {
+		t.Fatalf("len(chapters) = %d, want 2", len(res))
+	}
+
+	if res[0].InternalID == nil || *res[0].InternalID != chapterID {
+		t.Errorf("chapter[0].InternalID = %v, want %s", res[0].InternalID, chapterID)
+	}
+
+	if res[0].Download == nil || *res[0].Download != download {
+		t.Errorf("chapter[0].Download = %v, want %d", res[0].Download, download)
+	}
+
+	if res[1].InternalID != nil {
+		t.Errorf("chapter[1].InternalID = %v, want nil", res[1].InternalID)
+	}
+
+	if res[1].Download != nil {
+		t.Errorf("chapter[1].Download = %v, want nil", res[1].Download)
+	}
+}
+
+func TestAppGetChaptersListBySeriesWithoutLibraryEntry(t *testing.T) {
+	t.Parallel()
+
+	deps := fullDeps(t)
+	deps.GetChaptersListBySeriesCache = newCache(t, identityKey,
+		func(context.Context, string) (*[]domain.Chapter, error) {
+			chapterList := []domain.Chapter{{ID: "c1", Number: 1}}
+
+			return &chapterList, nil
+		})
+
+	app, err := core.New(testConfig(), deps)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	res, err := app.GetChaptersListBySeries(context.Background(), "solo-leveling", uuid.New())
+	if err != nil {
+		t.Fatalf("GetChaptersListBySeries: %v", err)
+	}
+
+	if len(res) != 1 {
+		t.Fatalf("len(chapters) = %d, want 1", len(res))
+	}
+
+	if res[0].InternalID != nil {
+		t.Errorf("InternalID = %v, want nil when comic is not in library", res[0].InternalID)
+	}
+
+	if res[0].Download != nil {
+		t.Errorf("Download = %v, want nil when comic is not in library", res[0].Download)
 	}
 }
 

--- a/api/pkg/sources/asurascans/pkg/domain/apiclient.go
+++ b/api/pkg/sources/asurascans/pkg/domain/apiclient.go
@@ -230,6 +230,8 @@ func (r *GetInfosBySlugResponse) Source(internalURL *uuid.UUID) sources.GetInfos
 type Chapter struct {
 	EarlyAccessUntil time.Time
 	PublishedAt      time.Time
+	InternalID       *uuid.UUID
+	Download         *int
 	ID               string
 	Title            string
 	Number           float64

--- a/api/pkg/sources/asurascans/pkg/gateway/http/controller.go
+++ b/api/pkg/sources/asurascans/pkg/gateway/http/controller.go
@@ -234,7 +234,15 @@ func (c *Controller) getChaptersListBySeries(w http.ResponseWriter, r *http.Requ
 	slug := chi.URLParam(r, "seriesSlug")
 	ctx := r.Context()
 
-	chapters, err := c.deps.AsuraApp.GetChaptersListBySeries(ctx, slug)
+	user, ok := httpsession.UserFrom(ctx)
+	if !ok {
+		c.deps.Logger.ErrorContext(ctx, "user not found")
+		httputils.WriteError(w, c.deps.Logger, http.StatusUnauthorized, "user not found")
+
+		return
+	}
+
+	chapters, err := c.deps.AsuraApp.GetChaptersListBySeries(ctx, slug, user.ID)
 	if err != nil {
 		if errors.Is(err, domain.ErrNotFound) {
 			c.deps.Logger.ErrorContext(ctx, "series not found", "slug", slug)
@@ -253,6 +261,8 @@ func (c *Controller) getChaptersListBySeries(w http.ResponseWriter, r *http.Requ
 		return getChaptersListBySeriesResItemDTO{
 			EarlyAccessUntil: ch.EarlyAccessUntil,
 			PublishedAt:      ch.PublishedAt,
+			InternalID:       ch.InternalID,
+			Download:         ch.Download,
 			ID:               ch.ID,
 			Title:            ch.Title,
 			Number:           ch.Number,

--- a/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
+++ b/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//nolint:goconst,lll,unparam
 package http_test
 
 import (
@@ -358,8 +359,10 @@ func newChaptersTestAsuraApp(t *testing.T, deps asura.Deps) *asura.App {
 	if deps.SearchCache == nil {
 		searchCache, err := fncache.New(
 			fncache.Config[domain.SearchCacheOpts, domain.SearchCacheResult]{
-				Name:          "search",
-				Fn:            func(context.Context, domain.SearchCacheOpts) (*domain.SearchCacheResult, error) { return &domain.SearchCacheResult{}, nil },
+				Name: "search",
+				Fn: func(context.Context, domain.SearchCacheOpts) (*domain.SearchCacheResult, error) {
+					return &domain.SearchCacheResult{}, nil
+				},
 				Key:           func(domain.SearchCacheOpts) string { return "k" },
 				TTL:           time.Minute,
 				ErrorTTL:      time.Minute,
@@ -379,8 +382,10 @@ func newChaptersTestAsuraApp(t *testing.T, deps asura.Deps) *asura.App {
 	if deps.GetInfosBySlugCache == nil {
 		infosCache, err := fncache.New(
 			fncache.Config[string, domain.GetInfosBySlugResponse]{
-				Name:          "infos",
-				Fn:            func(context.Context, string) (*domain.GetInfosBySlugResponse, error) { return &domain.GetInfosBySlugResponse{}, nil },
+				Name: "infos",
+				Fn: func(context.Context, string) (*domain.GetInfosBySlugResponse, error) {
+					return &domain.GetInfosBySlugResponse{}, nil
+				},
 				Key:           func(slug string) string { return slug },
 				TTL:           time.Minute,
 				ErrorTTL:      time.Minute,
@@ -499,9 +504,9 @@ func TestGetChaptersListBySeriesEnrichesLibraryChapters(t *testing.T) {
 	}
 
 	var body []struct {
-		ID         string  `json:"id"`
 		InternalID *string `json:"internalId"`
 		Download   *int    `json:"download"`
+		ID         string  `json:"id"`
 	}
 
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
@@ -575,9 +580,9 @@ func TestGetChaptersListBySeriesWithoutLibraryEntry(t *testing.T) {
 	}
 
 	var body []struct {
-		ID         string `json:"id"`
 		InternalID *string `json:"internalId"`
 		Download   *int    `json:"download"`
+		ID         string  `json:"id"`
 	}
 
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {

--- a/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
+++ b/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
 	sessionshttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
 	coredomain "github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
@@ -67,6 +68,80 @@ func (stubComicsRepository) Delete(context.Context, uuid.UUID) error {
 
 func (stubComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]comics.Comic, error) {
 	return nil, nil
+}
+
+type inLibraryComicsRepository struct {
+	comic *comics.Comic
+}
+
+func (r inLibraryComicsRepository) GetByID(context.Context, comics.GetByIDOpts) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (r inLibraryComicsRepository) FindByID(context.Context, uuid.UUID) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (r inLibraryComicsRepository) GetBySourceSlug(
+	_ context.Context, _ comics.GetBySourceSlugOpts,
+) (*comics.Comic, error) {
+	return r.comic, nil
+}
+
+func (r inLibraryComicsRepository) FindBySourceSlug(
+	context.Context, comics.FindBySourceSlugOpts,
+) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (r inLibraryComicsRepository) Create(context.Context, comics.CreateComicOpts) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (r inLibraryComicsRepository) GetBySlugsAndSource(
+	context.Context, comics.GetBySlugsAndSource,
+) ([]comics.Comic, error) {
+	return nil, nil
+}
+
+func (r inLibraryComicsRepository) Delete(context.Context, uuid.UUID) error {
+	return coredomain.ErrNotFound
+}
+
+func (r inLibraryComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]comics.Comic, error) {
+	return nil, nil
+}
+
+type libraryChaptersService struct {
+	chapters []chapters.Chapter
+}
+
+func (s libraryChaptersService) CreateAll(
+	context.Context, uuid.UUID, []sources.SourceChapter,
+) ([]chapters.Chapter, error) {
+	return nil, nil
+}
+
+func (s libraryChaptersService) ListByComicID(
+	context.Context, uuid.UUID,
+) ([]chapters.Chapter, error) {
+	return s.chapters, nil
+}
+
+func (s libraryChaptersService) EnqueueDownloadable(context.Context, []chapters.Chapter) error {
+	return nil
+}
+
+func (s libraryChaptersService) EnqueueResumable(context.Context) error {
+	return nil
+}
+
+func (s libraryChaptersService) ScanEarlyAccess(context.Context) error {
+	return nil
+}
+
+func (s libraryChaptersService) CleanupComic(context.Context, uuid.UUID, []chapters.Chapter) error {
+	return nil
 }
 
 func newTestAsuraApp(t *testing.T) *asura.App {
@@ -270,5 +345,258 @@ func TestGetInfosBySlugReturnsProxiedCoverURL(t *testing.T) {
 	want := coverURLBuilder(covers.SourceAsuraScans, "solo-leveling")
 	if body.Cover != want {
 		t.Errorf("cover = %q, want %q", body.Cover, want)
+	}
+}
+
+func newChaptersTestAsuraApp(t *testing.T, deps asura.Deps) *asura.App {
+	t.Helper()
+
+	if deps.Logger == nil {
+		deps.Logger = slog.New(slog.DiscardHandler)
+	}
+
+	if deps.SearchCache == nil {
+		searchCache, err := fncache.New(
+			fncache.Config[domain.SearchCacheOpts, domain.SearchCacheResult]{
+				Name:          "search",
+				Fn:            func(context.Context, domain.SearchCacheOpts) (*domain.SearchCacheResult, error) { return &domain.SearchCacheResult{}, nil },
+				Key:           func(domain.SearchCacheOpts) string { return "k" },
+				TTL:           time.Minute,
+				ErrorTTL:      time.Minute,
+				FetchTimeout:  time.Minute,
+				CleanInterval: time.Minute,
+				MaxEntries:    1,
+			},
+			fncache.Deps{Logger: deps.Logger},
+		)
+		if err != nil {
+			t.Fatalf("fncache.New(search): %v", err)
+		}
+
+		deps.SearchCache = searchCache
+	}
+
+	if deps.GetInfosBySlugCache == nil {
+		infosCache, err := fncache.New(
+			fncache.Config[string, domain.GetInfosBySlugResponse]{
+				Name:          "infos",
+				Fn:            func(context.Context, string) (*domain.GetInfosBySlugResponse, error) { return &domain.GetInfosBySlugResponse{}, nil },
+				Key:           func(slug string) string { return slug },
+				TTL:           time.Minute,
+				ErrorTTL:      time.Minute,
+				FetchTimeout:  time.Minute,
+				CleanInterval: time.Minute,
+				MaxEntries:    1,
+			},
+			fncache.Deps{Logger: deps.Logger},
+		)
+		if err != nil {
+			t.Fatalf("fncache.New(infos): %v", err)
+		}
+
+		deps.GetInfosBySlugCache = infosCache
+	}
+
+	if deps.GetImageURLsByChapter == nil {
+		imagesCache, err := fncache.New(
+			fncache.Config[domain.GetImageURLsByChapterOpts, []string]{
+				Name: "images",
+				Fn: func(context.Context, domain.GetImageURLsByChapterOpts) (*[]string, error) {
+					return nil, errors.New("n/a")
+				},
+				Key:           func(domain.GetImageURLsByChapterOpts) string { return "k" },
+				TTL:           time.Minute,
+				ErrorTTL:      time.Minute,
+				FetchTimeout:  time.Minute,
+				CleanInterval: time.Minute,
+				MaxEntries:    1,
+			},
+			fncache.Deps{Logger: deps.Logger},
+		)
+		if err != nil {
+			t.Fatalf("fncache.New(images): %v", err)
+		}
+
+		deps.GetImageURLsByChapter = imagesCache
+	}
+
+	if deps.ComicsRepository == nil {
+		deps.ComicsRepository = stubComicsRepository{}
+	}
+
+	app, err := asura.New(asura.Config{SourceName: sources.SourceAsuraScans}, deps)
+	if err != nil {
+		t.Fatalf("asura.New: %v", err)
+	}
+
+	return app
+}
+
+func TestGetChaptersListBySeriesEnrichesLibraryChapters(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chapterID := uuid.New()
+	sourceChapterSlug := "solo-leveling-chapter-1"
+	download := 75
+
+	chaptersCache, err := fncache.New(
+		fncache.Config[string, []domain.Chapter]{
+			Name: "chapters",
+			Fn: func(context.Context, string) (*[]domain.Chapter, error) {
+				chapterList := []domain.Chapter{{
+					ID:     sourceChapterSlug,
+					Number: 1,
+					Title:  "Chapter 1",
+				}}
+
+				return &chapterList, nil
+			},
+			Key:           func(slug string) string { return slug },
+			TTL:           time.Minute,
+			ErrorTTL:      time.Minute,
+			FetchTimeout:  time.Minute,
+			CleanInterval: time.Minute,
+			MaxEntries:    1,
+		},
+		fncache.Deps{Logger: slog.New(slog.DiscardHandler)},
+	)
+	if err != nil {
+		t.Fatalf("fncache.New(chapters): %v", err)
+	}
+
+	ctrl, err := asurahttp.New(
+		asurahttp.Config{Endpoint: "/asura"},
+		asurahttp.Deps{
+			AsuraApp: newChaptersTestAsuraApp(t, asura.Deps{
+				GetChaptersListBySeriesCache: chaptersCache,
+				ComicsRepository: inLibraryComicsRepository{
+					comic: &comics.Comic{ID: comicID, Slug: "solo-leveling"},
+				},
+				ChaptersService: libraryChaptersService{chapters: []chapters.Chapter{{
+					ID:                chapterID,
+					ComicID:           comicID,
+					SourceChapterSlug: sourceChapterSlug,
+					Download:          download,
+				}}},
+			}),
+			Logger:          slog.New(slog.DiscardHandler),
+			CoverURLBuilder: coverURLBuilder,
+		},
+	)
+	if err != nil {
+		t.Fatalf("asurahttp.New: %v", err)
+	}
+
+	r := chi.NewRouter()
+	ctrl.InitRouter(r)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, authenticatedRequest(http.MethodGet, "/asura/series/solo-leveling/chapters"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var body []struct {
+		ID         string  `json:"id"`
+		InternalID *string `json:"internalId"`
+		Download   *int    `json:"download"`
+	}
+
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	if len(body) != 1 {
+		t.Fatalf("len(chapters) = %d, want 1", len(body))
+	}
+
+	if body[0].ID != sourceChapterSlug {
+		t.Errorf("id = %q, want %q", body[0].ID, sourceChapterSlug)
+	}
+
+	if body[0].InternalID == nil || *body[0].InternalID != chapterID.String() {
+		t.Errorf("internalId = %v, want %q", body[0].InternalID, chapterID)
+	}
+
+	if body[0].Download == nil || *body[0].Download != download {
+		t.Errorf("download = %v, want %d", body[0].Download, download)
+	}
+}
+
+func TestGetChaptersListBySeriesWithoutLibraryEntry(t *testing.T) {
+	t.Parallel()
+
+	chaptersCache, err := fncache.New(
+		fncache.Config[string, []domain.Chapter]{
+			Name: "chapters",
+			Fn: func(context.Context, string) (*[]domain.Chapter, error) {
+				chapterList := []domain.Chapter{{ID: "c1", Number: 1, Title: "Chapter 1"}}
+
+				return &chapterList, nil
+			},
+			Key:           func(slug string) string { return slug },
+			TTL:           time.Minute,
+			ErrorTTL:      time.Minute,
+			FetchTimeout:  time.Minute,
+			CleanInterval: time.Minute,
+			MaxEntries:    1,
+		},
+		fncache.Deps{Logger: slog.New(slog.DiscardHandler)},
+	)
+	if err != nil {
+		t.Fatalf("fncache.New(chapters): %v", err)
+	}
+
+	ctrl, err := asurahttp.New(
+		asurahttp.Config{Endpoint: "/asura"},
+		asurahttp.Deps{
+			AsuraApp: newChaptersTestAsuraApp(t, asura.Deps{
+				GetChaptersListBySeriesCache: chaptersCache,
+				ComicsRepository:             stubComicsRepository{},
+			}),
+			Logger:          slog.New(slog.DiscardHandler),
+			CoverURLBuilder: coverURLBuilder,
+		},
+	)
+	if err != nil {
+		t.Fatalf("asurahttp.New: %v", err)
+	}
+
+	r := chi.NewRouter()
+	ctrl.InitRouter(r)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, authenticatedRequest(http.MethodGet, "/asura/series/solo-leveling/chapters"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var body []struct {
+		ID         string `json:"id"`
+		InternalID *string `json:"internalId"`
+		Download   *int    `json:"download"`
+	}
+
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	if len(body) != 1 {
+		t.Fatalf("len(chapters) = %d, want 1", len(body))
+	}
+
+	if body[0].ID != "c1" {
+		t.Errorf("id = %q, want %q", body[0].ID, "c1")
+	}
+
+	if body[0].InternalID != nil {
+		t.Errorf("internalId = %v, want nil", body[0].InternalID)
+	}
+
+	if body[0].Download != nil {
+		t.Errorf("download = %v, want nil", body[0].Download)
 	}
 }

--- a/api/pkg/sources/asurascans/pkg/gateway/http/dto.go
+++ b/api/pkg/sources/asurascans/pkg/gateway/http/dto.go
@@ -193,11 +193,13 @@ type getInfosBySlugResDTO struct {
 }
 
 type getChaptersListBySeriesResItemDTO struct {
-	EarlyAccessUntil time.Time `json:"earlyAccessUntil"`
-	PublishedAt      time.Time `json:"publishedAt"`
-	ID               string    `json:"id"`
-	Title            string    `json:"title"`
-	Number           float64   `json:"number"`
+	EarlyAccessUntil time.Time  `json:"earlyAccessUntil"`
+	PublishedAt      time.Time  `json:"publishedAt"`
+	InternalID       *uuid.UUID `json:"internalId,omitempty"`
+	Download         *int       `json:"download,omitempty"`
+	ID               string     `json:"id"`
+	Title            string     `json:"title"`
+	Number           float64    `json:"number"`
 }
 
 type getImageURLsByChapterResDTO struct {

--- a/web/app/features/asura/components/Comic/Chapters/Item.vue
+++ b/web/app/features/asura/components/Comic/Chapters/Item.vue
@@ -73,7 +73,29 @@ const to = computed(() => {
         </div>
       </div>
 
-      <span class="text-body-medium text-medium-emphasis" :class="{ 'text-gold': isEarlyAccess }">{{ date }}</span>
+      <div class="d-flex align-center ga-3">
+        <VProgressCircular
+          v-if="chapter.internalId && chapter.download !== undefined && chapter.download >= 0 && chapter.download < 100"
+          :model-value="chapter.download"
+          size="18"
+          :indeterminate="chapter.download === 0"
+          width="2"
+          color="primary"
+        />
+        <VIcon
+          v-else-if="chapter.internalId && chapter.download === 100"
+          icon="fa6-solid:check"
+          size="x-small"
+          color="success"
+        />
+        <VIcon
+          v-else-if="chapter.internalId && chapter.download === -1"
+          icon="fa6-solid:exclamation"
+          size="x-small"
+          color="error"
+        />
+        <span class="text-body-medium text-medium-emphasis" :class="{ 'text-gold': isEarlyAccess }">{{ date }}</span>
+      </div>
     </div>
   </AtomLink>
 </template>

--- a/web/app/features/asura/components/Comic/Chapters/index.vue
+++ b/web/app/features/asura/components/Comic/Chapters/index.vue
@@ -1,46 +1,15 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script setup lang="ts">
-import type { AsuraComicChapter } from '../../../types'
+const props = defineProps<{
+  slug: string
+  comicOriginUrl: string
+}>()
 
-const props = defineProps<{ slug: string, comicOriginUrl: string }>()
+const { sort, chapters, loading, fetchChapters } = useAsuraChapters()
 
-const api = createAsuraApi()
-const toast = useToast()
-const { t } = useI18n()
-
-const fetchChaptersLoading = ref(false)
-const chapters = ref<AsuraComicChapter[]>([])
-
-onMounted(() => {
+watch(() => props.slug, () => {
   fetchChapters()
-})
-
-async function fetchChapters(): Promise<void> {
-  fetchChaptersLoading.value = true
-
-  const res = await api.getSeriesChapters(props.slug as string)
-
-  if (res.success) {
-    chapters.value = res.data
-  } else {
-    console.error('api.getSeriesChapters', res.error)
-    toast.error(res.error.status === 404
-      ? t('sources.asura.comic.chapters.error.fetch')
-      : t('error.unknown'))
-  }
-
-  fetchChaptersLoading.value = false
-}
-
-const sort = ref<'asc' | 'desc'>('desc')
-
-const filteredChapters = computed(() => chapters.value.toSorted((a, b) => {
-  if (sort.value === 'asc') {
-    return a.number - b.number
-  }
-
-  return b.number - a.number
-}))
+}, { immediate: true })
 </script>
 
 <template>
@@ -57,16 +26,16 @@ const filteredChapters = computed(() => chapters.value.toSorted((a, b) => {
       />
     </div>
 
-    <div v-if="fetchChaptersLoading || filteredChapters.length === 0" class="d-flex justify-center align-center w-100 pa-4">
+    <div v-if="loading || chapters.length === 0" class="d-flex justify-center align-center w-100 pa-4">
       <VProgressCircular
-        v-if="fetchChaptersLoading"
+        v-if="loading"
         class="m-auto"
         indeterminate
         color="primary"
       />
       <span v-else class="text-medium-emphasis">{{ $t('sources.asurascans.comic.chaptersCount', { count: 0 }) }}</span>
     </div>
-    <VVirtualScroll :items="filteredChapters" style="border-bottom-left-radius: 12px; border-bottom-right-radius: 12px;">
+    <VVirtualScroll :items="chapters" style="border-bottom-left-radius: 12px; border-bottom-right-radius: 12px;">
       <template #default="{ item }">
         <AsuraComicChaptersItem
           :chapter="item"

--- a/web/app/features/asura/components/Comic/StatusInfos.vue
+++ b/web/app/features/asura/components/Comic/StatusInfos.vue
@@ -7,6 +7,7 @@ const props = defineProps<{ comicOriginUrl: string }>()
 const comic = defineModel<AsuraComicInfos>({ required: true })
 
 const { addComicInLibrary } = useAsuraSearch({ doSearch: false })
+const { fetchChapters } = useAsuraChapters()
 
 const showDeleteModal = ref(false)
 const addToLibraryLoading = ref(false)
@@ -37,6 +38,12 @@ async function addComicToLibrary(): Promise<void> {
 
   addToLibraryLoading.value = false
 }
+
+watch(() => comic.value.internalId, (newValue, oldValue) => {
+  if (!newValue && oldValue) {
+    fetchChapters()
+  }
+})
 </script>
 
 <template>

--- a/web/app/features/asura/composables/asura-chapters.composable.ts
+++ b/web/app/features/asura/composables/asura-chapters.composable.ts
@@ -1,0 +1,58 @@
+import type { AsuraComicChapter } from '../types'
+import { useAsuraChaptersStore } from '../stores/asura-chapters.store'
+
+export interface AsuraChaptersComposable {
+  sort: Ref<'asc' | 'desc'>
+  chapters: Ref<AsuraComicChapter[]>
+  loading: Ref<boolean>
+  fetchChapters: () => Promise<void>
+}
+
+export function useAsuraChapters(): AsuraChaptersComposable {
+  const store = useAsuraChaptersStore()
+  const api = createAsuraApi()
+  const toast = useToast()
+  const { t } = useI18n()
+  const route = useRoute('browse-sources-asura-slug')
+
+  const sort = ref<'asc' | 'desc'>('desc')
+  const chapters = computed(() => store.chapters.toSorted((a, b) => {
+    if (sort.value === 'asc') {
+      return a.number - b.number
+    }
+
+    return b.number - a.number
+  }))
+
+  const loading = ref(false)
+  async function fetchChapters(): Promise<void> {
+    loading.value = true
+
+    const res = await api.getSeriesChapters(route.params.slug)
+
+    if (res.success) {
+      store.setChapters(res.data)
+    } else {
+      console.error('api.getSeriesChapters', res.error)
+
+      if (res.error.status === 404) {
+        toast.error(t('sources.asura.comic.chapters.error.fetch'))
+      } else {
+        toast.error(t('error.unknown'))
+      }
+    }
+
+    loading.value = false
+  }
+
+  onBeforeRouteLeave(() => {
+    store.invalidate()
+  })
+
+  return {
+    sort,
+    chapters,
+    loading,
+    fetchChapters,
+  }
+}

--- a/web/app/features/asura/stores/asura-chapters.store.ts
+++ b/web/app/features/asura/stores/asura-chapters.store.ts
@@ -1,0 +1,26 @@
+import type { AsuraComicChapter } from '../types'
+
+export interface AsuraChaptersStore {
+  chapters: AsuraComicChapter[]
+  setChapters: (value: AsuraComicChapter[]) => void
+  invalidate: () => void
+}
+
+export const useAsuraChaptersStore = defineStore('asuraChapters', () => {
+  const chapters = ref<AsuraComicChapter[]>([])
+
+  function setChapters(value: AsuraComicChapter[]): void {
+    chapters.value = value
+  }
+
+  function invalidate(): void {
+    chapters.value = []
+  }
+
+  return {
+    chapters,
+
+    setChapters,
+    invalidate,
+  }
+})

--- a/web/app/features/asura/types.ts
+++ b/web/app/features/asura/types.ts
@@ -49,6 +49,8 @@ export interface AsuraComicChapter {
   id: string
   title: string
   number: number
+  internalId?: string
+  download?: number
 }
 
 export interface AsuraComicInfos {

--- a/web/app/pages/browse/sources/asura/[slug].vue
+++ b/web/app/pages/browse/sources/asura/[slug].vue
@@ -1,5 +1,6 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script setup lang="ts">
+import type AsuraComicChapters from '~/features/asura/components/Comic/Chapters/index.vue'
 import type { AsuraComicInfos } from '~/features/asura/types'
 import defaultCover from '~/assets/images/default/comic-cover.webp'
 import asuraImg from '~/assets/images/sources/asurascans.webp'
@@ -19,6 +20,7 @@ const api = createAsuraApi()
 
 const fetchInfosLoading = ref(false)
 const infos = ref<AsuraComicInfos>()
+const chaptersComponent = useTemplateRef<InstanceType<typeof AsuraComicChapters>>('chaptersComponent')
 
 const coverSrc = ref<string>()
 
@@ -111,7 +113,11 @@ const comicOriginUrl = computed(() => {
           :comic-origin-url="comicOriginUrl"
         />
         <AsuraComicGeneralInfos :comic="infos" />
-        <AsuraComicChapters :slug="route.params.slug" :comic-origin-url="comicOriginUrl" />
+        <AsuraComicChapters
+          ref="chaptersComponent"
+          :slug="route.params.slug"
+          :comic-origin-url="comicOriginUrl"
+        />
       </div>
     </div>
   </OrganismPageLayout>


### PR DESCRIPTION
## Summary

- Enrich `GET /api/sources/asura/series/{slug}/chapters` with internal chapter `id` and `download` progress when the series is in the authenticated user's library
- Match DB chapters by `sourceChapterSlug`; chapters without a DB row keep the unchanged Asura payload
- Wire `ChaptersService` into the Asura app and extend web `AsuraComicChapter` types

Closes #40

## Test plan

- [x] `cd api && go build ./...`
- [x] `cd api && go test ./...`
- [x] `cd api && golangci-lint run ./...`
- [x] Manual: open a library series detail page and confirm chapter download progress appears once the UI consumes the new fields