### PR TITLE
feat: persist and serve local comic covers (#56)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,7 @@ server/utils/suwayomi/generated
 PROJECT_BRIEF.md
 ENGINEERING.md
 .env
-docs/superpowers
-docs/design
+docs
 .nuxtrc
 .superpowers
 .claude

--- a/api/cmd/uchiyomiserver/setup.go
+++ b/api/cmd/uchiyomiserver/setup.go
@@ -484,7 +484,7 @@ type comicsCoverFinder struct {
 func (f comicsCoverFinder) FindBySourceSlug(ctx context.Context, source, slug string) (uuid.UUID, error) {
 	name, err := sources.ParseSourceName(source)
 	if err != nil {
-		return uuid.Nil, fmt.Errorf("sources.ParseSourceName: %w", err)
+		return uuid.Nil, fmt.Errorf("%w: %w", covers.ErrUnknownSource, err)
 	}
 
 	comic, err := f.repo.FindBySourceSlug(ctx, comics.FindBySourceSlugOpts{Source: name, Slug: slug})

--- a/api/cmd/uchiyomiserver/setup.go
+++ b/api/cmd/uchiyomiserver/setup.go
@@ -140,6 +140,7 @@ func setupApp(cfg *cfg) (*core.App, error) {
 		Transactor:        dbr.Txor,
 		LibraryRepository: dbr.LibraryRepository,
 		ChaptersService:   chaptersSvc,
+		LocalCoverStore:   coversBundle.Service,
 		Sources:           sources.SourceMap{sources.SourceAsuraScans: asuraApp},
 		Logger:            logger,
 	})

--- a/api/cmd/uchiyomiserver/setup.go
+++ b/api/cmd/uchiyomiserver/setup.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 	core "github.com/kharente-deuh/uchiyomi-server/pkg/core"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
 	httpcomics "github.com/kharente-deuh/uchiyomi-server/pkg/core/comics/gateway/http"
@@ -94,10 +96,11 @@ func setupApp(cfg *cfg) (*core.App, error) {
 	}
 
 	coversBundle, err := setupCovers(coversDeps{
-		Logger:       logger,
-		CoversDir:    coversDir,
-		DownloadsDir: downloadsDir,
-		AsuraApp:     asuraApp,
+		Logger:           logger,
+		CoversDir:        coversDir,
+		DownloadsDir:     downloadsDir,
+		AsuraApp:         asuraApp,
+		ComicsRepository: dbr.ComicsRepository,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to init covers: %w", err)
@@ -465,11 +468,30 @@ type coversBundle struct {
 }
 
 type coversDeps struct {
-	Logger   *slog.Logger
-	AsuraApp *asura.App
+	Logger           *slog.Logger
+	AsuraApp         *asura.App
+	ComicsRepository comics.ComicsRepository
 
 	CoversDir    string
 	DownloadsDir string
+}
+
+type comicsCoverFinder struct {
+	repo comics.ComicsRepository
+}
+
+func (f comicsCoverFinder) FindBySourceSlug(ctx context.Context, source, slug string) (uuid.UUID, error) {
+	name, err := sources.ParseSourceName(source)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("sources.ParseSourceName: %w", err)
+	}
+
+	comic, err := f.repo.FindBySourceSlug(ctx, comics.FindBySourceSlugOpts{Source: name, Slug: slug})
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("repo.FindBySourceSlug: %w", err)
+	}
+
+	return comic.ID, nil
 }
 
 func setupCovers(deps coversDeps) (*coversBundle, error) {
@@ -521,6 +543,7 @@ func setupCovers(deps coversDeps) (*coversBundle, error) {
 			Resolvers:  resolvers,
 			HTTPClient: httpClient,
 			Logger:     deps.Logger,
+			Finder:     comicsCoverFinder{repo: deps.ComicsRepository},
 		},
 	)
 	if err != nil {

--- a/api/cmd/uchiyomiserver/setup.go
+++ b/api/cmd/uchiyomiserver/setup.go
@@ -94,9 +94,10 @@ func setupApp(cfg *cfg) (*core.App, error) {
 	}
 
 	coversBundle, err := setupCovers(coversDeps{
-		Logger:    logger,
-		CoversDir: coversDir,
-		AsuraApp:  asuraApp,
+		Logger:       logger,
+		CoversDir:    coversDir,
+		DownloadsDir: downloadsDir,
+		AsuraApp:     asuraApp,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to init covers: %w", err)
@@ -467,7 +468,8 @@ type coversDeps struct {
 	Logger   *slog.Logger
 	AsuraApp *asura.App
 
-	CoversDir string
+	CoversDir    string
+	DownloadsDir string
 }
 
 func setupCovers(deps coversDeps) (*coversBundle, error) {
@@ -510,7 +512,10 @@ func setupCovers(deps coversDeps) (*coversBundle, error) {
 	}
 
 	svc, err := covers.NewService(
-		covers.ServiceConfig{ProxyPathPrefix: core.APIPrefix + "/sources/cover"},
+		covers.ServiceConfig{
+			ProxyPathPrefix: core.APIPrefix + "/sources/cover",
+			DownloadsDir:    deps.DownloadsDir,
+		},
 		covers.ServiceDeps{
 			Cache:      cache,
 			Resolvers:  resolvers,

--- a/api/cmd/uchiyomiserver/setup_internal_test.go
+++ b/api/cmd/uchiyomiserver/setup_internal_test.go
@@ -223,9 +223,10 @@ func newTestCtrlsForUser(t *testing.T, user *users.User) *ctrls {
 	}
 
 	coversBundle, err := setupCovers(coversDeps{
-		Logger:    logger,
-		CoversDir: t.TempDir(),
-		AsuraApp:  asuraApp,
+		Logger:       logger,
+		CoversDir:    t.TempDir(),
+		DownloadsDir: t.TempDir(),
+		AsuraApp:     asuraApp,
 	})
 	if err != nil {
 		t.Fatalf("setupCovers: %v", err)

--- a/api/cmd/uchiyomiserver/setup_internal_test.go
+++ b/api/cmd/uchiyomiserver/setup_internal_test.go
@@ -223,10 +223,11 @@ func newTestCtrlsForUser(t *testing.T, user *users.User) *ctrls {
 	}
 
 	coversBundle, err := setupCovers(coversDeps{
-		Logger:       logger,
-		CoversDir:    t.TempDir(),
-		DownloadsDir: t.TempDir(),
-		AsuraApp:     asuraApp,
+		Logger:           logger,
+		CoversDir:        t.TempDir(),
+		DownloadsDir:     t.TempDir(),
+		AsuraApp:         asuraApp,
+		ComicsRepository: stubComicsRepository{},
 	})
 	if err != nil {
 		t.Fatalf("setupCovers: %v", err)

--- a/api/cmd/uchiyomiserver/setup_internal_test.go
+++ b/api/cmd/uchiyomiserver/setup_internal_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
 	coredomain "github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/users"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/health"
@@ -246,6 +247,44 @@ func newTestCtrlsForUser(t *testing.T, user *users.User) *ctrls {
 	}
 
 	return c
+}
+
+func TestComicsCoverFinderUnknownSource(t *testing.T) {
+	t.Parallel()
+
+	finder := comicsCoverFinder{repo: stubComicsRepository{}}
+
+	_, err := finder.FindBySourceSlug(context.Background(), "unknown", "solo-leveling")
+	if !errors.Is(err, covers.ErrUnknownSource) {
+		t.Errorf("FindBySourceSlug = %v, want ErrUnknownSource", err)
+	}
+}
+
+func TestSetupCoversServeUnknownSource(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+
+	asuraApp, err := setupAsura(logger, stubComicsRepository{})
+	if err != nil {
+		t.Fatalf("setupAsura: %v", err)
+	}
+
+	bundle, err := setupCovers(coversDeps{
+		Logger:           logger,
+		CoversDir:        t.TempDir(),
+		DownloadsDir:     t.TempDir(),
+		AsuraApp:         asuraApp,
+		ComicsRepository: stubComicsRepository{},
+	})
+	if err != nil {
+		t.Fatalf("setupCovers: %v", err)
+	}
+
+	_, _, err = bundle.Service.Serve(context.Background(), "unknown", "solo-leveling")
+	if !errors.Is(err, covers.ErrUnknownSource) {
+		t.Errorf("Serve = %v, want ErrUnknownSource", err)
+	}
 }
 
 func TestOIDCProvidersController(t *testing.T) {

--- a/api/pkg/core/comics/domain.go
+++ b/api/pkg/core/comics/domain.go
@@ -61,7 +61,6 @@ type CreateComicOpts struct {
 	Status       sources.SeriesStatus
 	Type         sources.SeriesType
 	Description  string
-	ID           uuid.UUID
 	Source       sources.SourceName
 	Artist       string
 	Slug         string
@@ -70,6 +69,7 @@ type CreateComicOpts struct {
 	AltTitles    []string
 	Genres       []string
 	ChapterCount int
+	ID           uuid.UUID
 }
 
 type GetBySlugsAndSource struct {

--- a/api/pkg/core/comics/domain.go
+++ b/api/pkg/core/comics/domain.go
@@ -38,6 +38,12 @@ type FindBySourceSlugOpts struct {
 	Slug   string
 }
 
+type LocalCoverStore interface {
+	ObtainLocal(ctx context.Context, comicID uuid.UUID, source, slug string) error
+	ServeLocal(ctx context.Context, comicID uuid.UUID) (diskPath, contentType string, err error)
+	RemoveLocal(comicID uuid.UUID) error
+}
+
 type ComicsRepository interface {
 	GetByID(context.Context, GetByIDOpts) (*Comic, error)
 	FindByID(context.Context, uuid.UUID) (*Comic, error)
@@ -78,6 +84,7 @@ type ComicsService interface {
 	GetMany(context.Context, GetManyOpts) ([]Comic, error)
 	Delete(context.Context, DeleteOpts) error
 	RefreshChapterLists(context.Context) error
+	ServeCover(ctx context.Context, opts GetByIDOpts) (diskPath, contentType string, err error)
 }
 
 type CreateOpts struct {

--- a/api/pkg/core/comics/domain.go
+++ b/api/pkg/core/comics/domain.go
@@ -55,7 +55,7 @@ type CreateComicOpts struct {
 	Status       sources.SeriesStatus
 	Type         sources.SeriesType
 	Description  string
-	CoverPath    string
+	ID           uuid.UUID
 	Source       sources.SourceName
 	Artist       string
 	Slug         string

--- a/api/pkg/core/comics/gateway/http/controller.go
+++ b/api/pkg/core/comics/gateway/http/controller.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -88,6 +90,7 @@ func (c *Controller) InitRouter(r chi.Router) {
 
 		r.Post("/", c.create)
 		r.Get("/", c.getMany)
+		r.Get("/{id}/cover", c.serveCover)
 		r.Get("/{id}", c.getByID)
 		r.Delete("/{id}", c.deleteByID)
 	})
@@ -320,4 +323,52 @@ func parseQueryOffset(q string) (int, error) {
 	}
 
 	return offset, nil
+}
+
+func (c *Controller) serveCover(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user, ok := httpsession.UserFrom(ctx)
+	if !ok {
+		c.deps.Logger.Error("user not found in context")
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+
+		return
+	}
+
+	id, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "id must be a valid UUID")
+
+		return
+	}
+
+	diskPath, contentType, err := c.deps.ComicsService.ServeCover(ctx, comics.GetByIDOpts{
+		UserID: user.ID,
+		ID:     id,
+	})
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusNotFound, "comic not found")
+
+			return
+		}
+
+		c.deps.Logger.Error("failed to serve comic cover", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	f, err := os.Open(diskPath)
+	if err != nil {
+		c.deps.Logger.Error("failed to open local cover", "path", diskPath, "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	defer f.Close()
+
+	w.Header().Set("Content-Type", contentType)
+	http.ServeContent(w, r, diskPath, time.Time{}, f)
 }

--- a/api/pkg/core/comics/gateway/http/controller_test.go
+++ b/api/pkg/core/comics/gateway/http/controller_test.go
@@ -35,18 +35,18 @@ const (
 )
 
 type stubComicsService struct {
-	getManyResult    []comics.Comic
-	serveCoverPath   string
-	serveCoverType   string
-	lastServeCoverID uuid.UUID
-	createResult     *comics.Comic
-	getByIDResult    *comics.Comic
-	serveCoverCalls  int
 	createErr        error
 	getByIDErr       error
 	getManyErr       error
 	deleteErr        error
 	serveCoverErr    error
+	createResult     *comics.Comic
+	getByIDResult    *comics.Comic
+	serveCoverPath   string
+	serveCoverType   string
+	getManyResult    []comics.Comic
+	serveCoverCalls  int
+	lastServeCoverID uuid.UUID
 }
 
 func (s *stubComicsService) Create(_ context.Context, _ comics.CreateOpts) (*comics.Comic, error) {

--- a/api/pkg/core/comics/gateway/http/controller_test.go
+++ b/api/pkg/core/comics/gateway/http/controller_test.go
@@ -11,6 +11,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -33,13 +35,18 @@ const (
 )
 
 type stubComicsService struct {
-	createErr     error
-	getByIDErr    error
-	getManyErr    error
-	deleteErr     error
-	createResult  *comics.Comic
-	getByIDResult *comics.Comic
-	getManyResult []comics.Comic
+	getManyResult    []comics.Comic
+	serveCoverPath   string
+	serveCoverType   string
+	lastServeCoverID uuid.UUID
+	createResult     *comics.Comic
+	getByIDResult    *comics.Comic
+	serveCoverCalls  int
+	createErr        error
+	getByIDErr       error
+	getManyErr       error
+	deleteErr        error
+	serveCoverErr    error
 }
 
 func (s *stubComicsService) Create(_ context.Context, _ comics.CreateOpts) (*comics.Comic, error) {
@@ -62,8 +69,11 @@ func (s *stubComicsService) RefreshChapterLists(context.Context) error {
 	return nil
 }
 
-func (s *stubComicsService) ServeCover(context.Context, comics.GetByIDOpts) (string, string, error) {
-	return "", "", nil
+func (s *stubComicsService) ServeCover(_ context.Context, opts comics.GetByIDOpts) (string, string, error) {
+	s.serveCoverCalls++
+	s.lastServeCoverID = opts.ID
+
+	return s.serveCoverPath, s.serveCoverType, s.serveCoverErr
 }
 
 type stubSessionService struct {
@@ -230,11 +240,17 @@ func TestCreateReturnsComic(t *testing.T) {
 	if got.ID != comic.ID || got.Slug != comic.Slug {
 		t.Errorf("response = %+v, want comic %+v", got, comic)
 	}
+
+	wantCover := "/api/comics/" + comic.ID.String() + "/cover"
+	if got.Cover != wantCover {
+		t.Errorf("cover = %q, want %q", got.Cover, wantCover)
+	}
 }
 
 type comicshttpLightComic struct {
 	Title        string               `json:"title"`
 	Slug         string               `json:"slug"`
+	Cover        string               `json:"cover"`
 	Source       sources.SourceName   `json:"source"`
 	Status       sources.SeriesStatus `json:"status"`
 	ChapterCount int                  `json:"chapter_count"`
@@ -291,6 +307,78 @@ func TestGetManyReturnsComics(t *testing.T) {
 
 	if len(got) != 1 || got[0].Slug != items[0].Slug {
 		t.Errorf("response = %+v, want %+v", got, items)
+	}
+
+	wantCover := "/api/comics/" + items[0].ID.String() + "/cover"
+	if got[0].Cover != wantCover {
+		t.Errorf("cover = %q, want %q", got[0].Cover, wantCover)
+	}
+}
+
+func TestServeCoverOK(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	comicID := uuid.New()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cover.webp")
+	if err := os.WriteFile(path, []byte("webp-bytes"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	r := newTestRouter(t, &stubComicsService{
+		serveCoverPath: path,
+		serveCoverType: "image/webp",
+	}, authenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodGet, comicsEndpoint+"/"+comicID.String()+"/cover", nil)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	if rec.Header().Get("Content-Type") != "image/webp" {
+		t.Errorf("Content-Type = %q", rec.Header().Get("Content-Type"))
+	}
+
+	if rec.Body.String() != "webp-bytes" {
+		t.Errorf("body = %q", rec.Body.String())
+	}
+}
+
+func TestServeCoverNotInLibrary(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	comicID := uuid.New()
+	r := newTestRouter(t, &stubComicsService{
+		serveCoverErr: fmt.Errorf("s.GetByID: %w", domain.ErrNotFound),
+	}, authenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodGet, comicsEndpoint+"/"+comicID.String()+"/cover", nil)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestServeCoverUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRouter(t, &stubComicsService{}, authenticatorFor(t, &users.User{ID: uuid.New(), Name: testUsername}))
+
+	req := httptest.NewRequest(http.MethodGet, comicsEndpoint+"/"+uuid.New().String()+"/cover", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
 	}
 }
 

--- a/api/pkg/core/comics/gateway/http/controller_test.go
+++ b/api/pkg/core/comics/gateway/http/controller_test.go
@@ -62,6 +62,10 @@ func (s *stubComicsService) RefreshChapterLists(context.Context) error {
 	return nil
 }
 
+func (s *stubComicsService) ServeCover(context.Context, comics.GetByIDOpts) (string, string, error) {
+	return "", "", nil
+}
+
 type stubSessionService struct {
 	result *sessions.AuthenticatedSession
 }

--- a/api/pkg/core/comics/gateway/http/dto.go
+++ b/api/pkg/core/comics/gateway/http/dto.go
@@ -12,10 +12,15 @@ import (
 type lightComic struct {
 	Title        string               `json:"title"`
 	Slug         string               `json:"slug"`
+	Cover        string               `json:"cover"`
 	Source       sources.SourceName   `json:"source"`
 	Status       sources.SeriesStatus `json:"status"`
 	ChapterCount int                  `json:"chapter_count"`
 	ID           uuid.UUID            `json:"id"`
+}
+
+func comicCoverURL(id uuid.UUID) string {
+	return "/api/comics/" + id.String() + "/cover"
 }
 
 func lightComicFromDomain(comic *comics.Comic) lightComic {
@@ -24,6 +29,7 @@ func lightComicFromDomain(comic *comics.Comic) lightComic {
 		ChapterCount: comic.ChapterCount,
 		Title:        comic.Title,
 		Slug:         comic.Slug,
+		Cover:        comicCoverURL(comic.ID),
 		Source:       comic.Source,
 		Status:       comic.Status,
 	}
@@ -43,6 +49,7 @@ type comicResponse struct {
 	Status       sources.SeriesStatus `json:"status"`
 	Slug         string               `json:"slug"`
 	Title        string               `json:"title"`
+	Cover        string               `json:"cover"`
 	Genres       []string             `json:"genres"`
 	AltTitles    []string             `json:"alt_titles"`
 	ChapterCount int                  `json:"chapter_count"`
@@ -61,6 +68,7 @@ func comicResponseFromDomain(comic *comics.Comic) comicResponse {
 		Status:       comic.Status,
 		Slug:         comic.Slug,
 		Title:        comic.Title,
+		Cover:        comicCoverURL(comic.ID),
 		Genres:       comic.Genres,
 		AltTitles:    comic.AltTitles,
 	}

--- a/api/pkg/core/comics/refresh/app_test.go
+++ b/api/pkg/core/comics/refresh/app_test.go
@@ -64,6 +64,10 @@ func (f *fakeComicsService) RefreshChapterLists(ctx context.Context) error {
 	return f.refreshErr
 }
 
+func (f *fakeComicsService) ServeCover(context.Context, comics.GetByIDOpts) (string, string, error) {
+	panic("ServeCover must not be called")
+}
+
 func TestNewRejectsShortInterval(t *testing.T) {
 	t.Parallel()
 

--- a/api/pkg/core/comics/repository/pg/repository.go
+++ b/api/pkg/core/comics/repository/pg/repository.go
@@ -130,7 +130,7 @@ func (r *PGComicsRepository) Create(ctx context.Context, opts comics.CreateComic
 	now := time.Now()
 
 	model := &pgmodels.Comic{
-		ID:           uuid.New(),
+		ID:           opts.ID,
 		Source:       opts.Source,
 		Slug:         opts.Slug,
 		Title:        opts.Title,

--- a/api/pkg/core/comics/repository/pg/repository_test.go
+++ b/api/pkg/core/comics/repository/pg/repository_test.go
@@ -202,14 +202,17 @@ func TestCreate(t *testing.T) {
 
 	r, mock := newComicsRepo(t)
 
+	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+
 	mock.ExpectBegin()
 	mock.ExpectQuery(`INSERT INTO "comics"`).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(id))
 	mock.ExpectCommit()
 
 	before := time.Now()
 
 	got, err := r.Create(context.Background(), comics.CreateComicOpts{
+		ID:           id,
 		Source:       comicSource,
 		Slug:         comicSlug,
 		Title:        comicTitle,
@@ -230,8 +233,8 @@ func TestCreate(t *testing.T) {
 		t.Errorf("Create() = %+v", got)
 	}
 
-	if got.ID == uuid.Nil {
-		t.Error("Create did not generate ID")
+	if got.ID != id {
+		t.Errorf("Create ID = %s, want %s", got.ID, id)
 	}
 
 	if got.CreatedAt.Before(before) || got.UpdatedAt.Before(before) {
@@ -250,6 +253,7 @@ func TestCreateDuplicate(t *testing.T) {
 	mock.ExpectRollback()
 
 	_, err := r.Create(context.Background(), comics.CreateComicOpts{
+		ID:     uuid.New(),
 		Source: comicSource,
 		Slug:   comicSlug,
 		Title:  comicTitle,

--- a/api/pkg/core/comics/service.go
+++ b/api/pkg/core/comics/service.go
@@ -182,11 +182,10 @@ func (s *Service) createNewComic(ctx context.Context, opts CreateOpts) (*Comic, 
 
 		return nil
 	})
+
 	if err != nil {
-		if remErr := s.deps.LocalCoverStore.RemoveLocal(id); remErr != nil {
-			if s.deps.Logger != nil {
-				s.deps.Logger.ErrorContext(ctx, "failed to remove orphan cover", "comic_id", id, "error", remErr)
-			}
+		if remErr := s.deps.LocalCoverStore.RemoveLocal(id); remErr != nil && s.deps.Logger != nil {
+			s.deps.Logger.ErrorContext(ctx, "failed to remove orphan cover", "comic_id", id, "error", remErr)
 		}
 
 		if errors.Is(err, domain.ErrAlreadyExists) {

--- a/api/pkg/core/comics/service.go
+++ b/api/pkg/core/comics/service.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/google/uuid"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/library"
@@ -22,6 +23,7 @@ type Deps struct {
 	Transactor        transaction.Transactor
 	LibraryRepository library.LibraryRepository
 	ChaptersService   chapters.ChaptersService
+	LocalCoverStore   LocalCoverStore
 	Sources           sources.SourceMap
 	Logger            *slog.Logger
 }
@@ -41,6 +43,10 @@ func (deps *Deps) Validate() error {
 
 	if deps.ChaptersService == nil {
 		return errors.New("chapters service is required")
+	}
+
+	if deps.LocalCoverStore == nil {
+		return errors.New("local cover store is required")
 	}
 
 	if deps.Sources == nil {
@@ -132,10 +138,17 @@ func (s *Service) createNewComic(ctx context.Context, opts CreateOpts) (*Comic, 
 		return nil, fmt.Errorf("src.GetChaptersBySlug: %w", err)
 	}
 
+	id := uuid.New()
+
+	if err = s.deps.LocalCoverStore.ObtainLocal(ctx, id, string(opts.Source), opts.Slug); err != nil {
+		return nil, fmt.Errorf("s.deps.LocalCoverStore.ObtainLocal: %w", err)
+	}
+
 	var comic *Comic
 
 	err = s.deps.Transactor.WithinTx(ctx, transaction.TxOpts{}, func(ctx context.Context) error {
 		created, err := s.deps.ComicsRepository.Create(ctx, CreateComicOpts{
+			ID:           id,
 			Status:       item.Status,
 			Type:         item.Type,
 			Description:  item.Description,
@@ -170,6 +183,24 @@ func (s *Service) createNewComic(ctx context.Context, opts CreateOpts) (*Comic, 
 		return nil
 	})
 	if err != nil {
+		if remErr := s.deps.LocalCoverStore.RemoveLocal(id); remErr != nil {
+			if s.deps.Logger != nil {
+				s.deps.Logger.ErrorContext(ctx, "failed to remove orphan cover", "comic_id", id, "error", remErr)
+			}
+		}
+
+		if errors.Is(err, domain.ErrAlreadyExists) {
+			winner, findErr := s.deps.ComicsRepository.FindBySourceSlug(ctx, FindBySourceSlugOpts{
+				Source: opts.Source,
+				Slug:   opts.Slug,
+			})
+			if findErr != nil {
+				return nil, fmt.Errorf("s.deps.ComicsRepository.FindBySourceSlug: %w", findErr)
+			}
+
+			return s.addExistingComicToLibrary(ctx, opts, winner)
+		}
+
 		return nil, fmt.Errorf("s.deps.Transactor.WithinTx: %w", err)
 	}
 
@@ -193,6 +224,20 @@ func (s *Service) GetByID(ctx context.Context, opts GetByIDOpts) (*Comic, error)
 	}
 
 	return comic, nil
+}
+
+func (s *Service) ServeCover(ctx context.Context, opts GetByIDOpts) (string, string, error) {
+	comic, err := s.GetByID(ctx, opts)
+	if err != nil {
+		return "", "", fmt.Errorf("s.GetByID: %w", err)
+	}
+
+	path, contentType, err := s.deps.LocalCoverStore.ServeLocal(ctx, comic.ID)
+	if err != nil {
+		return "", "", fmt.Errorf("s.deps.LocalCoverStore.ServeLocal: %w", err)
+	}
+
+	return path, contentType, nil
 }
 
 func (s *Service) GetMany(ctx context.Context, opts GetManyOpts) ([]Comic, error) {

--- a/api/pkg/core/comics/service_test.go
+++ b/api/pkg/core/comics/service_test.go
@@ -42,20 +42,20 @@ func (f *fakeTransactor) WithinTx(ctx context.Context, _ transaction.TxOpts, fn 
 }
 
 type fakeLocalCoverStore struct {
-	obtainErr   error
-	serveErr    error
-	removeErr   error
-	obtainCalls int
-	removeCalls int
-	serveCalls  int
-	lastObtain  struct {
+	obtainErr  error
+	serveErr   error
+	removeErr  error
+	diskPath   string
+	mime       string
+	lastObtain struct {
 		source string
 		slug   string
 		id     uuid.UUID
 	}
-	lastRemove uuid.UUID
-	diskPath   string
-	mime       string
+	obtainCalls int
+	removeCalls int
+	serveCalls  int
+	lastRemove  uuid.UUID
 }
 
 func (f *fakeLocalCoverStore) ObtainLocal(_ context.Context, comicID uuid.UUID, source, slug string) error {
@@ -92,12 +92,11 @@ type fakeComicsRepository struct {
 	findBySourceSlugResult *comics.Comic
 	findBySourceSlugSecond *comics.Comic
 	createResult           *comics.Comic
-	getManyResult          []comics.Comic
-	listByStatusesResult   []comics.Comic
-	lastCreateOpts         comics.CreateComicOpts
 	lastListByStatuses     comics.ListByStatusesOpts
+	listByStatusesResult   []comics.Comic
+	getManyResult          []comics.Comic
 	lastUpdateStatus       comics.UpdateStatusAndChapterCountOpts
-	lastDeleteID           uuid.UUID
+	lastCreateOpts         comics.CreateComicOpts
 	findBySourceSlugCalls  int
 	createCalls            int
 	getByIDCalls           int
@@ -105,6 +104,7 @@ type fakeComicsRepository struct {
 	deleteCalls            int
 	listByStatusesCalls    int
 	updateStatusCalls      int
+	lastDeleteID           uuid.UUID
 }
 
 func (f *fakeComicsRepository) GetByID(_ context.Context, _ comics.GetByIDOpts) (*comics.Comic, error) {

--- a/api/pkg/core/comics/service_test.go
+++ b/api/pkg/core/comics/service_test.go
@@ -41,6 +41,45 @@ func (f *fakeTransactor) WithinTx(ctx context.Context, _ transaction.TxOpts, fn 
 	return f.err
 }
 
+type fakeLocalCoverStore struct {
+	obtainErr   error
+	serveErr    error
+	removeErr   error
+	obtainCalls int
+	removeCalls int
+	serveCalls  int
+	lastObtain  struct {
+		source string
+		slug   string
+		id     uuid.UUID
+	}
+	lastRemove uuid.UUID
+	diskPath   string
+	mime       string
+}
+
+func (f *fakeLocalCoverStore) ObtainLocal(_ context.Context, comicID uuid.UUID, source, slug string) error {
+	f.obtainCalls++
+	f.lastObtain.id = comicID
+	f.lastObtain.source = source
+	f.lastObtain.slug = slug
+
+	return f.obtainErr
+}
+
+func (f *fakeLocalCoverStore) ServeLocal(context.Context, uuid.UUID) (string, string, error) {
+	f.serveCalls++
+
+	return f.diskPath, f.mime, f.serveErr
+}
+
+func (f *fakeLocalCoverStore) RemoveLocal(comicID uuid.UUID) error {
+	f.removeCalls++
+	f.lastRemove = comicID
+
+	return f.removeErr
+}
+
 type fakeComicsRepository struct {
 	getByIDErr             error
 	findBySourceSlugErr    error
@@ -51,6 +90,7 @@ type fakeComicsRepository struct {
 	updateStatusErr        error
 	getByIDResult          *comics.Comic
 	findBySourceSlugResult *comics.Comic
+	findBySourceSlugSecond *comics.Comic
 	createResult           *comics.Comic
 	getManyResult          []comics.Comic
 	listByStatusesResult   []comics.Comic
@@ -86,6 +126,10 @@ func (f *fakeComicsRepository) FindBySourceSlug(
 	opts comics.FindBySourceSlugOpts,
 ) (*comics.Comic, error) {
 	f.findBySourceSlugCalls++
+
+	if f.findBySourceSlugCalls > 1 && f.findBySourceSlugSecond != nil {
+		return f.findBySourceSlugSecond, nil
+	}
 
 	return f.findBySourceSlugResult, f.findBySourceSlugErr
 }
@@ -339,6 +383,7 @@ func validServiceDeps() comics.Deps {
 		ComicsRepository:  &fakeComicsRepository{},
 		LibraryRepository: &fakeLibraryRepository{},
 		ChaptersService:   &fakeChaptersService{},
+		LocalCoverStore:   &fakeLocalCoverStore{},
 		Transactor:        &fakeTransactor{},
 		Sources: sources.SourceMap{
 			testSource: &fakeSource{
@@ -419,11 +464,13 @@ func TestCreateReturnsExistingComicAndAddsLibraryEntry(t *testing.T) {
 	}
 	libraryRepo := &fakeLibraryRepository{}
 	chaptersSvc := &fakeChaptersService{listByComicIDResult: existingChapters}
+	coverStore := &fakeLocalCoverStore{}
 	source := &fakeSource{}
 	deps := validServiceDeps()
 	deps.ComicsRepository = comicsRepo
 	deps.LibraryRepository = libraryRepo
 	deps.ChaptersService = chaptersSvc
+	deps.LocalCoverStore = coverStore
 	deps.Sources = sources.SourceMap{testSource: source}
 
 	svc, err := comics.NewService(deps)
@@ -483,6 +530,10 @@ func TestCreateReturnsExistingComicAndAddsLibraryEntry(t *testing.T) {
 	if len(chaptersSvc.lastEnqueueChapters) != 1 {
 		t.Errorf("enqueued chapters = %+v, want existing chapter list", chaptersSvc.lastEnqueueChapters)
 	}
+
+	if coverStore.obtainCalls != 0 {
+		t.Errorf("ObtainLocal called %d times, want 0", coverStore.obtainCalls)
+	}
 }
 
 func TestCreateFetchesSourceAndPersistsLibraryEntry(t *testing.T) {
@@ -492,6 +543,7 @@ func TestCreateFetchesSourceAndPersistsLibraryEntry(t *testing.T) {
 	comicsRepo := &fakeComicsRepository{findBySourceSlugErr: domain.ErrNotFound}
 	libraryRepo := &fakeLibraryRepository{}
 	chaptersSvc := &fakeChaptersService{}
+	coverStore := &fakeLocalCoverStore{}
 	tx := &fakeTransactor{}
 	source := &fakeSource{
 		infos: &sources.GetInfosBySlugResponse{
@@ -517,6 +569,7 @@ func TestCreateFetchesSourceAndPersistsLibraryEntry(t *testing.T) {
 	deps.ComicsRepository = comicsRepo
 	deps.LibraryRepository = libraryRepo
 	deps.ChaptersService = chaptersSvc
+	deps.LocalCoverStore = coverStore
 	deps.Transactor = tx
 	deps.Sources = sources.SourceMap{testSource: source}
 
@@ -580,6 +633,26 @@ func TestCreateFetchesSourceAndPersistsLibraryEntry(t *testing.T) {
 
 	if chaptersSvc.enqueueDownloadableCalls != 1 {
 		t.Errorf("EnqueueDownloadable called %d times, want 1", chaptersSvc.enqueueDownloadableCalls)
+	}
+
+	if coverStore.obtainCalls != 1 {
+		t.Errorf("ObtainLocal called %d times, want 1", coverStore.obtainCalls)
+	}
+
+	if coverStore.lastObtain.slug != testSlug {
+		t.Errorf("ObtainLocal slug = %q, want %q", coverStore.lastObtain.slug, testSlug)
+	}
+
+	if comicsRepo.lastCreateOpts.ID != coverStore.lastObtain.id {
+		t.Errorf("CreateComicOpts.ID = %s, want %s", comicsRepo.lastCreateOpts.ID, coverStore.lastObtain.id)
+	}
+
+	if comicsRepo.lastCreateOpts.ID == uuid.Nil {
+		t.Error("CreateComicOpts.ID must not be uuid.Nil")
+	}
+
+	if coverStore.removeCalls != 0 {
+		t.Errorf("RemoveLocal called %d times, want 0", coverStore.removeCalls)
 	}
 }
 
@@ -850,5 +923,190 @@ func TestDeleteReturnsWhenLibraryEntryMissing(t *testing.T) {
 	})
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Errorf("Delete = %v, want domain.ErrNotFound", err)
+	}
+}
+
+func TestCreateDoesNotInsertWhenObtainLocalFails(t *testing.T) {
+	t.Parallel()
+
+	comicsRepo := &fakeComicsRepository{findBySourceSlugErr: domain.ErrNotFound}
+	libraryRepo := &fakeLibraryRepository{}
+	coverStore := &fakeLocalCoverStore{obtainErr: errors.New("cdn down")}
+	deps := validServiceDeps()
+	deps.ComicsRepository = comicsRepo
+	deps.LibraryRepository = libraryRepo
+	deps.LocalCoverStore = coverStore
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	_, err = svc.Create(context.Background(), comics.CreateOpts{
+		UserID: uuid.New(),
+		Source: testSource,
+		Slug:   testSlug,
+	})
+	if err == nil {
+		t.Fatal("Create must fail when ObtainLocal fails")
+	}
+
+	if comicsRepo.createCalls != 0 {
+		t.Errorf("ComicsRepository.Create called %d times, want 0", comicsRepo.createCalls)
+	}
+
+	if libraryRepo.createCalls != 0 {
+		t.Errorf("LibraryRepository.Create called %d times, want 0", libraryRepo.createCalls)
+	}
+}
+
+func TestCreateUniqueRaceRemovesOrphanCoverAndAddsExisting(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	winner := &comics.Comic{ID: uuid.New(), Slug: testSlug, Source: testSource}
+	winnerChapters := []chapters.Chapter{
+		{ID: uuid.New(), ComicID: winner.ID, SourceChapterSlug: testChapterSlug, Number: 1},
+	}
+
+	comicsRepo := &fakeComicsRepository{
+		findBySourceSlugErr:    domain.ErrNotFound,
+		findBySourceSlugSecond: winner,
+		createErr:              domain.ErrAlreadyExists,
+	}
+	libraryRepo := &fakeLibraryRepository{}
+	chaptersSvc := &fakeChaptersService{listByComicIDResult: winnerChapters}
+	coverStore := &fakeLocalCoverStore{}
+	deps := validServiceDeps()
+	deps.ComicsRepository = comicsRepo
+	deps.LibraryRepository = libraryRepo
+	deps.ChaptersService = chaptersSvc
+	deps.LocalCoverStore = coverStore
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	got, err := svc.Create(context.Background(), comics.CreateOpts{
+		UserID: userID,
+		Source: testSource,
+		Slug:   testSlug,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if got != winner {
+		t.Errorf("Create() = %+v, want winner %+v", got, winner)
+	}
+
+	if coverStore.removeCalls != 1 {
+		t.Errorf("RemoveLocal called %d times, want 1", coverStore.removeCalls)
+	}
+
+	if coverStore.lastRemove != coverStore.lastObtain.id {
+		t.Errorf("RemoveLocal comic ID = %s, want %s", coverStore.lastRemove, coverStore.lastObtain.id)
+	}
+
+	if libraryRepo.lastCreate.ComicID != winner.ID {
+		t.Errorf("library CreateOpts.ComicID = %s, want %s", libraryRepo.lastCreate.ComicID, winner.ID)
+	}
+}
+
+func TestCreateRemovesCoverWhenTxFails(t *testing.T) {
+	t.Parallel()
+
+	comicsRepo := &fakeComicsRepository{
+		findBySourceSlugErr: domain.ErrNotFound,
+		createErr:           errors.New("db down"),
+	}
+	coverStore := &fakeLocalCoverStore{}
+	deps := validServiceDeps()
+	deps.ComicsRepository = comicsRepo
+	deps.LocalCoverStore = coverStore
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	_, err = svc.Create(context.Background(), comics.CreateOpts{
+		UserID: uuid.New(),
+		Source: testSource,
+		Slug:   testSlug,
+	})
+	if err == nil {
+		t.Fatal("Create must fail when tx fails")
+	}
+
+	if coverStore.removeCalls != 1 {
+		t.Errorf("RemoveLocal called %d times, want 1", coverStore.removeCalls)
+	}
+}
+
+func TestServeCoverNotInLibrary(t *testing.T) {
+	t.Parallel()
+
+	comicsRepo := &fakeComicsRepository{getByIDErr: domain.ErrNotFound}
+	coverStore := &fakeLocalCoverStore{}
+	deps := validServiceDeps()
+	deps.ComicsRepository = comicsRepo
+	deps.LocalCoverStore = coverStore
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	_, _, err = svc.ServeCover(context.Background(), comics.GetByIDOpts{
+		UserID: uuid.New(),
+		ID:     uuid.New(),
+	})
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("ServeCover = %v, want domain.ErrNotFound", err)
+	}
+
+	if coverStore.serveCalls != 0 {
+		t.Errorf("ServeLocal called %d times, want 0", coverStore.serveCalls)
+	}
+}
+
+func TestServeCoverReturnsLocalPath(t *testing.T) {
+	t.Parallel()
+
+	comic := &comics.Comic{ID: uuid.New()}
+	comicsRepo := &fakeComicsRepository{getByIDResult: comic}
+	coverStore := &fakeLocalCoverStore{
+		diskPath: "/covers/abc.webp",
+		mime:     "image/webp",
+	}
+	deps := validServiceDeps()
+	deps.ComicsRepository = comicsRepo
+	deps.LocalCoverStore = coverStore
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	path, contentType, err := svc.ServeCover(context.Background(), comics.GetByIDOpts{
+		UserID: uuid.New(),
+		ID:     comic.ID,
+	})
+	if err != nil {
+		t.Fatalf("ServeCover: %v", err)
+	}
+
+	if path != coverStore.diskPath {
+		t.Errorf("disk path = %q, want %q", path, coverStore.diskPath)
+	}
+
+	if contentType != coverStore.mime {
+		t.Errorf("content type = %q, want %q", contentType, coverStore.mime)
+	}
+
+	if coverStore.serveCalls != 1 {
+		t.Errorf("ServeLocal called %d times, want 1", coverStore.serveCalls)
 	}
 }

--- a/api/pkg/core/covers/domain.go
+++ b/api/pkg/core/covers/domain.go
@@ -11,9 +11,10 @@ import (
 const SourceAsuraScans = "asurascans"
 
 var (
-	ErrUnknownSource  = errors.New("unknown source")
-	ErrSeriesNotFound = errors.New("series not found")
-	ErrDownloadFailed = errors.New("cover download failed")
+	ErrUnknownSource     = errors.New("unknown source")
+	ErrSeriesNotFound    = errors.New("series not found")
+	ErrDownloadFailed    = errors.New("cover download failed")
+	ErrLocalCoverMissing = errors.New("local cover missing")
 )
 
 type CoverResolver interface {

--- a/api/pkg/core/covers/domain.go
+++ b/api/pkg/core/covers/domain.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"errors"
 	"io"
+
+	"github.com/google/uuid"
 )
 
 const SourceAsuraScans = "asurascans"
@@ -20,4 +22,8 @@ var (
 type CoverResolver interface {
 	ResolveExternalURL(context.Context, string) (string, error)
 	Fetch(context.Context, string) (io.ReadCloser, error)
+}
+
+type LocalComicFinder interface {
+	FindBySourceSlug(ctx context.Context, source, slug string) (uuid.UUID, error)
 }

--- a/api/pkg/core/covers/ext_test.go
+++ b/api/pkg/core/covers/ext_test.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//nolint:goconst
 package covers_test
 
 import (

--- a/api/pkg/core/covers/gateway/http/controller.go
+++ b/api/pkg/core/covers/gateway/http/controller.go
@@ -108,6 +108,9 @@ func (c *Controller) serveCover(w http.ResponseWriter, r *http.Request) {
 			httputils.WriteError(w, c.deps.Logger, http.StatusNotFound, "series not found")
 		case errors.Is(err, covers.ErrDownloadFailed):
 			httputils.WriteError(w, c.deps.Logger, http.StatusBadGateway, "cover download failed")
+		case errors.Is(err, covers.ErrLocalCoverMissing):
+			c.deps.Logger.ErrorContext(ctx, "local cover missing", "source", source, "slug", slug, "error", err)
+			httputils.WriteError(w, c.deps.Logger, http.StatusInternalServerError, "")
 		default:
 			c.deps.Logger.ErrorContext(ctx, "failed to serve cover", "source", source, "slug", slug, "error", err)
 			httputils.WriteError(w, c.deps.Logger, http.StatusBadGateway, "cover download failed")

--- a/api/pkg/core/covers/gateway/http/controller_test.go
+++ b/api/pkg/core/covers/gateway/http/controller_test.go
@@ -76,7 +76,10 @@ func newTestController(t *testing.T, resolvers map[string]covers.CoverResolver) 
 	}
 
 	svc, err := covers.NewService(
-		covers.ServiceConfig{ProxyPathPrefix: "/api/sources/cover"},
+		covers.ServiceConfig{
+			ProxyPathPrefix: "/api/sources/cover",
+			DownloadsDir:    t.TempDir(),
+		},
 		covers.ServiceDeps{
 			Cache:      cache,
 			Resolvers:  resolvers,
@@ -251,7 +254,10 @@ func TestServeCoverUsesDiskCachePath(t *testing.T) {
 	}
 
 	svc, err := covers.NewService(
-		covers.ServiceConfig{ProxyPathPrefix: "/api/sources/cover"},
+		covers.ServiceConfig{
+			ProxyPathPrefix: "/api/sources/cover",
+			DownloadsDir:    t.TempDir(),
+		},
 		covers.ServiceDeps{
 			Cache:      cache,
 			Resolvers:  resolvers,

--- a/api/pkg/core/covers/gateway/http/controller_test.go
+++ b/api/pkg/core/covers/gateway/http/controller_test.go
@@ -16,8 +16,10 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
 	covershttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/gateway/http"
+	coredomain "github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/imgcache"
 )
 
@@ -45,11 +47,31 @@ func (f *fakeResolver) Fetch(ctx context.Context, externalURL string) (io.ReadCl
 	return io.NopCloser(bytes.NewReader([]byte("cover-bytes"))), nil
 }
 
-func newTestController(t *testing.T, resolvers map[string]covers.CoverResolver) *covershttp.Controller {
+type stubFinder struct {
+	err error
+	id  uuid.UUID
+}
+
+func (f stubFinder) FindBySourceSlug(context.Context, string, string) (uuid.UUID, error) {
+	if f.err != nil {
+		return uuid.Nil, f.err
+	}
+
+	return f.id, nil
+}
+
+func newTestControllerWithDirs(
+	t *testing.T,
+	resolvers map[string]covers.CoverResolver,
+	finder covers.LocalComicFinder,
+) (*covershttp.Controller, string, string) {
 	t.Helper()
 
+	cacheDir := t.TempDir()
+	downloadsDir := t.TempDir()
+
 	cache, err := imgcache.New(imgcache.Config{
-		Dir:           t.TempDir(),
+		Dir:           cacheDir,
 		FetchFn:       covers.NewFetchFn(resolvers),
 		ErrorCacheTTL: time.Minute,
 		MinInterval:   time.Millisecond,
@@ -78,13 +100,14 @@ func newTestController(t *testing.T, resolvers map[string]covers.CoverResolver) 
 	svc, err := covers.NewService(
 		covers.ServiceConfig{
 			ProxyPathPrefix: "/api/sources/cover",
-			DownloadsDir:    t.TempDir(),
+			DownloadsDir:    downloadsDir,
 		},
 		covers.ServiceDeps{
 			Cache:      cache,
 			Resolvers:  resolvers,
 			HTTPClient: &http.Client{Timeout: time.Second},
 			Logger:     slog.New(slog.DiscardHandler),
+			Finder:     finder,
 		},
 	)
 	if err != nil {
@@ -99,6 +122,14 @@ func newTestController(t *testing.T, resolvers map[string]covers.CoverResolver) 
 		t.Fatalf("covershttp.New: %v", err)
 	}
 
+	return ctrl, cacheDir, downloadsDir
+}
+
+func newTestController(t *testing.T, resolvers map[string]covers.CoverResolver) *covershttp.Controller {
+	t.Helper()
+
+	ctrl, _, _ := newTestControllerWithDirs(t, resolvers, stubFinder{err: coredomain.ErrNotFound})
+
 	return ctrl
 }
 
@@ -112,6 +143,61 @@ func serveCover(t *testing.T, ctrl *covershttp.Controller, path string) *httptes
 	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
 
 	return rec
+}
+
+func TestServeCoverPrefersLocalWithoutFillingCache(t *testing.T) {
+	t.Parallel()
+
+	var fetchCount int
+	comicID := uuid.New()
+
+	resolvers := map[string]covers.CoverResolver{
+		covers.SourceAsuraScans: &fakeResolver{
+			url: testExternalCoverURL,
+			fetch: func(context.Context, string) (io.ReadCloser, error) {
+				fetchCount++
+
+				return io.NopCloser(bytes.NewReader([]byte("cdn"))), nil
+			},
+		},
+	}
+
+	ctrl, cacheDir, downloadsDir := newTestControllerWithDirs(t, resolvers, stubFinder{id: comicID})
+
+	coverPath := filepath.Join(downloadsDir, comicID.String(), "cover.webp")
+	if err := os.MkdirAll(filepath.Dir(coverPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	if err := os.WriteFile(coverPath, []byte("local-bytes"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	rec := serveCover(t, ctrl, "/cover/solo-leveling?source=asurascans")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	if ct := rec.Header().Get("Content-Type"); ct != "image/webp" {
+		t.Errorf("Content-Type = %q, want image/webp", ct)
+	}
+
+	if !bytes.Equal(rec.Body.Bytes(), []byte("local-bytes")) {
+		t.Errorf("body = %q, want local-bytes", rec.Body.Bytes())
+	}
+
+	if fetchCount != 0 {
+		t.Errorf("fetchCount = %d, want 0", fetchCount)
+	}
+
+	entries, err := os.ReadDir(cacheDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+
+	if len(entries) != 0 {
+		t.Errorf("cache filled: %v", entries)
+	}
 }
 
 func TestServeCoverDownloadsAndCaches(t *testing.T) {
@@ -263,6 +349,7 @@ func TestServeCoverUsesDiskCachePath(t *testing.T) {
 			Resolvers:  resolvers,
 			HTTPClient: &http.Client{Timeout: time.Second},
 			Logger:     slog.New(slog.DiscardHandler),
+			Finder:     stubFinder{err: coredomain.ErrNotFound},
 		},
 	)
 	if err != nil {

--- a/api/pkg/core/covers/local.go
+++ b/api/pkg/core/covers/local.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package covers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
+)
+
+func (s *Service) ObtainLocal(ctx context.Context, comicID uuid.UUID, source, slug string) error {
+	resolver, ok := s.deps.Resolvers[source]
+	if !ok {
+		return ErrUnknownSource
+	}
+
+	externalURL, err := resolver.ResolveExternalURL(ctx, slug)
+	if err != nil {
+		if errors.Is(err, ErrSeriesNotFound) {
+			return ErrSeriesNotFound
+		}
+
+		return fmt.Errorf("resolver.ResolveExternalURL: %w", err)
+	}
+
+	ext := ExtensionFromURL(externalURL)
+	if ext == "" {
+		ext, err = probeExtension(ctx, s.deps.HTTPClient, externalURL)
+		if err != nil {
+			if errors.Is(err, ErrSeriesNotFound) {
+				return ErrSeriesNotFound
+			}
+
+			return fmt.Errorf("%w: %w", ErrDownloadFailed, err)
+		}
+	}
+
+	dest := filepath.Join(s.cfg.DownloadsDir, comicID.String(), "cover"+ext)
+
+	moved, err := s.deps.Cache.Take(ctx, cacheKey(source, slug, ext), dest)
+	if err != nil {
+		return fmt.Errorf("cache.Take: %w", err)
+	}
+
+	if moved {
+		return nil
+	}
+
+	rc, err := resolver.Fetch(ctx, externalURL)
+	if err != nil {
+		if errors.Is(err, ErrSeriesNotFound) {
+			return ErrSeriesNotFound
+		}
+
+		return fmt.Errorf("%w: %w", ErrDownloadFailed, err)
+	}
+
+	defer rc.Close()
+
+	if err = writeFileAtomic(dest, rc); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Service) ServeLocal(_ context.Context, comicID uuid.UUID) (string, string, error) {
+	dir := filepath.Join(s.cfg.DownloadsDir, comicID.String())
+	matches, err := filepath.Glob(filepath.Join(dir, "cover.*"))
+	if err != nil {
+		return "", "", fmt.Errorf("filepath.Glob: %w", err)
+	}
+
+	var files []string
+	for _, match := range matches {
+		st, err := os.Stat(match)
+		if err != nil {
+			return "", "", fmt.Errorf("os.Stat %s: %w", match, err)
+		}
+
+		if st.Mode().IsRegular() {
+			files = append(files, match)
+		}
+	}
+
+	if len(files) != 1 {
+		return "", "", ErrLocalCoverMissing
+	}
+
+	return files[0], MIMEForExtension(filepath.Ext(files[0])), nil
+}
+
+func (s *Service) RemoveLocal(comicID uuid.UUID) error {
+	dir := filepath.Join(s.cfg.DownloadsDir, comicID.String())
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("os.RemoveAll %s: %w", dir, err)
+	}
+
+	return nil
+}
+
+func writeFileAtomic(dest string, r io.Reader) error {
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return fmt.Errorf("os.MkdirAll %s: %w", dest, err)
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(dest), ".cover-*")
+	if err != nil {
+		return fmt.Errorf("os.CreateTemp %s: %w", dest, err)
+	}
+
+	tmpName := tmp.Name()
+	defer func() {
+		tmp.Close()
+		os.Remove(tmpName)
+	}()
+
+	if _, err = io.Copy(tmp, r); err != nil {
+		return fmt.Errorf("io.Copy %s: %w", tmpName, err)
+	}
+
+	if err = tmp.Sync(); err != nil {
+		return fmt.Errorf("tmp.Sync %s: %w", tmpName, err)
+	}
+
+	if err = tmp.Close(); err != nil {
+		return fmt.Errorf("tmp.Close %s: %w", tmpName, err)
+	}
+
+	if err = os.Rename(tmpName, dest); err != nil {
+		return fmt.Errorf("os.Rename %s: %w", tmpName, err)
+	}
+
+	return nil
+}

--- a/api/pkg/core/covers/service.go
+++ b/api/pkg/core/covers/service.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"path/filepath"
 
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/imgcache"
 )
 
@@ -36,6 +37,7 @@ type ServiceDeps struct {
 	Resolvers  map[string]CoverResolver
 	HTTPClient *http.Client
 	Logger     *slog.Logger
+	Finder     LocalComicFinder
 }
 
 func (deps *ServiceDeps) Validate() error {
@@ -53,6 +55,10 @@ func (deps *ServiceDeps) Validate() error {
 
 	if deps.Logger == nil {
 		return errors.New("logger is required")
+	}
+
+	if deps.Finder == nil {
+		return errors.New("finder is required")
 	}
 
 	return nil
@@ -82,6 +88,15 @@ func (s *Service) BuildProxyURL(source, slug string) string {
 }
 
 func (s *Service) Serve(ctx context.Context, source, slug string) (string, string, error) {
+	id, err := s.deps.Finder.FindBySourceSlug(ctx, source, slug)
+	if err == nil {
+		return s.ServeLocal(ctx, id)
+	}
+
+	if !errors.Is(err, domain.ErrNotFound) {
+		return "", "", fmt.Errorf("finder.FindBySourceSlug: %w", err)
+	}
+
 	resolver, ok := s.deps.Resolvers[source]
 	if !ok {
 		return "", "", ErrUnknownSource

--- a/api/pkg/core/covers/service.go
+++ b/api/pkg/core/covers/service.go
@@ -16,11 +16,16 @@ import (
 
 type ServiceConfig struct {
 	ProxyPathPrefix string
+	DownloadsDir    string
 }
 
 func (cfg *ServiceConfig) Validate() error {
 	if cfg.ProxyPathPrefix == "" {
 		return errors.New("proxyPathPrefix is required")
+	}
+
+	if cfg.DownloadsDir == "" {
+		return errors.New("downloadsDir is required")
 	}
 
 	return nil

--- a/api/pkg/core/covers/service_test.go
+++ b/api/pkg/core/covers/service_test.go
@@ -11,11 +11,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
+	coredomain "github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/imgcache"
 )
 
@@ -43,7 +45,24 @@ func (f *fakeResolver) Fetch(ctx context.Context, externalURL string) (io.ReadCl
 	return io.NopCloser(bytes.NewReader([]byte("cover-bytes"))), nil
 }
 
-func startServiceWithDirs(t *testing.T, resolvers map[string]covers.CoverResolver) (*covers.Service, string) {
+type stubFinder struct {
+	err error
+	id  uuid.UUID
+}
+
+func (f stubFinder) FindBySourceSlug(context.Context, string, string) (uuid.UUID, error) {
+	if f.err != nil {
+		return uuid.Nil, f.err
+	}
+
+	return f.id, nil
+}
+
+func startServiceWithDirs(
+	t *testing.T,
+	resolvers map[string]covers.CoverResolver,
+	finder covers.LocalComicFinder,
+) (*covers.Service, string, string) {
 	t.Helper()
 
 	cacheDir := t.TempDir()
@@ -86,21 +105,32 @@ func startServiceWithDirs(t *testing.T, resolvers map[string]covers.CoverResolve
 			Resolvers:  resolvers,
 			HTTPClient: &http.Client{Timeout: time.Second},
 			Logger:     slog.New(slog.DiscardHandler),
+			Finder:     finder,
 		},
 	)
 	if err != nil {
 		t.Fatalf("covers.NewService: %v", err)
 	}
 
-	return svc, cacheDir
+	return svc, cacheDir, downloadsDir
 }
 
 func startService(t *testing.T, resolvers map[string]covers.CoverResolver) *covers.Service {
 	t.Helper()
 
-	svc, _ := startServiceWithDirs(t, resolvers)
+	svc, _, _ := startServiceWithDirs(t, resolvers, stubFinder{err: coredomain.ErrNotFound})
 
 	return svc
+}
+
+func startServiceFull(
+	t *testing.T,
+	resolvers map[string]covers.CoverResolver,
+	finder covers.LocalComicFinder,
+) (*covers.Service, string, string) {
+	t.Helper()
+
+	return startServiceWithDirs(t, resolvers, finder)
 }
 
 func TestBuildProxyURL(t *testing.T) {
@@ -274,7 +304,7 @@ func TestObtainLocalDownloadsWhenCacheMisses(t *testing.T) {
 		},
 	}
 
-	svc, cacheDir := startServiceWithDirs(t, resolvers)
+	svc, cacheDir, _ := startServiceWithDirs(t, resolvers, stubFinder{err: coredomain.ErrNotFound})
 	comicID := uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
 
 	if err := svc.ObtainLocal(context.Background(), comicID, covers.SourceAsuraScans, "solo-leveling"); err != nil {
@@ -342,6 +372,60 @@ func TestRemoveLocalDeletesComicDir(t *testing.T) {
 	_, _, err := svc.ServeLocal(context.Background(), comicID)
 	if !errors.Is(err, covers.ErrLocalCoverMissing) {
 		t.Errorf("after RemoveLocal: %v", err)
+	}
+}
+
+func TestServePrefersLocalCoverWithoutFillingCache(t *testing.T) {
+	t.Parallel()
+
+	var fetchCount int
+	resolvers := map[string]covers.CoverResolver{
+		covers.SourceAsuraScans: &fakeResolver{
+			url: testCoverURL,
+			fetch: func(context.Context, string) (io.ReadCloser, error) {
+				fetchCount++
+
+				return io.NopCloser(bytes.NewReader([]byte("cdn"))), nil
+			},
+		},
+	}
+
+	comicID := uuid.New()
+	svc, cacheDir, downloadsDir := startServiceFull(t, resolvers, stubFinder{id: comicID})
+
+	coverPath := filepath.Join(downloadsDir, comicID.String(), "cover.webp")
+	if err := os.MkdirAll(filepath.Dir(coverPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	if err := os.WriteFile(coverPath, []byte("local-bytes"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	path, contentType, err := svc.Serve(context.Background(), covers.SourceAsuraScans, "solo-leveling")
+	if err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+
+	if path != coverPath {
+		t.Errorf("path = %q, want %q", path, coverPath)
+	}
+
+	if contentType != "image/webp" {
+		t.Errorf("contentType = %q", contentType)
+	}
+
+	if fetchCount != 0 {
+		t.Errorf("fetchCount = %d, want 0", fetchCount)
+	}
+
+	entries, err := os.ReadDir(cacheDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+
+	if len(entries) != 0 {
+		t.Errorf("cache filled: %v", entries)
 	}
 }
 

--- a/api/pkg/core/covers/service_test.go
+++ b/api/pkg/core/covers/service_test.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//nolint:goconst
 package covers_test
 
 import (

--- a/api/pkg/core/covers/service_test.go
+++ b/api/pkg/core/covers/service_test.go
@@ -10,9 +10,11 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/imgcache"
 )
@@ -41,11 +43,14 @@ func (f *fakeResolver) Fetch(ctx context.Context, externalURL string) (io.ReadCl
 	return io.NopCloser(bytes.NewReader([]byte("cover-bytes"))), nil
 }
 
-func startService(t *testing.T, resolvers map[string]covers.CoverResolver) *covers.Service {
+func startServiceWithDirs(t *testing.T, resolvers map[string]covers.CoverResolver) (*covers.Service, string) {
 	t.Helper()
 
+	cacheDir := t.TempDir()
+	downloadsDir := t.TempDir()
+
 	cache, err := imgcache.New(imgcache.Config{
-		Dir:           t.TempDir(),
+		Dir:           cacheDir,
 		FetchFn:       covers.NewFetchFn(resolvers),
 		ErrorCacheTTL: time.Minute,
 		MinInterval:   time.Millisecond,
@@ -72,7 +77,10 @@ func startService(t *testing.T, resolvers map[string]covers.CoverResolver) *cove
 	}
 
 	svc, err := covers.NewService(
-		covers.ServiceConfig{ProxyPathPrefix: "/api/sources/cover"},
+		covers.ServiceConfig{
+			ProxyPathPrefix: "/api/sources/cover",
+			DownloadsDir:    downloadsDir,
+		},
 		covers.ServiceDeps{
 			Cache:      cache,
 			Resolvers:  resolvers,
@@ -83,6 +91,14 @@ func startService(t *testing.T, resolvers map[string]covers.CoverResolver) *cove
 	if err != nil {
 		t.Fatalf("covers.NewService: %v", err)
 	}
+
+	return svc, cacheDir
+}
+
+func startService(t *testing.T, resolvers map[string]covers.CoverResolver) *covers.Service {
+	t.Helper()
+
+	svc, _ := startServiceWithDirs(t, resolvers)
 
 	return svc
 }
@@ -189,6 +205,143 @@ func TestNewFetchFnUnknownSource(t *testing.T) {
 	_, err := fn(context.Background(), "asurascans/solo-leveling.webp")
 	if !errors.Is(err, covers.ErrUnknownSource) {
 		t.Errorf("NewFetchFn = %v, want ErrUnknownSource", err)
+	}
+}
+
+func TestObtainLocalMovesCachedCover(t *testing.T) {
+	t.Parallel()
+
+	var fetchCount int
+	resolvers := map[string]covers.CoverResolver{
+		covers.SourceAsuraScans: &fakeResolver{
+			url: testCoverURL,
+			fetch: func(context.Context, string) (io.ReadCloser, error) {
+				fetchCount++
+
+				return io.NopCloser(bytes.NewReader([]byte("cover-bytes"))), nil
+			},
+		},
+	}
+
+	svc := startService(t, resolvers)
+	ctx := context.Background()
+
+	if _, _, err := svc.Serve(ctx, covers.SourceAsuraScans, "solo-leveling"); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+
+	comicID := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+	if err := svc.ObtainLocal(ctx, comicID, covers.SourceAsuraScans, "solo-leveling"); err != nil {
+		t.Fatalf("ObtainLocal: %v", err)
+	}
+
+	path, contentType, err := svc.ServeLocal(ctx, comicID)
+	if err != nil {
+		t.Fatalf("ServeLocal: %v", err)
+	}
+
+	if contentType != "image/webp" {
+		t.Errorf("contentType = %q, want image/webp", contentType)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("os.ReadFile: %v", err)
+	}
+
+	if string(got) != "cover-bytes" {
+		t.Errorf("local cover = %q", got)
+	}
+
+	if fetchCount != 1 {
+		t.Errorf("fetchCount = %d, want 1 (cache hit then move)", fetchCount)
+	}
+}
+
+func TestObtainLocalDownloadsWhenCacheMisses(t *testing.T) {
+	t.Parallel()
+
+	var fetchCount int
+	resolvers := map[string]covers.CoverResolver{
+		covers.SourceAsuraScans: &fakeResolver{
+			url: testCoverURL,
+			fetch: func(context.Context, string) (io.ReadCloser, error) {
+				fetchCount++
+
+				return io.NopCloser(bytes.NewReader([]byte("fresh"))), nil
+			},
+		},
+	}
+
+	svc, cacheDir := startServiceWithDirs(t, resolvers)
+	comicID := uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+	if err := svc.ObtainLocal(context.Background(), comicID, covers.SourceAsuraScans, "solo-leveling"); err != nil {
+		t.Fatalf("ObtainLocal: %v", err)
+	}
+
+	if fetchCount != 1 {
+		t.Errorf("fetchCount = %d, want 1", fetchCount)
+	}
+
+	entries, err := os.ReadDir(cacheDir)
+	if err != nil {
+		t.Fatalf("os.ReadDir cache: %v", err)
+	}
+
+	if len(entries) != 0 {
+		t.Errorf("browse cache filled on miss: %v", entries)
+	}
+
+	path, _, err := svc.ServeLocal(context.Background(), comicID)
+	if err != nil {
+		t.Fatalf("ServeLocal: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("os.ReadFile: %v", err)
+	}
+
+	if string(got) != "fresh" {
+		t.Errorf("local cover = %q", got)
+	}
+}
+
+func TestServeLocalMissing(t *testing.T) {
+	t.Parallel()
+
+	svc := startService(t, map[string]covers.CoverResolver{
+		covers.SourceAsuraScans: &fakeResolver{url: testCoverURL},
+	})
+
+	_, _, err := svc.ServeLocal(context.Background(), uuid.New())
+	if !errors.Is(err, covers.ErrLocalCoverMissing) {
+		t.Errorf("ServeLocal = %v, want ErrLocalCoverMissing", err)
+	}
+}
+
+func TestRemoveLocalDeletesComicDir(t *testing.T) {
+	t.Parallel()
+
+	resolvers := map[string]covers.CoverResolver{
+		covers.SourceAsuraScans: &fakeResolver{url: testCoverURL},
+	}
+	svc := startService(t, resolvers)
+	comicID := uuid.New()
+
+	if err := svc.ObtainLocal(context.Background(), comicID, covers.SourceAsuraScans, "solo-leveling"); err != nil {
+		t.Fatalf("ObtainLocal: %v", err)
+	}
+
+	if err := svc.RemoveLocal(comicID); err != nil {
+		t.Fatalf("RemoveLocal: %v", err)
+	}
+
+	_, _, err := svc.ServeLocal(context.Background(), comicID)
+	if !errors.Is(err, covers.ErrLocalCoverMissing) {
+		t.Errorf("after RemoveLocal: %v", err)
 	}
 }
 

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -350,6 +350,10 @@ func (fakeComicsService) RefreshChapterLists(context.Context) error {
 	return errors.New(notImplemented)
 }
 
+func (fakeComicsService) ServeCover(context.Context, comics.GetByIDOpts) (string, string, error) {
+	return "", "", errors.New(notImplemented)
+}
+
 type fakeChaptersService struct{}
 
 func (fakeChaptersService) CreateAll(

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -111,6 +111,12 @@ func (fakeSessionsRepository) DeleteByTokenHash(context.Context, []byte) error {
 	return errors.New(notImplemented)
 }
 
+type stubCoverFinder struct{}
+
+func (stubCoverFinder) FindBySourceSlug(context.Context, string, string) (uuid.UUID, error) {
+	return uuid.Nil, coredomain.ErrNotFound
+}
+
 func newTestCoversBundle(t *testing.T, asuraApp *asura.App) (*covers.App, *covers.Service) {
 	t.Helper()
 
@@ -155,6 +161,7 @@ func newTestCoversBundle(t *testing.T, asuraApp *asura.App) (*covers.App, *cover
 			Resolvers:  resolvers,
 			HTTPClient: httpClient,
 			Logger:     logger,
+			Finder:     stubCoverFinder{},
 		},
 	)
 	if err != nil {

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -146,7 +146,10 @@ func newTestCoversBundle(t *testing.T, asuraApp *asura.App) (*covers.App, *cover
 	}
 
 	svc, err := covers.NewService(
-		covers.ServiceConfig{ProxyPathPrefix: APIPrefix + "/sources/cover"},
+		covers.ServiceConfig{
+			ProxyPathPrefix: APIPrefix + "/sources/cover",
+			DownloadsDir:    t.TempDir(),
+		},
 		covers.ServiceDeps{
 			Cache:      cache,
 			Resolvers:  resolvers,

--- a/api/pkg/utils/imgcache/imgcache.go
+++ b/api/pkg/utils/imgcache/imgcache.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils"
@@ -200,6 +201,98 @@ func (ic *Cache) Ensure(ctx context.Context, name string) (string, error) {
 		//nolint:wrapcheck
 		return "", ctx.Err()
 	}
+}
+
+func (ic *Cache) Take(ctx context.Context, name, dest string) (bool, error) {
+	key, err := safeKey(name)
+	if err != nil {
+		return false, err
+	}
+
+	if err = ic.waitIfProcessing(ctx, key); err != nil {
+		return false, err
+	}
+
+	src := filepath.Join(ic.cfg.Dir, filepath.FromSlash(key))
+	st, err := os.Stat(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("os.Stat %s: %w", src, err)
+	}
+
+	if !st.Mode().IsRegular() {
+		return false, nil
+	}
+
+	if err = os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return false, fmt.Errorf("os.MkdirAll %s: %w", dest, err)
+	}
+
+	if err = os.Rename(src, dest); err != nil {
+		if !errors.Is(err, syscall.EXDEV) {
+			return false, fmt.Errorf("os.Rename %s: %w", src, err)
+		}
+
+		if err = copyThenRemove(src, dest); err != nil {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+func (ic *Cache) waitIfProcessing(ctx context.Context, key string) error {
+	ic.mtx.Lock()
+	j, ok := ic.processing[key]
+	ic.mtx.Unlock()
+
+	if !ok {
+		return nil
+	}
+
+	select {
+	case <-j.done:
+		return nil
+	case <-ctx.Done():
+		//nolint:wrapcheck
+		return ctx.Err()
+	}
+}
+
+func copyThenRemove(src, dest string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("os.Open %s: %w", src, err)
+	}
+
+	defer in.Close()
+
+	out, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("os.Create %s: %w", dest, err)
+	}
+
+	if _, err = io.Copy(out, in); err != nil {
+		out.Close()
+		os.Remove(dest)
+
+		return fmt.Errorf("io.Copy %s: %w", dest, err)
+	}
+
+	if err = out.Close(); err != nil {
+		os.Remove(dest)
+
+		return fmt.Errorf("out.Close %s: %w", dest, err)
+	}
+
+	if err = os.Remove(src); err != nil {
+		return fmt.Errorf("os.Remove %s: %w", src, err)
+	}
+
+	return nil
 }
 
 func (ic *Cache) enqueue(ctx context.Context, key string, diskPath string) (*job, error) {

--- a/api/pkg/utils/imgcache/imgcache_internal_test.go
+++ b/api/pkg/utils/imgcache/imgcache_internal_test.go
@@ -536,6 +536,91 @@ func TestImageCacheProcessSkipsRateLimitWhenAlreadyOnDisk(t *testing.T) {
 	}
 }
 
+func TestImageCacheTakeMovesExistingFile(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	dir := t.TempDir()
+	ic := startCache(t, Config{
+		Dir:           dir,
+		ErrorCacheTTL: time.Minute,
+		MinInterval:   time.Millisecond,
+		FetchFn: func(context.Context, string) (io.ReadCloser, error) {
+			calls.Add(1)
+
+			return io.NopCloser(strings.NewReader("image-bytes")), nil
+		},
+	})
+
+	if _, err := ic.Ensure(context.Background(), "asurascans/solo-leveling.webp"); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+
+	destDir := t.TempDir()
+	dest := filepath.Join(destDir, "cover.webp")
+
+	moved, err := ic.Take(context.Background(), "asurascans/solo-leveling.webp", dest)
+	if err != nil {
+		t.Fatalf("Take: %v", err)
+	}
+
+	if !moved {
+		t.Fatal("Take returned false, want true")
+	}
+
+	content, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("os.ReadFile dest: %v", err)
+	}
+
+	if string(content) != "image-bytes" {
+		t.Errorf("dest content = %q", content)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "asurascans", "solo-leveling.webp")); !os.IsNotExist(err) {
+		t.Errorf("cache file still present: %v", err)
+	}
+
+	if got := calls.Load(); got != 1 {
+		t.Errorf("FetchFn called %d times, want 1", got)
+	}
+}
+
+func TestImageCacheTakeMissDoesNotFetch(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	ic := startCache(t, Config{
+		Dir:           t.TempDir(),
+		ErrorCacheTTL: time.Minute,
+		MinInterval:   time.Millisecond,
+		FetchFn: func(context.Context, string) (io.ReadCloser, error) {
+			calls.Add(1)
+
+			return io.NopCloser(strings.NewReader("nope")), nil
+		},
+	})
+
+	dest := filepath.Join(t.TempDir(), "cover.webp")
+
+	moved, err := ic.Take(context.Background(), "asurascans/missing.webp", dest)
+	if err != nil {
+		t.Fatalf("Take: %v", err)
+	}
+
+	if moved {
+		t.Fatal("Take returned true on miss")
+	}
+
+	if got := calls.Load(); got != 0 {
+		t.Errorf("FetchFn called %d times, want 0", got)
+	}
+
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Errorf("dest created on miss: %v", err)
+	}
+}
+
 func TestImageCacheProcessDoesNotCacheContextErrors(t *testing.T) {
 	t.Parallel()
 

--- a/web/app/assets/styles/constants.scss
+++ b/web/app/assets/styles/constants.scss
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: AGPL-3.0-or-later */
 :root {
-  --bottom-navigation-height: calc(80px + env(safe-area-inset-bottom));
+  --bottom-navigation-height: calc(58px + env(safe-area-inset-bottom));
   --navigation-drawer-width: calc(230px + env(safe-area-inset-left));
   --navigation-drawer-compact-width: calc(82px + env(safe-area-inset-left));
   --bottom-pagination-height: calc(80px + env(safe-area-inset-bottom));

--- a/web/app/components/Organism/BottomNavigation/index.vue
+++ b/web/app/components/Organism/BottomNavigation/index.vue
@@ -8,15 +8,18 @@ defineProps<{
 </script>
 
 <template>
-  <header class="position-fixed bottom-0 w-100 pa-4 nvagation-bottom">
-    <div class="w-100 h-100 bg-surface rounded-lg border-thin elevation-down d-flex justify-space-evenly">
+  <footer class="">
+    <div
+      class="position-fixed bottom-0 w-100 pa-4 nvagation-bottom h-100 bg-surface border-thin elevation-down d-flex justify-space-evenly"
+      style="border-top-left-radius: 12px; border-top-right-radius: 12px;"
+    >
       <OrganismBottomNavigationItem
         v-for="(item, index) in items"
         :key="index"
         v-bind="item"
       />
     </div>
-  </header>
+  </footer>
 </template>
 
 <style lang="scss">


### PR DESCRIPTION
## Summary

Closes #56.

- Persist a **Cover (local)** at `downloads/{comicId}/cover.{ext}` when a comic is first added to the library (move from browse cache when available, otherwise download directly)
- Serve local covers at `GET /api/comics/{id}/cover` (authenticated, scoped to the current user's library)
- Expose `cover: /api/comics/{id}/cover` on comics DTOs (create, get-by-id, list)
- When a comic already exists in the DB, the source cover proxy (`GET /api/sources/cover/{slug}?source=`) serves the local file instead of re-downloading into the browse cache
- Handle unique `(source, slug)` race: orphan cover cleanup + fall through to add-existing

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] Add a comic to the library → `downloads/{id}/cover.*` is created on disk
- [x] `GET /api/comics/{id}/cover` returns 200 with image bytes for a comic in the current user's library
- [x] `GET /api/comics/{id}/cover` returns 404 for a comic not in the current user's library
- [x] `GET /api/comics/{id}/cover` returns 401 without session cookie
- [x] Create / get / list comics responses include `cover: /api/comics/{id}/cover`
- [x] Source cover proxy serves the local file when the comic exists in the DB (no new cache entry)
- [x] Cover obtain failure on first create returns 500 and does not create the comic row
