### PR TITLE
feat: periodic chapter list refresh for library comics

### DIFF
--- a/api/cmd/uchiyomiserver/config.go
+++ b/api/cmd/uchiyomiserver/config.go
@@ -48,6 +48,7 @@ type cfg struct {
 		UID int `env:"PUID" envDefault:"65532"`
 		GID int `env:"PGID" envDefault:"65532"`
 	}
+	ChapterListRefreshInterval time.Duration `env:"CHAPTER_LIST_REFRESH_INTERVAL" envDefault:"3h"`
 }
 
 func newConfig() (*cfg, error) {

--- a/api/cmd/uchiyomiserver/setup.go
+++ b/api/cmd/uchiyomiserver/setup.go
@@ -14,6 +14,7 @@ import (
 	core "github.com/kharente-deuh/uchiyomi-server/pkg/core"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
 	httpcomics "github.com/kharente-deuh/uchiyomi-server/pkg/core/comics/gateway/http"
+	comicrefresh "github.com/kharente-deuh/uchiyomi-server/pkg/core/comics/refresh"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
 	asura "github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/core"
 	asuradomain "github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/domain"
@@ -136,9 +137,18 @@ func setupApp(cfg *cfg) (*core.App, error) {
 		LibraryRepository: dbr.LibraryRepository,
 		ChaptersService:   chaptersSvc,
 		Sources:           sources.SourceMap{sources.SourceAsuraScans: asuraApp},
+		Logger:            logger,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to init comicsSvc: %w", err)
+	}
+
+	chapterListRefresh, err := comicrefresh.New(
+		comicrefresh.Config{Interval: cfg.ChapterListRefreshInterval},
+		comicrefresh.Deps{ComicsService: comicsSvc, Logger: logger},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init chapter list refresh: %w", err)
 	}
 
 	apps.Asura = asuraApp
@@ -179,14 +189,15 @@ func setupApp(cfg *cfg) (*core.App, error) {
 			ComicsCtrl:        ctrls.Comics,
 			ChaptersCtrl:      ctrls.Chapters,
 
-			Health:           registry,
-			Logger:           logger,
-			DB:               dbr.PGDB,
-			Asura:            apps.Asura,
-			Covers:           apps.Covers,
-			Downloads:        downloadApp,
-			Sessions:         apps.Sessions,
-			OIDCRevalidation: apps.OIDCRevalidation,
+			Health:             registry,
+			Logger:             logger,
+			DB:                 dbr.PGDB,
+			Asura:              apps.Asura,
+			Covers:             apps.Covers,
+			Downloads:          downloadApp,
+			ChapterListRefresh: chapterListRefresh,
+			Sessions:           apps.Sessions,
+			OIDCRevalidation:   apps.OIDCRevalidation,
 		})
 	if err != nil {
 		return nil, fmt.Errorf("failed to init main app: %w", err)

--- a/api/cmd/uchiyomiserver/setup_internal_test.go
+++ b/api/cmd/uchiyomiserver/setup_internal_test.go
@@ -61,6 +61,14 @@ func (stubComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]comi
 	return nil, nil
 }
 
+func (stubComicsRepository) ListByStatuses(context.Context, comics.ListByStatusesOpts) ([]comics.Comic, error) {
+	return nil, nil
+}
+
+func (stubComicsRepository) UpdateStatusAndChapterCount(context.Context, comics.UpdateStatusAndChapterCountOpts) error {
+	return nil
+}
+
 type emptyOIDCProvidersRepository struct{}
 
 func (emptyOIDCProvidersRepository) GetByID(

--- a/api/pkg/core/app.go
+++ b/api/pkg/core/app.go
@@ -79,11 +79,12 @@ type Deps struct {
 	Logger *slog.Logger
 	Health *health.Registry
 
-	Asura            *asura.App
-	Covers           *covers.App
-	Downloads        interface{ Run(context.Context) error }
-	Sessions         *sessions.App
-	OIDCRevalidation interface{ Run(context.Context) error }
+	Asura              *asura.App
+	Covers             *covers.App
+	Downloads          interface{ Run(context.Context) error }
+	ChapterListRefresh interface{ Run(context.Context) error }
+	Sessions           *sessions.App
+	OIDCRevalidation   interface{ Run(context.Context) error }
 }
 
 func (deps *Deps) Validate() error {
@@ -117,6 +118,10 @@ func (deps *Deps) Validate() error {
 
 	if deps.Downloads == nil {
 		return errors.New("downloads is required")
+	}
+
+	if deps.ChapterListRefresh == nil {
+		return errors.New("chapterListRefresh is required")
 	}
 
 	if deps.Sessions == nil {
@@ -208,6 +213,7 @@ func (a *App) startup(ctx context.Context, errG *errgroup.Group) func() error {
 		errG.Go(a.runComponent(ctx, componentAsura, a.deps.Asura.Run))
 		errG.Go(a.runComponent(ctx, componentCovers, a.deps.Covers.Run))
 		errG.Go(a.runComponent(ctx, componentDownloads, a.deps.Downloads.Run))
+		errG.Go(a.runComponent(ctx, componentChapterListRefresh, a.deps.ChapterListRefresh.Run))
 		errG.Go(a.runComponent(ctx, componentSessions, a.deps.Sessions.Run))
 		errG.Go(a.runComponent(ctx, componentOIDCRevalidation, a.deps.OIDCRevalidation.Run))
 

--- a/api/pkg/core/app_internal_test.go
+++ b/api/pkg/core/app_internal_test.go
@@ -142,7 +142,7 @@ func TestRunReportsEverythingOKOnceMigrationCompletes(t *testing.T) {
 
 	body := decodeReadyz(t, raw)
 	components := []string{
-		componentMigrations, componentAsura, componentCovers, componentDownloads, componentSessions, componentOIDCRevalidation, componentDB,
+		componentMigrations, componentAsura, componentCovers, componentDownloads, componentChapterListRefresh, componentSessions, componentOIDCRevalidation, componentDB,
 	}
 	for _, name := range components {
 		if got := body.Components[name].Status; got != string(health.StatusOK) {

--- a/api/pkg/core/chapters/download/worker_test.go
+++ b/api/pkg/core/chapters/download/worker_test.go
@@ -131,6 +131,14 @@ func (f *fakeComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]c
 	panic("not implemented")
 }
 
+func (f *fakeComicsRepository) ListByStatuses(context.Context, comics.ListByStatusesOpts) ([]comics.Comic, error) {
+	panic("not implemented")
+}
+
+func (f *fakeComicsRepository) UpdateStatusAndChapterCount(context.Context, comics.UpdateStatusAndChapterCountOpts) error {
+	panic("not implemented")
+}
+
 type fakeSource struct {
 	pageURLs []string
 }
@@ -139,7 +147,7 @@ func (f *fakeSource) GetInfosBySlug(context.Context, sources.GetInfosBySlugOpts)
 	panic("not implemented")
 }
 
-func (f *fakeSource) GetChaptersBySlug(context.Context, string) ([]sources.SourceChapter, error) {
+func (f *fakeSource) GetChaptersBySlug(context.Context, sources.GetChaptersBySlugOpts) ([]sources.SourceChapter, error) {
 	panic("not implemented")
 }
 

--- a/api/pkg/core/comics/domain.go
+++ b/api/pkg/core/comics/domain.go
@@ -47,6 +47,8 @@ type ComicsRepository interface {
 	GetBySlugsAndSource(context.Context, GetBySlugsAndSource) ([]Comic, error)
 	Delete(context.Context, uuid.UUID) error
 	GetMany(context.Context, GetManyOpts) ([]Comic, error)
+	ListByStatuses(context.Context, ListByStatusesOpts) ([]Comic, error)
+	UpdateStatusAndChapterCount(context.Context, UpdateStatusAndChapterCountOpts) error
 }
 
 type CreateComicOpts struct {
@@ -75,6 +77,7 @@ type ComicsService interface {
 	GetByID(context.Context, GetByIDOpts) (*Comic, error)
 	GetMany(context.Context, GetManyOpts) ([]Comic, error)
 	Delete(context.Context, DeleteOpts) error
+	RefreshChapterLists(context.Context) error
 }
 
 type CreateOpts struct {
@@ -100,4 +103,15 @@ type GetManyOpts struct {
 type DeleteOpts struct {
 	UserID uuid.UUID
 	ID     uuid.UUID
+}
+
+type ListByStatusesOpts struct {
+	Source   sources.SourceName
+	Statuses []sources.SeriesStatus
+}
+
+type UpdateStatusAndChapterCountOpts struct {
+	Status       sources.SeriesStatus
+	ID           uuid.UUID
+	ChapterCount int
 }

--- a/api/pkg/core/comics/gateway/http/controller_test.go
+++ b/api/pkg/core/comics/gateway/http/controller_test.go
@@ -58,6 +58,10 @@ func (s *stubComicsService) Delete(_ context.Context, _ comics.DeleteOpts) error
 	return s.deleteErr
 }
 
+func (s *stubComicsService) RefreshChapterLists(context.Context) error {
+	return nil
+}
+
 type stubSessionService struct {
 	result *sessions.AuthenticatedSession
 }

--- a/api/pkg/core/comics/refresh.go
+++ b/api/pkg/core/comics/refresh.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package comics
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"slices"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/logging"
+)
+
+func (s *Service) logger() *slog.Logger {
+	if s.deps.Logger == nil {
+		return slog.Default()
+	}
+
+	return s.deps.Logger
+}
+
+func (s *Service) RefreshChapterLists(ctx context.Context) error {
+	names := make([]sources.SourceName, 0, len(s.deps.Sources))
+	for name := range s.deps.Sources {
+		names = append(names, name)
+	}
+
+	slices.Sort(names)
+
+	for _, name := range names {
+		if err := s.refreshSource(ctx, name); err != nil {
+			s.logger().ErrorContext(ctx, "chapter list refresh failed for source",
+				"source", name, logging.Err(err))
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) refreshSource(ctx context.Context, name sources.SourceName) error {
+	src, ok := s.deps.Sources[name]
+	if !ok || src == nil {
+		return fmt.Errorf("source %s not found", name)
+	}
+
+	list, err := s.deps.ComicsRepository.ListByStatuses(ctx, ListByStatusesOpts{
+		Source: name,
+		Statuses: []sources.SeriesStatus{
+			sources.SeriesStatusOngoing,
+			sources.SeriesStatusHiatus,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("s.deps.ComicsRepository.ListByStatuses: %w", err)
+	}
+
+	for i := range list {
+		comic := list[i]
+		if err := s.refreshComic(ctx, src, comic); err != nil {
+			s.logger().ErrorContext(ctx, "chapter list refresh failed for comic",
+				"source", name, "slug", comic.Slug, logging.Err(err))
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) refreshComic(ctx context.Context, src sources.Source, comic Comic) error {
+	infos, err := src.GetInfosBySlug(ctx, sources.GetInfosBySlugOpts{
+		Slug:  comic.Slug,
+		Fresh: true,
+	})
+	if err != nil {
+		return fmt.Errorf("src.GetInfosBySlug: %w", err)
+	}
+
+	srcChapters, err := src.GetChaptersBySlug(ctx, sources.GetChaptersBySlugOpts{
+		Slug:  comic.Slug,
+		Fresh: true,
+	})
+	if err != nil {
+		return fmt.Errorf("src.GetChaptersBySlug: %w", err)
+	}
+
+	existing, err := s.deps.ChaptersService.ListByComicID(ctx, comic.ID)
+	if err != nil {
+		return fmt.Errorf("s.deps.ChaptersService.ListByComicID: %w", err)
+	}
+
+	missing := missingSourceChapters(existing, srcChapters)
+	if len(missing) > 0 {
+		created, err := s.deps.ChaptersService.CreateAll(ctx, comic.ID, missing)
+		if err != nil {
+			return fmt.Errorf("s.deps.ChaptersService.CreateAll: %w", err)
+		}
+
+		err = s.deps.ChaptersService.EnqueueDownloadable(ctx, created)
+		if err != nil {
+			return fmt.Errorf("s.deps.ChaptersService.EnqueueDownloadable: %w", err)
+		}
+	}
+
+	err = s.deps.ComicsRepository.UpdateStatusAndChapterCount(ctx, UpdateStatusAndChapterCountOpts{
+		ID:           comic.ID,
+		Status:       infos.Status,
+		ChapterCount: infos.ChapterCount,
+	})
+	if err != nil {
+		return fmt.Errorf("s.deps.ComicsRepository.UpdateStatusAndChapterCount: %w", err)
+	}
+
+	return nil
+}
+
+func missingSourceChapters(
+	existing []chapters.Chapter,
+	srcChapters []sources.SourceChapter,
+) []sources.SourceChapter {
+	have := make(map[string]struct{}, len(existing))
+	for _, chapter := range existing {
+		have[chapter.SourceChapterSlug] = struct{}{}
+	}
+
+	var missing []sources.SourceChapter
+
+	for _, srcChapter := range srcChapters {
+		if _, ok := have[srcChapter.SourceChapterSlug]; ok {
+			continue
+		}
+
+		missing = append(missing, srcChapter)
+	}
+
+	return missing
+}

--- a/api/pkg/core/comics/refresh/app.go
+++ b/api/pkg/core/comics/refresh/app.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package refresh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/logging"
+)
+
+type Config struct {
+	Interval time.Duration
+}
+
+func (cfg *Config) Validate() error {
+	if cfg.Interval < time.Minute {
+		return errors.New("interval must be at least 1 minute")
+	}
+
+	return nil
+}
+
+type Deps struct {
+	ComicsService comics.ComicsService
+	Logger        *slog.Logger
+}
+
+func (deps *Deps) Validate() error {
+	if deps.ComicsService == nil {
+		return errors.New("comicsService is required")
+	}
+
+	return nil
+}
+
+type App struct {
+	deps    Deps
+	cfg     Config
+	running atomic.Bool
+}
+
+func New(cfg Config, deps Deps) (*App, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("cfg.Validate: %w", err)
+	}
+
+	if err := deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	if deps.Logger == nil {
+		deps.Logger = slog.Default()
+	}
+
+	deps.Logger = deps.Logger.With("component", "comics.refresh")
+
+	return &App{deps: deps, cfg: cfg}, nil
+}
+
+func (a *App) Run(ctx context.Context) error {
+	a.deps.Logger.Info("chapter list refresh started")
+
+	//nolint:wrapcheck
+	return utils.Loop(ctx, utils.LoopOpts{
+		Interval: a.cfg.Interval,
+		Fn:       a.refresh,
+	})
+}
+
+func (a *App) refresh(ctx context.Context) error {
+	if !a.running.CompareAndSwap(false, true) {
+		a.deps.Logger.WarnContext(ctx, "chapter list refresh skipped: already running")
+
+		return nil
+	}
+
+	defer a.running.Store(false)
+
+	if err := a.deps.ComicsService.RefreshChapterLists(ctx); err != nil {
+		a.deps.Logger.ErrorContext(ctx, "chapter list refresh failed", logging.Err(err))
+	}
+
+	return nil
+}

--- a/api/pkg/core/comics/refresh/app_test.go
+++ b/api/pkg/core/comics/refresh/app_test.go
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package refresh_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics/refresh"
+)
+
+type fakeComicsService struct {
+	refreshErr   error
+	started      chan struct{}
+	release      chan struct{}
+	refreshCalls int
+	mu           sync.Mutex
+}
+
+func (f *fakeComicsService) Create(context.Context, comics.CreateOpts) (*comics.Comic, error) {
+	panic("Create must not be called")
+}
+
+func (f *fakeComicsService) GetByID(context.Context, comics.GetByIDOpts) (*comics.Comic, error) {
+	panic("GetByID must not be called")
+}
+
+func (f *fakeComicsService) GetMany(context.Context, comics.GetManyOpts) ([]comics.Comic, error) {
+	panic("GetMany must not be called")
+}
+
+func (f *fakeComicsService) Delete(context.Context, comics.DeleteOpts) error {
+	panic("Delete must not be called")
+}
+
+func (f *fakeComicsService) RefreshChapterLists(ctx context.Context) error {
+	f.mu.Lock()
+	f.refreshCalls++
+	started := f.started
+	release := f.release
+	f.mu.Unlock()
+
+	if started != nil {
+		select {
+		case <-started:
+		default:
+			close(started)
+		}
+	}
+
+	if release != nil {
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return fmt.Errorf("refresh interrupted: %w", ctx.Err())
+		}
+	}
+
+	return f.refreshErr
+}
+
+func TestNewRejectsShortInterval(t *testing.T) {
+	t.Parallel()
+
+	app, err := refresh.New(refresh.Config{Interval: time.Second}, refresh.Deps{
+		ComicsService: &fakeComicsService{},
+	})
+	if err == nil {
+		t.Fatal("New with 1s interval must fail")
+	}
+
+	if app != nil {
+		t.Error("New returned an app in addition to the error")
+	}
+}
+
+func TestRunRefreshesOnStartup(t *testing.T) {
+	t.Parallel()
+
+	svc := &fakeComicsService{started: make(chan struct{})}
+	app, err := refresh.New(
+		refresh.Config{Interval: time.Hour},
+		refresh.Deps{ComicsService: svc},
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- app.Run(ctx)
+	}()
+
+	select {
+	case <-svc.started:
+	case <-time.After(time.Second):
+		t.Fatal("RefreshChapterLists did not run on startup")
+	}
+
+	cancel()
+
+	if err := <-errCh; err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run: %v", err)
+	}
+
+	svc.mu.Lock()
+	calls := svc.refreshCalls
+	svc.mu.Unlock()
+
+	if calls != 1 {
+		t.Errorf("RefreshChapterLists called %d times, want 1", calls)
+	}
+}
+
+func TestRunDoesNotAbortWhenRefreshFails(t *testing.T) {
+	t.Parallel()
+
+	svc := &fakeComicsService{
+		refreshErr: errors.New("source down"),
+		started:    make(chan struct{}),
+	}
+	app, err := refresh.New(
+		refresh.Config{Interval: time.Hour},
+		refresh.Deps{ComicsService: svc},
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- app.Run(ctx)
+	}()
+
+	select {
+	case <-svc.started:
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not start")
+	}
+
+	cancel()
+
+	if err := <-errCh; err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run: %v, want context cancel not refresh error", err)
+	}
+}
+
+func TestSkipIfAlreadyRunning(t *testing.T) {
+	t.Parallel()
+
+	svc := &fakeComicsService{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	app, err := refresh.New(
+		refresh.Config{Interval: time.Hour},
+		refresh.Deps{ComicsService: svc},
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 2)
+
+	go func() { errCh <- app.Run(ctx) }()
+
+	select {
+	case <-svc.started:
+	case <-time.After(time.Second):
+		t.Fatal("first refresh did not start")
+	}
+
+	go func() { errCh <- app.Run(ctx) }()
+
+	time.Sleep(50 * time.Millisecond)
+
+	close(svc.release)
+	cancel()
+
+	<-errCh
+	<-errCh
+
+	svc.mu.Lock()
+	calls := svc.refreshCalls
+	svc.mu.Unlock()
+
+	if calls != 1 {
+		t.Errorf("RefreshChapterLists called %d times, want 1 (second run skipped)", calls)
+	}
+}

--- a/api/pkg/core/comics/refresh_test.go
+++ b/api/pkg/core/comics/refresh_test.go
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package comics_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+)
+
+func TestRefreshChapterListsListsOngoingAndHiatusPerSource(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeComicsRepository{}
+	deps := validServiceDeps()
+	deps.ComicsRepository = repo
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	if err := svc.RefreshChapterLists(context.Background()); err != nil {
+		t.Fatalf("RefreshChapterLists: %v", err)
+	}
+
+	if repo.listByStatusesCalls != 1 {
+		t.Fatalf("ListByStatuses called %d times, want 1", repo.listByStatusesCalls)
+	}
+
+	if repo.lastListByStatuses.Source != testSource {
+		t.Errorf("source = %q, want %q", repo.lastListByStatuses.Source, testSource)
+	}
+
+	want := []sources.SeriesStatus{sources.SeriesStatusOngoing, sources.SeriesStatusHiatus}
+	if len(repo.lastListByStatuses.Statuses) != 2 ||
+		repo.lastListByStatuses.Statuses[0] != want[0] ||
+		repo.lastListByStatuses.Statuses[1] != want[1] {
+		t.Errorf("statuses = %v, want %v", repo.lastListByStatuses.Statuses, want)
+	}
+}
+
+func TestRefreshChapterListsCreatesOnlyMissingChaptersAndEnqueuesThem(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	existing := chapters.Chapter{
+		ID:                uuid.New(),
+		ComicID:           comicID,
+		SourceChapterSlug: testChapterSlug,
+		Number:            1,
+		Download:          100,
+	}
+	newSrc := sources.SourceChapter{
+		SourceChapterSlug: testChapter2Slug,
+		Number:            2,
+		Title:             "Chapter 2",
+		PageCount:         18,
+		PublishedAt:       time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	created := chapters.Chapter{
+		ID:                uuid.New(),
+		ComicID:           comicID,
+		SourceChapterSlug: newSrc.SourceChapterSlug,
+		Number:            newSrc.Number,
+		Title:             newSrc.Title,
+		PagesNb:           newSrc.PageCount,
+		PublishedAt:       newSrc.PublishedAt,
+	}
+
+	repo := &fakeComicsRepository{
+		listByStatusesResult: []comics.Comic{{
+			ID:     comicID,
+			Source: testSource,
+			Slug:   testSlug,
+			Status: sources.SeriesStatusOngoing,
+		}},
+	}
+	chaptersSvc := &fakeChaptersService{
+		listByComicIDResult: []chapters.Chapter{existing},
+		createAllResult:     []chapters.Chapter{created},
+	}
+	source := &fakeSource{
+		infos: &sources.GetInfosBySlugResponse{
+			Status:       sources.SeriesStatusOngoing,
+			ChapterCount: 2,
+		},
+		chapters: []sources.SourceChapter{
+			{
+				SourceChapterSlug: existing.SourceChapterSlug,
+				Number:            1,
+				Title:             testChapterTitle,
+			},
+			newSrc,
+		},
+	}
+
+	deps := validServiceDeps()
+	deps.ComicsRepository = repo
+	deps.ChaptersService = chaptersSvc
+	deps.Sources = sources.SourceMap{testSource: source}
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	if err := svc.RefreshChapterLists(context.Background()); err != nil {
+		t.Fatalf("RefreshChapterLists: %v", err)
+	}
+
+	if !source.lastInfosFresh || !source.lastChaptersFresh {
+		t.Errorf("fresh infos=%v chapters=%v, want both true", source.lastInfosFresh, source.lastChaptersFresh)
+	}
+
+	if chaptersSvc.createAllCalls != 1 {
+		t.Fatalf("CreateAll called %d times, want 1", chaptersSvc.createAllCalls)
+	}
+
+	if len(chaptersSvc.lastCreateAllChapters) != 1 ||
+		chaptersSvc.lastCreateAllChapters[0].SourceChapterSlug != testChapter2Slug {
+		t.Errorf("CreateAll chapters = %+v, want only %s", chaptersSvc.lastCreateAllChapters, testChapter2Slug)
+	}
+
+	if chaptersSvc.enqueueDownloadableCalls != 1 {
+		t.Fatalf("EnqueueDownloadable called %d times, want 1", chaptersSvc.enqueueDownloadableCalls)
+	}
+
+	if len(chaptersSvc.lastEnqueueChapters) != 1 || chaptersSvc.lastEnqueueChapters[0].ID != created.ID {
+		t.Errorf("enqueued = %+v, want created chapter", chaptersSvc.lastEnqueueChapters)
+	}
+
+	if repo.updateStatusCalls != 1 {
+		t.Fatalf("UpdateStatusAndChapterCount called %d times, want 1", repo.updateStatusCalls)
+	}
+
+	if repo.lastUpdateStatus.ID != comicID ||
+		repo.lastUpdateStatus.Status != sources.SeriesStatusOngoing ||
+		repo.lastUpdateStatus.ChapterCount != 2 {
+		t.Errorf("update opts = %+v", repo.lastUpdateStatus)
+	}
+}
+
+func TestRefreshChapterListsFetchesChaptersWhenInfosBecomeCompleted(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	repo := &fakeComicsRepository{
+		listByStatusesResult: []comics.Comic{{
+			ID:     comicID,
+			Source: testSource,
+			Slug:   testSlug,
+			Status: sources.SeriesStatusOngoing,
+		}},
+	}
+	source := &fakeSource{
+		infos: &sources.GetInfosBySlugResponse{
+			Status:       sources.SeriesStatusCompleted,
+			ChapterCount: 200,
+		},
+		chapters: []sources.SourceChapter{{
+			SourceChapterSlug: "final",
+			Number:            200,
+		}},
+	}
+	chaptersSvc := &fakeChaptersService{}
+
+	deps := validServiceDeps()
+	deps.ComicsRepository = repo
+	deps.ChaptersService = chaptersSvc
+	deps.Sources = sources.SourceMap{testSource: source}
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	if err := svc.RefreshChapterLists(context.Background()); err != nil {
+		t.Fatalf("RefreshChapterLists: %v", err)
+	}
+
+	if source.chaptersCalls != 1 {
+		t.Errorf("GetChaptersBySlug called %d times, want 1", source.chaptersCalls)
+	}
+
+	if repo.lastUpdateStatus.Status != sources.SeriesStatusCompleted {
+		t.Errorf("status = %q, want completed", repo.lastUpdateStatus.Status)
+	}
+}
+
+func TestRefreshChapterListsContinuesAfterComicFailure(t *testing.T) {
+	t.Parallel()
+
+	failID := uuid.New()
+	okID := uuid.New()
+	repo := &fakeComicsRepository{
+		listByStatusesResult: []comics.Comic{
+			{ID: failID, Source: testSource, Slug: "broken", Status: sources.SeriesStatusOngoing},
+			{ID: okID, Source: testSource, Slug: testSlug, Status: sources.SeriesStatusOngoing},
+		},
+	}
+	okSource := &fakeSource{
+		infos: &sources.GetInfosBySlugResponse{
+			Status:       sources.SeriesStatusOngoing,
+			ChapterCount: 1,
+		},
+		chapters: []sources.SourceChapter{{SourceChapterSlug: "c1", Number: 1}},
+	}
+	failing := &failThenOKSource{
+		failSlug: "broken",
+		ok:       okSource,
+		failErr:  errors.New("gone"),
+	}
+
+	deps := validServiceDeps()
+	deps.ComicsRepository = repo
+	deps.ChaptersService = &fakeChaptersService{}
+	deps.Sources = sources.SourceMap{testSource: failing}
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	if err := svc.RefreshChapterLists(context.Background()); err != nil {
+		t.Fatalf("RefreshChapterLists: %v", err)
+	}
+
+	if failing.okCalls == 0 {
+		t.Fatal("second comic was not refreshed after the first failed")
+	}
+}
+
+type failThenOKSource struct {
+	failErr  error
+	ok       *fakeSource
+	failSlug string
+	okCalls  int
+}
+
+func (f *failThenOKSource) GetInfosBySlug(
+	ctx context.Context,
+	opts sources.GetInfosBySlugOpts,
+) (*sources.GetInfosBySlugResponse, error) {
+	if opts.Slug == f.failSlug {
+		return nil, f.failErr
+	}
+
+	f.okCalls++
+
+	return f.ok.GetInfosBySlug(ctx, opts)
+}
+
+func (f *failThenOKSource) GetChaptersBySlug(
+	ctx context.Context,
+	opts sources.GetChaptersBySlugOpts,
+) ([]sources.SourceChapter, error) {
+	return f.ok.GetChaptersBySlug(ctx, opts)
+}
+
+func (f *failThenOKSource) GetPageURLsByChapter(context.Context, sources.GetPageURLsByChapterOpts) ([]string, error) {
+	return nil, nil
+}
+
+func TestRefreshChapterListsSkipsCreateWhenNoMissingChapters(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	repo := &fakeComicsRepository{
+		listByStatusesResult: []comics.Comic{{
+			ID:     comicID,
+			Source: testSource,
+			Slug:   testSlug,
+			Status: sources.SeriesStatusHiatus,
+		}},
+	}
+	chaptersSvc := &fakeChaptersService{
+		listByComicIDResult: []chapters.Chapter{{
+			ComicID:           comicID,
+			SourceChapterSlug: testChapterSlug,
+		}},
+	}
+	source := &fakeSource{
+		infos: &sources.GetInfosBySlugResponse{
+			Status:       sources.SeriesStatusHiatus,
+			ChapterCount: 1,
+		},
+		chapters: []sources.SourceChapter{{SourceChapterSlug: testChapterSlug, Number: 1}},
+	}
+
+	deps := validServiceDeps()
+	deps.ComicsRepository = repo
+	deps.ChaptersService = chaptersSvc
+	deps.Sources = sources.SourceMap{testSource: source}
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	if err := svc.RefreshChapterLists(context.Background()); err != nil {
+		t.Fatalf("RefreshChapterLists: %v", err)
+	}
+
+	if chaptersSvc.createAllCalls != 0 {
+		t.Errorf("CreateAll called %d times, want 0", chaptersSvc.createAllCalls)
+	}
+
+	if chaptersSvc.enqueueDownloadableCalls != 0 {
+		t.Errorf("EnqueueDownloadable called %d times, want 0", chaptersSvc.enqueueDownloadableCalls)
+	}
+
+	if repo.updateStatusCalls != 1 {
+		t.Errorf("UpdateStatusAndChapterCount called %d times, want 1", repo.updateStatusCalls)
+	}
+}

--- a/api/pkg/core/comics/repository/pg/repository.go
+++ b/api/pkg/core/comics/repository/pg/repository.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/transaction/pgtx"
 	"github.com/lib/pq"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 var _ comics.ComicsRepository = (*PGComicsRepository)(nil)
@@ -191,6 +192,52 @@ func (r *PGComicsRepository) GetMany(ctx context.Context, opts comics.GetManyOpt
 	}
 
 	return ret, nil
+}
+
+func (r *PGComicsRepository) ListByStatuses(
+	ctx context.Context,
+	opts comics.ListByStatusesOpts,
+) ([]comics.Comic, error) {
+	if len(opts.Statuses) == 0 {
+		return nil, nil
+	}
+
+	models, err := r.db(ctx).
+		Where("comics.source = ? AND comics.status IN ?", opts.Source, opts.Statuses).
+		Order("comics.created_at ASC").
+		Find(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
+	}
+
+	ret := make([]comics.Comic, len(models))
+	for i, model := range models {
+		ret[i] = model.Domain()
+	}
+
+	return ret, nil
+}
+
+func (r *PGComicsRepository) UpdateStatusAndChapterCount(
+	ctx context.Context,
+	opts comics.UpdateStatusAndChapterCountOpts,
+) error {
+	values := map[string]any{
+		"status":        pgmodels.ComicStatusFromDomain(opts.Status),
+		"chapter_count": opts.ChapterCount,
+		"updated_at":    time.Now(),
+	}
+
+	rows, err := r.db(ctx).Where("id = ?", opts.ID).Set(clause.Assignments(values)).Update(ctx)
+	if err != nil {
+		return fmt.Errorf("r.db(ctx).Updates: %w", err)
+	}
+
+	if rows == 0 {
+		return domain.ErrNotFound
+	}
+
+	return nil
 }
 
 // nolint:lll

--- a/api/pkg/core/comics/repository/pg/repository_test.go
+++ b/api/pkg/core/comics/repository/pg/repository_test.go
@@ -298,6 +298,102 @@ func TestGetMany(t *testing.T) {
 	}
 }
 
+func TestListByStatuses(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newComicsRepo(t)
+
+	id := uuid.New()
+	created := time.Now().UTC().Truncate(time.Second)
+	updated := created
+
+	mock.ExpectQuery(`FROM "comics".*source = \$1 AND comics.status IN`).
+		WithArgs(string(comicSource), string(sources.SeriesStatusOngoing), string(sources.SeriesStatusHiatus)).
+		WillReturnRows(
+			sqlmock.NewRows([]string{
+				"id", "source", "slug", "title", "status", "comic_type",
+				"chapter_count", "author", "artist", "description",
+				"genres", "alt_titles", "created_at", "updated_at",
+			}).AddRow(
+				id, string(comicSource), comicSlug, comicTitle, string(sources.SeriesStatusOngoing), string(comicType),
+				10, "Chugong", "Dubu", "desc",
+				"{}", "{}", created, updated,
+			),
+		)
+
+	got, err := r.ListByStatuses(context.Background(), comics.ListByStatusesOpts{
+		Source: comicSource,
+		Statuses: []sources.SeriesStatus{
+			sources.SeriesStatusOngoing,
+			sources.SeriesStatusHiatus,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ListByStatuses: %v", err)
+	}
+
+	if len(got) != 1 || got[0].ID != id {
+		t.Errorf("ListByStatuses() = %+v", got)
+	}
+}
+
+func TestListByStatusesEmptyStatuses(t *testing.T) {
+	t.Parallel()
+
+	r, _ := newComicsRepo(t)
+
+	got, err := r.ListByStatuses(context.Background(), comics.ListByStatusesOpts{
+		Source: comicSource,
+	})
+	if err != nil {
+		t.Fatalf("ListByStatuses: %v", err)
+	}
+
+	if got != nil {
+		t.Errorf("ListByStatuses() = %+v, want nil", got)
+	}
+}
+
+func TestUpdateStatusAndChapterCount(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newComicsRepo(t)
+
+	id := uuid.New()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "comics" SET`).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	err := r.UpdateStatusAndChapterCount(context.Background(), comics.UpdateStatusAndChapterCountOpts{
+		ID:           id,
+		Status:       sources.SeriesStatusCompleted,
+		ChapterCount: 201,
+	})
+	if err != nil {
+		t.Fatalf("UpdateStatusAndChapterCount: %v", err)
+	}
+}
+
+func TestUpdateStatusAndChapterCountNotFound(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newComicsRepo(t)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "comics" SET`).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	err := r.UpdateStatusAndChapterCount(context.Background(), comics.UpdateStatusAndChapterCountOpts{
+		ID:           uuid.New(),
+		Status:       sources.SeriesStatusCompleted,
+		ChapterCount: 1,
+	})
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("UpdateStatusAndChapterCount = %v, want domain.ErrNotFound", err)
+	}
+}
+
 func TestGetBySlugsAndSource(t *testing.T) {
 	t.Parallel()
 

--- a/api/pkg/core/comics/service.go
+++ b/api/pkg/core/comics/service.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
@@ -22,6 +23,7 @@ type Deps struct {
 	LibraryRepository library.LibraryRepository
 	ChaptersService   chapters.ChaptersService
 	Sources           sources.SourceMap
+	Logger            *slog.Logger
 }
 
 func (deps *Deps) Validate() error {
@@ -125,7 +127,7 @@ func (s *Service) createNewComic(ctx context.Context, opts CreateOpts) (*Comic, 
 		return nil, fmt.Errorf("src.GetInfosBySlug: %w", err)
 	}
 
-	srcChapters, err := src.GetChaptersBySlug(ctx, opts.Slug)
+	srcChapters, err := src.GetChaptersBySlug(ctx, sources.GetChaptersBySlugOpts{Slug: opts.Slug})
 	if err != nil {
 		return nil, fmt.Errorf("src.GetChaptersBySlug: %w", err)
 	}

--- a/api/pkg/core/comics/service_test.go
+++ b/api/pkg/core/comics/service_test.go
@@ -19,8 +19,11 @@ import (
 )
 
 const (
-	testSlug   = "solo-leveling"
-	testSource = sources.SourceAsuraScans
+	testSlug         = "solo-leveling"
+	testSource       = sources.SourceAsuraScans
+	testChapterSlug  = "chapter-1"
+	testChapter2Slug = "chapter-2"
+	testChapterTitle = "Chapter 1"
 )
 
 type fakeTransactor struct {
@@ -44,17 +47,24 @@ type fakeComicsRepository struct {
 	deleteErr              error
 	createErr              error
 	getManyErr             error
+	listByStatusesErr      error
+	updateStatusErr        error
 	getByIDResult          *comics.Comic
 	findBySourceSlugResult *comics.Comic
 	createResult           *comics.Comic
 	getManyResult          []comics.Comic
+	listByStatusesResult   []comics.Comic
 	lastCreateOpts         comics.CreateComicOpts
+	lastListByStatuses     comics.ListByStatusesOpts
+	lastUpdateStatus       comics.UpdateStatusAndChapterCountOpts
+	lastDeleteID           uuid.UUID
 	findBySourceSlugCalls  int
 	createCalls            int
 	getByIDCalls           int
 	getManyCalls           int
 	deleteCalls            int
-	lastDeleteID           uuid.UUID
+	listByStatusesCalls    int
+	updateStatusCalls      int
 }
 
 func (f *fakeComicsRepository) GetByID(_ context.Context, _ comics.GetByIDOpts) (*comics.Comic, error) {
@@ -118,6 +128,26 @@ func (f *fakeComicsRepository) GetMany(_ context.Context, _ comics.GetManyOpts) 
 	f.getManyCalls++
 
 	return f.getManyResult, f.getManyErr
+}
+
+func (f *fakeComicsRepository) ListByStatuses(
+	_ context.Context,
+	opts comics.ListByStatusesOpts,
+) ([]comics.Comic, error) {
+	f.listByStatusesCalls++
+	f.lastListByStatuses = opts
+
+	return f.listByStatusesResult, f.listByStatusesErr
+}
+
+func (f *fakeComicsRepository) UpdateStatusAndChapterCount(
+	_ context.Context,
+	opts comics.UpdateStatusAndChapterCountOpts,
+) error {
+	f.updateStatusCalls++
+	f.lastUpdateStatus = opts
+
+	return f.updateStatusErr
 }
 
 type fakeLibraryRepository struct {
@@ -257,14 +287,17 @@ func (f *fakeChaptersService) RetryDownload(context.Context, chapters.RetryDownl
 	return nil
 }
 
+//nolint:govet // fieldalignment on a test fake is not worth the unreadable field order
 type fakeSource struct {
-	err           error
-	chaptersErr   error
-	infos         *sources.GetInfosBySlugResponse
-	lastSlug      string
-	chapters      []sources.SourceChapter
-	calls         int
-	chaptersCalls int
+	infos             *sources.GetInfosBySlugResponse
+	err               error
+	chaptersErr       error
+	chapters          []sources.SourceChapter
+	lastSlug          string
+	calls             int
+	chaptersCalls     int
+	lastInfosFresh    bool
+	lastChaptersFresh bool
 }
 
 func (f *fakeSource) GetInfosBySlug(
@@ -273,6 +306,7 @@ func (f *fakeSource) GetInfosBySlug(
 ) (*sources.GetInfosBySlugResponse, error) {
 	f.calls++
 	f.lastSlug = opts.Slug
+	f.lastInfosFresh = opts.Fresh
 
 	if f.err != nil {
 		return nil, f.err
@@ -281,9 +315,13 @@ func (f *fakeSource) GetInfosBySlug(
 	return f.infos, nil
 }
 
-func (f *fakeSource) GetChaptersBySlug(_ context.Context, slug string) ([]sources.SourceChapter, error) {
+func (f *fakeSource) GetChaptersBySlug(
+	_ context.Context,
+	opts sources.GetChaptersBySlugOpts,
+) ([]sources.SourceChapter, error) {
 	f.chaptersCalls++
-	f.lastSlug = slug
+	f.lastSlug = opts.Slug
+	f.lastChaptersFresh = opts.Fresh
 
 	if f.chaptersErr != nil {
 		return nil, f.chaptersErr

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -182,6 +182,14 @@ func (fakeDownloadsApp) Run(ctx context.Context) error {
 	return fmt.Errorf("context done: %w", ctx.Err())
 }
 
+type fakeChapterListRefreshApp struct{}
+
+func (fakeChapterListRefreshApp) Run(ctx context.Context) error {
+	<-ctx.Done()
+
+	return fmt.Errorf("context done: %w", ctx.Err())
+}
+
 func (fakeSessionsRepository) DeleteByUserAndProvider(context.Context, uuid.UUID, uuid.UUID) error {
 	return errors.New(notImplemented)
 }
@@ -302,6 +310,14 @@ func (stubComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]comi
 	return nil, nil
 }
 
+func (stubComicsRepository) ListByStatuses(context.Context, comics.ListByStatusesOpts) ([]comics.Comic, error) {
+	return nil, nil
+}
+
+func (stubComicsRepository) UpdateStatusAndChapterCount(context.Context, comics.UpdateStatusAndChapterCountOpts) error {
+	return nil
+}
+
 type fakeComicsService struct{}
 
 func (fakeComicsService) Create(context.Context, comics.CreateOpts) (*comics.Comic, error) {
@@ -317,6 +333,10 @@ func (fakeComicsService) GetMany(context.Context, comics.GetManyOpts) ([]comics.
 }
 
 func (fakeComicsService) Delete(context.Context, comics.DeleteOpts) error {
+	return errors.New(notImplemented)
+}
+
+func (fakeComicsService) RefreshChapterLists(context.Context) error {
 	return errors.New(notImplemented)
 }
 
@@ -518,23 +538,24 @@ func newTestApp(t *testing.T, db Database, port int) (*App, *health.Registry) {
 	app, err := New(
 		Config{ServerPort: port, AllowedOrigins: []string{"*"}},
 		Deps{
-			DB:                db,
-			SetupCtrl:         setupCtrl,
-			AuthCtrl:          authCtrl,
-			UsersCtrl:         usersCtrl,
-			AsuraCtrl:         asuraCtrl,
-			CoversCtrl:        coversCtrl,
-			HealthCtrl:        healthCtrl,
-			OIDCProvidersCtrl: oidcProvidersCtrl,
-			ComicsCtrl:        comicsCtrl,
-			ChaptersCtrl:      chaptersCtrl,
-			Logger:            logger,
-			Health:            registry,
-			Asura:             asuraApp,
-			Covers:            coversApp,
-			Downloads:         fakeDownloadsApp{},
-			Sessions:          sessionsApp,
-			OIDCRevalidation:  fakeOIDCRevalidationApp{},
+			DB:                 db,
+			SetupCtrl:          setupCtrl,
+			AuthCtrl:           authCtrl,
+			UsersCtrl:          usersCtrl,
+			AsuraCtrl:          asuraCtrl,
+			CoversCtrl:         coversCtrl,
+			HealthCtrl:         healthCtrl,
+			OIDCProvidersCtrl:  oidcProvidersCtrl,
+			ComicsCtrl:         comicsCtrl,
+			ChaptersCtrl:       chaptersCtrl,
+			Logger:             logger,
+			Health:             registry,
+			Asura:              asuraApp,
+			Covers:             coversApp,
+			Downloads:          fakeDownloadsApp{},
+			ChapterListRefresh: fakeChapterListRefreshApp{},
+			Sessions:           sessionsApp,
+			OIDCRevalidation:   fakeOIDCRevalidationApp{},
 		})
 	if err != nil {
 		t.Fatalf("New: %v", err)

--- a/api/pkg/core/health.go
+++ b/api/pkg/core/health.go
@@ -10,13 +10,14 @@ import (
 )
 
 const (
-	componentMigrations       = "migrations"
-	componentAsura            = "asura"
-	componentCovers           = "covers"
-	componentDownloads        = "downloads"
-	componentSessions         = "sessions"
-	componentOIDCRevalidation = "oidc-revalidation"
-	componentDB               = "db"
+	componentMigrations         = "migrations"
+	componentAsura              = "asura"
+	componentCovers             = "covers"
+	componentDownloads          = "downloads"
+	componentChapterListRefresh = "chapter-list-refresh"
+	componentSessions           = "sessions"
+	componentOIDCRevalidation   = "oidc-revalidation"
+	componentDB                 = "db"
 )
 
 const notReadyMessage = "service is starting"
@@ -27,6 +28,7 @@ func NewHealthRegistry(db Database) *health.Registry {
 		componentAsura,
 		componentCovers,
 		componentDownloads,
+		componentChapterListRefresh,
 		componentSessions,
 		componentOIDCRevalidation,
 	)

--- a/api/pkg/core/health_internal_test.go
+++ b/api/pkg/core/health_internal_test.go
@@ -46,6 +46,7 @@ func TestNewHealthRegistryDeclaresTheLatchesAndTheDBProbe(t *testing.T) {
 		componentAsura,
 		componentCovers,
 		componentDownloads,
+		componentChapterListRefresh,
 		componentSessions,
 		componentOIDCRevalidation,
 	}

--- a/api/pkg/sources/asurascans/pkg/core/app.go
+++ b/api/pkg/sources/asurascans/pkg/core/app.go
@@ -172,7 +172,16 @@ func (a *App) GetInfosBySlug(
 	ctx context.Context,
 	opts sources.GetInfosBySlugOpts,
 ) (*sources.GetInfosBySlugResponse, error) {
-	infos, err := a.deps.GetInfosBySlugCache.Get(ctx, opts.Slug)
+	var (
+		infos *domain.GetInfosBySlugResponse
+		err   error
+	)
+
+	if opts.Fresh {
+		infos, err = a.deps.GetInfosBySlugCache.Fetch(ctx, opts.Slug)
+	} else {
+		infos, err = a.deps.GetInfosBySlugCache.Get(ctx, opts.Slug)
+	}
 	if err != nil {
 		//nolint:wrapcheck
 		return nil, err
@@ -200,8 +209,11 @@ func (a *App) GetInfosBySlug(
 	return &res, nil
 }
 
-func (a *App) GetChaptersBySlug(ctx context.Context, slug string) ([]sources.SourceChapter, error) {
-	chs, err := a.GetChaptersListBySeries(ctx, slug, uuid.Nil)
+func (a *App) GetChaptersBySlug(
+	ctx context.Context,
+	opts sources.GetChaptersBySlugOpts,
+) ([]sources.SourceChapter, error) {
+	chs, err := a.chaptersListBySeries(ctx, opts.Slug, uuid.Nil, opts.Fresh)
 	if err != nil {
 		//nolint:wrapcheck
 		return nil, err
@@ -227,7 +239,25 @@ func (a *App) GetChaptersListBySeries(
 	slug string,
 	userID uuid.UUID,
 ) ([]domain.Chapter, error) {
-	res, err := a.deps.GetChaptersListBySeriesCache.Get(ctx, slug)
+	return a.chaptersListBySeries(ctx, slug, userID, false)
+}
+
+func (a *App) chaptersListBySeries(
+	ctx context.Context,
+	slug string,
+	userID uuid.UUID,
+	fresh bool,
+) ([]domain.Chapter, error) {
+	var (
+		res *[]domain.Chapter
+		err error
+	)
+
+	if fresh {
+		res, err = a.deps.GetChaptersListBySeriesCache.Fetch(ctx, slug)
+	} else {
+		res, err = a.deps.GetChaptersListBySeriesCache.Get(ctx, slug)
+	}
 	if err != nil {
 		//nolint:wrapcheck
 		return nil, err

--- a/api/pkg/sources/asurascans/pkg/core/app_test.go
+++ b/api/pkg/sources/asurascans/pkg/core/app_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -60,6 +61,14 @@ func (stubComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]comi
 	return nil, nil
 }
 
+func (stubComicsRepository) ListByStatuses(context.Context, comics.ListByStatusesOpts) ([]comics.Comic, error) {
+	return nil, nil
+}
+
+func (stubComicsRepository) UpdateStatusAndChapterCount(context.Context, comics.UpdateStatusAndChapterCountOpts) error {
+	return nil
+}
+
 type libraryComicsRepository struct {
 	err    error
 	comics []comics.Comic
@@ -101,6 +110,14 @@ func (r libraryComicsRepository) Delete(context.Context, uuid.UUID) error {
 
 func (r libraryComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]comics.Comic, error) {
 	return nil, nil
+}
+
+func (r libraryComicsRepository) ListByStatuses(context.Context, comics.ListByStatusesOpts) ([]comics.Comic, error) {
+	return nil, nil
+}
+
+func (r libraryComicsRepository) UpdateStatusAndChapterCount(context.Context, comics.UpdateStatusAndChapterCountOpts) error {
+	return nil
 }
 
 type inLibraryComicsRepository struct {
@@ -148,6 +165,14 @@ func (r inLibraryComicsRepository) Delete(context.Context, uuid.UUID) error {
 
 func (r inLibraryComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]comics.Comic, error) {
 	return nil, nil
+}
+
+func (r inLibraryComicsRepository) ListByStatuses(context.Context, comics.ListByStatusesOpts) ([]comics.Comic, error) {
+	return nil, nil
+}
+
+func (r inLibraryComicsRepository) UpdateStatusAndChapterCount(context.Context, comics.UpdateStatusAndChapterCountOpts) error {
+	return nil
 }
 
 type libraryChaptersService struct {
@@ -453,6 +478,38 @@ func TestAppGetInfosBySlugWithoutLibraryEntry(t *testing.T) {
 
 	if res.InternalID != nil {
 		t.Errorf("InternalID = %v, want nil when comic is not in library", res.InternalID)
+	}
+}
+
+func TestAppGetInfosBySlugFreshBypassesCache(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	deps := fullDeps(t)
+	deps.GetInfosBySlugCache = newCache(t, identityKey,
+		func(context.Context, string) (*domain.GetInfosBySlugResponse, error) {
+			calls.Add(1)
+
+			return &domain.GetInfosBySlugResponse{Title: "Nano"}, nil
+		})
+
+	app, err := core.New(testConfig(), deps)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	opts := sources.GetInfosBySlugOpts{Slug: "nano-machine"}
+	if _, err := app.GetInfosBySlug(context.Background(), opts); err != nil {
+		t.Fatalf("GetInfosBySlug: %v", err)
+	}
+
+	opts.Fresh = true
+	if _, err := app.GetInfosBySlug(context.Background(), opts); err != nil {
+		t.Fatalf("GetInfosBySlug fresh: %v", err)
+	}
+
+	if got := calls.Load(); got != 2 {
+		t.Errorf("cache Fn called %d times, want 2 (cached Get then Fresh Fetch)", got)
 	}
 }
 

--- a/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
+++ b/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
@@ -71,6 +71,14 @@ func (stubComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]comi
 	return nil, nil
 }
 
+func (stubComicsRepository) ListByStatuses(context.Context, comics.ListByStatusesOpts) ([]comics.Comic, error) {
+	return nil, nil
+}
+
+func (stubComicsRepository) UpdateStatusAndChapterCount(context.Context, comics.UpdateStatusAndChapterCountOpts) error {
+	return nil
+}
+
 type inLibraryComicsRepository struct {
 	comic *comics.Comic
 }
@@ -111,6 +119,14 @@ func (r inLibraryComicsRepository) Delete(context.Context, uuid.UUID) error {
 
 func (r inLibraryComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]comics.Comic, error) {
 	return nil, nil
+}
+
+func (r inLibraryComicsRepository) ListByStatuses(context.Context, comics.ListByStatusesOpts) ([]comics.Comic, error) {
+	return nil, nil
+}
+
+func (r inLibraryComicsRepository) UpdateStatusAndChapterCount(context.Context, comics.UpdateStatusAndChapterCountOpts) error {
+	return nil
 }
 
 type libraryChaptersService struct {

--- a/api/pkg/sources/domain.go
+++ b/api/pkg/sources/domain.go
@@ -80,7 +80,7 @@ func ParseSeriesStatus(s string) (SeriesStatus, error) {
 
 type Source interface {
 	GetInfosBySlug(context.Context, GetInfosBySlugOpts) (*GetInfosBySlugResponse, error)
-	GetChaptersBySlug(context.Context, string) ([]SourceChapter, error)
+	GetChaptersBySlug(context.Context, GetChaptersBySlugOpts) ([]SourceChapter, error)
 	GetPageURLsByChapter(context.Context, GetPageURLsByChapterOpts) ([]string, error)
 }
 
@@ -100,7 +100,13 @@ type SourceChapter struct {
 
 type GetInfosBySlugOpts struct {
 	Slug   string
+	Fresh  bool
 	UserID uuid.UUID
+}
+
+type GetChaptersBySlugOpts struct {
+	Slug  string
+	Fresh bool
 }
 
 type GetInfosBySlugResponse struct {

--- a/api/pkg/utils/fncache/fncache.go
+++ b/api/pkg/utils/fncache/fncache.go
@@ -175,14 +175,24 @@ func (c *Cache[P, T]) Run(ctx context.Context) error {
 }
 
 func (c *Cache[P, T]) Get(ctx context.Context, opts P) (*T, error) {
+	return c.load(ctx, opts, false)
+}
+
+func (c *Cache[P, T]) Fetch(ctx context.Context, opts P) (*T, error) {
+	return c.load(ctx, opts, true)
+}
+
+func (c *Cache[P, T]) load(ctx context.Context, opts P, fresh bool) (*T, error) {
 	key := c.cfg.Key(opts)
 
-	c.mtx.Lock()
-	value, ok := c.store[key]
-	c.mtx.Unlock()
+	if !fresh {
+		c.mtx.Lock()
+		value, ok := c.store[key]
+		c.mtx.Unlock()
 
-	if ok && c.fresh(value, time.Now()) {
-		return value.Result, value.Error
+		if ok && c.fresh(value, time.Now()) {
+			return value.Result, value.Error
+		}
 	}
 
 	ch := c.sf.DoChan(key, func() (any, error) {

--- a/api/pkg/utils/fncache/fncache_test.go
+++ b/api/pkg/utils/fncache/fncache_test.go
@@ -209,6 +209,35 @@ func TestFnCacheGetCachesResult(t *testing.T) {
 	}
 }
 
+func TestFnCacheFetchBypassesFreshEntry(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	value := 7
+	c := newTestCache(t, func(context.Context, string) (*int, error) {
+		calls.Add(1)
+
+		return &value, nil
+	})
+
+	callWithTimeout(t, "Cache.Get", func() {
+		if _, err := c.Get(context.Background(), "same-key"); err != nil {
+			t.Errorf("Get: %v", err)
+		}
+	})
+
+	callWithTimeout(t, "Cache.Fetch", func() {
+		if _, err := c.Fetch(context.Background(), "same-key"); err != nil {
+			t.Errorf("Fetch: %v", err)
+		}
+	})
+
+	if got := calls.Load(); got != 2 {
+		t.Errorf("Fn called %d times after Get then Fetch, want 2", got)
+	}
+}
+
 func TestFnCacheGetDistinctKeys(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Closes #51

- Add a background **chapter list refresh** worker that runs on server startup and every 3 hours (`CHAPTER_LIST_REFRESH_INTERVAL`, default `3h`).
- For each source, walk persisted comics with status `ongoing` or `hiatus`, refetch infos and chapters with `Fresh: true`, create missing chapter rows, enqueue downloadable ones, and update comic status/chapter count.
- Per-comic and per-source failures are logged without aborting the run; concurrent runs are skipped via an atomic guard.

## Test plan

- [x] `go test ./...` passes
- [x] Unit tests cover: missing chapter insertion, skip terminal statuses, enqueue rules, per-comic failure isolation, worker interval/startup behavior, and `Fresh` cache bypass on AsuraScans
- [ ] Start the server and confirm the refresh worker logs on startup
- [ ] Add an ongoing comic to the library, publish a new chapter on the source, wait for the next refresh cycle (or lower `CHAPTER_LIST_REFRESH_INTERVAL` for testing) and verify the new chapter appears and is queued for download
