### PR TITLE
Comics list API — search, sort, { items, total }

### DIFF
--- a/api/cmd/uchiyomiserver/setup_internal_test.go
+++ b/api/cmd/uchiyomiserver/setup_internal_test.go
@@ -58,8 +58,8 @@ func (stubComicsRepository) Delete(context.Context, uuid.UUID) error {
 	return coredomain.ErrNotFound
 }
 
-func (stubComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]comics.Comic, error) {
-	return nil, nil
+func (stubComicsRepository) GetMany(context.Context, comics.GetManyOpts) (comics.Page, error) {
+	return comics.Page{}, nil
 }
 
 func (stubComicsRepository) ListByStatuses(context.Context, comics.ListByStatusesOpts) ([]comics.Comic, error) {

--- a/api/pkg/core/chapters/download/worker_test.go
+++ b/api/pkg/core/chapters/download/worker_test.go
@@ -127,7 +127,7 @@ func (f *fakeComicsRepository) Delete(context.Context, uuid.UUID) error {
 	panic("not implemented")
 }
 
-func (f *fakeComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]comics.Comic, error) {
+func (f *fakeComicsRepository) GetMany(context.Context, comics.GetManyOpts) (comics.Page, error) {
 	panic("not implemented")
 }
 

--- a/api/pkg/core/comics/domain.go
+++ b/api/pkg/core/comics/domain.go
@@ -4,6 +4,7 @@ package comics
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -52,7 +53,7 @@ type ComicsRepository interface {
 	Create(context.Context, CreateComicOpts) (*Comic, error)
 	GetBySlugsAndSource(context.Context, GetBySlugsAndSource) ([]Comic, error)
 	Delete(context.Context, uuid.UUID) error
-	GetMany(context.Context, GetManyOpts) ([]Comic, error)
+	GetMany(context.Context, GetManyOpts) (Page, error)
 	ListByStatuses(context.Context, ListByStatusesOpts) ([]Comic, error)
 	UpdateStatusAndChapterCount(context.Context, UpdateStatusAndChapterCountOpts) error
 }
@@ -81,7 +82,7 @@ type GetBySlugsAndSource struct {
 type ComicsService interface {
 	Create(context.Context, CreateOpts) (*Comic, error)
 	GetByID(context.Context, GetByIDOpts) (*Comic, error)
-	GetMany(context.Context, GetManyOpts) ([]Comic, error)
+	GetMany(context.Context, GetManyOpts) (Page, error)
 	Delete(context.Context, DeleteOpts) error
 	RefreshChapterLists(context.Context) error
 	ServeCover(ctx context.Context, opts GetByIDOpts) (diskPath, contentType string, err error)
@@ -98,11 +99,55 @@ type GetByIDOpts struct {
 	ID     uuid.UUID
 }
 
+type Page struct {
+	Items []Comic
+	Total int64
+}
+
+type ListSort string
+
+const (
+	ListSortTitle   ListSort = "title"
+	ListSortAddedAt ListSort = "addedAt"
+)
+
+func ParseListSort(s string) (ListSort, error) {
+	switch s {
+	case string(ListSortTitle):
+		return ListSortTitle, nil
+	case string(ListSortAddedAt):
+		return ListSortAddedAt, nil
+	default:
+		return "", fmt.Errorf("invalid sort: %s", s)
+	}
+}
+
+type ListOrder string
+
+const (
+	ListOrderAsc  ListOrder = "asc"
+	ListOrderDesc ListOrder = "desc"
+)
+
+func ParseListOrder(s string) (ListOrder, error) {
+	switch s {
+	case string(ListOrderAsc):
+		return ListOrderAsc, nil
+	case string(ListOrderDesc):
+		return ListOrderDesc, nil
+	default:
+		return "", fmt.Errorf("invalid order: %s", s)
+	}
+}
+
 type GetManyOpts struct {
 	UserID *uuid.UUID
 	Source *sources.SourceName
 	Type   *sources.SeriesType
 	Status *sources.SeriesStatus
+	Search string
+	Sort   ListSort
+	Order  ListOrder
 	Limit  int
 	Offset int
 }

--- a/api/pkg/core/comics/domain_test.go
+++ b/api/pkg/core/comics/domain_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package comics_test
+
+import (
+	"testing"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
+)
+
+func TestParseListSort(t *testing.T) {
+	t.Parallel()
+
+	got, err := comics.ParseListSort("title")
+	if err != nil || got != comics.ListSortTitle {
+		t.Fatalf("title: got %q err %v", got, err)
+	}
+
+	got, err = comics.ParseListSort("addedAt")
+	if err != nil || got != comics.ListSortAddedAt {
+		t.Fatalf("addedAt: got %q err %v", got, err)
+	}
+
+	if _, err = comics.ParseListSort("created_at"); err == nil {
+		t.Fatal("created_at must be invalid")
+	}
+}
+
+func TestParseListOrder(t *testing.T) {
+	t.Parallel()
+
+	got, err := comics.ParseListOrder("asc")
+	if err != nil || got != comics.ListOrderAsc {
+		t.Fatalf("asc: got %q err %v", got, err)
+	}
+
+	got, err = comics.ParseListOrder("desc")
+	if err != nil || got != comics.ListOrderDesc {
+		t.Fatalf("desc: got %q err %v", got, err)
+	}
+
+	if _, err = comics.ParseListOrder("ASC"); err == nil {
+		t.Fatal("ASC must be invalid")
+	}
+}

--- a/api/pkg/core/comics/gateway/http/controller.go
+++ b/api/pkg/core/comics/gateway/http/controller.go
@@ -196,12 +196,7 @@ func (c *Controller) getMany(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res := make([]lightComic, len(page.Items))
-	for i, comic := range page.Items {
-		res[i] = lightComicFromDomain(&comic)
-	}
-
-	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, res)
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, comicListFromPage(page))
 }
 
 func (c *Controller) deleteByID(w http.ResponseWriter, r *http.Request) {
@@ -269,6 +264,28 @@ func (c *Controller) getManyQuery(r *http.Request) (*comics.GetManyOpts, error) 
 
 		opts.Status = &parsed
 	}
+
+	opts.Sort = comics.ListSortTitle
+	if raw := r.URL.Query().Get("sort"); raw != "" {
+		parsed, err := comics.ParseListSort(raw)
+		if err != nil {
+			return nil, fmt.Errorf("comics.ParseListSort: %w", err)
+		}
+
+		opts.Sort = parsed
+	}
+
+	opts.Order = comics.ListOrderAsc
+	if raw := r.URL.Query().Get("order"); raw != "" {
+		parsed, err := comics.ParseListOrder(raw)
+		if err != nil {
+			return nil, fmt.Errorf("comics.ParseListOrder: %w", err)
+		}
+
+		opts.Order = parsed
+	}
+
+	opts.Search = strings.TrimSpace(r.URL.Query().Get("search"))
 
 	limit, err := parseQueryLimit(r.URL.Query().Get("limit"))
 	if err != nil {

--- a/api/pkg/core/comics/gateway/http/controller.go
+++ b/api/pkg/core/comics/gateway/http/controller.go
@@ -188,7 +188,7 @@ func (c *Controller) getMany(w http.ResponseWriter, r *http.Request) {
 
 	opts.UserID = &user.ID
 
-	comics, err := c.deps.ComicsService.GetMany(ctx, *opts)
+	page, err := c.deps.ComicsService.GetMany(ctx, *opts)
 	if err != nil {
 		c.deps.Logger.Error("failed to get many comics", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
@@ -196,8 +196,8 @@ func (c *Controller) getMany(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res := make([]lightComic, len(comics))
-	for i, comic := range comics {
+	res := make([]lightComic, len(page.Items))
+	for i, comic := range page.Items {
 		res[i] = lightComicFromDomain(&comic)
 	}
 

--- a/api/pkg/core/comics/gateway/http/controller_test.go
+++ b/api/pkg/core/comics/gateway/http/controller_test.go
@@ -44,7 +44,7 @@ type stubComicsService struct {
 	getByIDResult    *comics.Comic
 	serveCoverPath   string
 	serveCoverType   string
-	getManyResult    []comics.Comic
+	getManyResult    comics.Page
 	serveCoverCalls  int
 	lastServeCoverID uuid.UUID
 }
@@ -57,7 +57,7 @@ func (s *stubComicsService) GetByID(_ context.Context, _ comics.GetByIDOpts) (*c
 	return s.getByIDResult, s.getByIDErr
 }
 
-func (s *stubComicsService) GetMany(_ context.Context, _ comics.GetManyOpts) ([]comics.Comic, error) {
+func (s *stubComicsService) GetMany(_ context.Context, _ comics.GetManyOpts) (comics.Page, error) {
 	return s.getManyResult, s.getManyErr
 }
 
@@ -289,7 +289,7 @@ func TestGetManyReturnsComics(t *testing.T) {
 		Status: sources.SeriesStatusCompleted,
 	}}
 
-	r := newTestRouter(t, &stubComicsService{getManyResult: items}, authenticatorFor(t, user))
+	r := newTestRouter(t, &stubComicsService{getManyResult: comics.Page{Items: items}}, authenticatorFor(t, user))
 
 	req := httptest.NewRequest(http.MethodGet, comicsEndpoint+"/", nil)
 	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})

--- a/api/pkg/core/comics/gateway/http/controller_test.go
+++ b/api/pkg/core/comics/gateway/http/controller_test.go
@@ -33,6 +33,8 @@ const (
 	cookieName     = "uchiyomi_session"
 	testToken      = "letoken"
 	testUsername   = "alice"
+	testComicTitle = "Solo Leveling"
+	testComicSlug  = "solo-leveling"
 )
 
 type stubComicsService struct {
@@ -197,7 +199,7 @@ func TestCreateRequiresAuthentication(t *testing.T) {
 	req := httptest.NewRequest(
 		http.MethodPost,
 		comicsEndpoint+"/",
-		bytes.NewReader([]byte(`{"source":"asurascans","slug":"solo-leveling"}`)),
+		bytes.NewReader([]byte(`{"source":"asurascans","slug":"`+testComicSlug+`"}`)),
 	)
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
@@ -213,8 +215,8 @@ func TestCreateReturnsComic(t *testing.T) {
 	user := &users.User{ID: uuid.New(), Name: testUsername}
 	comic := &comics.Comic{
 		ID:           uuid.New(),
-		Title:        "Solo Leveling",
-		Slug:         "solo-leveling",
+		Title:        testComicTitle,
+		Slug:         testComicSlug,
 		Source:       sources.SourceAsuraScans,
 		Status:       sources.SeriesStatusCompleted,
 		ChapterCount: 200,
@@ -225,7 +227,7 @@ func TestCreateReturnsComic(t *testing.T) {
 	req := httptest.NewRequest(
 		http.MethodPost,
 		comicsEndpoint+"/",
-		bytes.NewReader([]byte(`{"source":"asurascans","slug":"solo-leveling"}`)),
+		bytes.NewReader([]byte(`{"source":"asurascans","slug":"`+testComicSlug+`"}`)),
 	)
 
 	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
@@ -268,9 +270,9 @@ type comicshttpPage struct {
 }
 
 type comicshttpDetail struct {
+	Cover        string    `json:"cover"`
 	AltTitles    []string  `json:"altTitles"`
 	ChapterCount int       `json:"chapterCount"`
-	Cover        string    `json:"cover"`
 	ID           uuid.UUID `json:"id"`
 }
 
@@ -302,9 +304,9 @@ func TestGetManyReturnsComics(t *testing.T) {
 	getManyResult := comics.Page{
 		Items: []comics.Comic{{
 			ID:           comicID,
-			Slug:         "solo-leveling",
+			Slug:         testComicSlug,
 			Source:       sources.SourceAsuraScans,
-			Title:        "Solo Leveling",
+			Title:        testComicTitle,
 			Status:       sources.SeriesStatusCompleted,
 			Type:         sources.SeriesTypeManhwa,
 			ChapterCount: 200,
@@ -332,7 +334,7 @@ func TestGetManyReturnsComics(t *testing.T) {
 		t.Errorf("total = %d, want 42", got.Total)
 	}
 
-	if len(got.Items) != 1 || got.Items[0].Slug != "solo-leveling" {
+	if len(got.Items) != 1 || got.Items[0].Slug != testComicSlug {
 		t.Errorf("response = %+v, want %+v", got, getManyResult.Items)
 	}
 
@@ -438,8 +440,8 @@ func TestGetByIDCamelCaseJSON(t *testing.T) {
 	user := &users.User{ID: uuid.New(), Name: testUsername}
 	comic := &comics.Comic{
 		ID:           uuid.New(),
-		Title:        "Solo Leveling",
-		Slug:         "solo-leveling",
+		Title:        testComicTitle,
+		Slug:         testComicSlug,
 		AltTitles:    []string{"Na Honjaman Level-Up"},
 		ChapterCount: 200,
 		Source:       sources.SourceAsuraScans,

--- a/api/pkg/core/comics/gateway/http/controller_test.go
+++ b/api/pkg/core/comics/gateway/http/controller_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -45,6 +46,7 @@ type stubComicsService struct {
 	serveCoverPath   string
 	serveCoverType   string
 	getManyResult    comics.Page
+	lastGetMany      comics.GetManyOpts
 	serveCoverCalls  int
 	lastServeCoverID uuid.UUID
 }
@@ -57,7 +59,9 @@ func (s *stubComicsService) GetByID(_ context.Context, _ comics.GetByIDOpts) (*c
 	return s.getByIDResult, s.getByIDErr
 }
 
-func (s *stubComicsService) GetMany(_ context.Context, _ comics.GetManyOpts) (comics.Page, error) {
+func (s *stubComicsService) GetMany(_ context.Context, opts comics.GetManyOpts) (comics.Page, error) {
+	s.lastGetMany = opts
+
 	return s.getManyResult, s.getManyErr
 }
 
@@ -253,8 +257,21 @@ type comicshttpLightComic struct {
 	Cover        string               `json:"cover"`
 	Source       sources.SourceName   `json:"source"`
 	Status       sources.SeriesStatus `json:"status"`
-	ChapterCount int                  `json:"chapter_count"`
+	Type         sources.SeriesType   `json:"type"`
+	ChapterCount int                  `json:"chapterCount"`
 	ID           uuid.UUID            `json:"id"`
+}
+
+type comicshttpPage struct {
+	Items []comicshttpLightComic `json:"items"`
+	Total int64                  `json:"total"`
+}
+
+type comicshttpDetail struct {
+	AltTitles    []string  `json:"altTitles"`
+	ChapterCount int       `json:"chapterCount"`
+	Cover        string    `json:"cover"`
+	ID           uuid.UUID `json:"id"`
 }
 
 func TestGetByIDNotFound(t *testing.T) {
@@ -281,15 +298,21 @@ func TestGetManyReturnsComics(t *testing.T) {
 	t.Parallel()
 
 	user := &users.User{ID: uuid.New(), Name: testUsername}
-	items := []comics.Comic{{
-		ID:     uuid.New(),
-		Slug:   "solo-leveling",
-		Source: sources.SourceAsuraScans,
-		Title:  "Solo Leveling",
-		Status: sources.SeriesStatusCompleted,
-	}}
+	comicID := uuid.New()
+	getManyResult := comics.Page{
+		Items: []comics.Comic{{
+			ID:           comicID,
+			Slug:         "solo-leveling",
+			Source:       sources.SourceAsuraScans,
+			Title:        "Solo Leveling",
+			Status:       sources.SeriesStatusCompleted,
+			Type:         sources.SeriesTypeManhwa,
+			ChapterCount: 200,
+		}},
+		Total: 42,
+	}
 
-	r := newTestRouter(t, &stubComicsService{getManyResult: comics.Page{Items: items}}, authenticatorFor(t, user))
+	r := newTestRouter(t, &stubComicsService{getManyResult: getManyResult}, authenticatorFor(t, user))
 
 	req := httptest.NewRequest(http.MethodGet, comicsEndpoint+"/", nil)
 	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
@@ -300,18 +323,147 @@ func TestGetManyReturnsComics(t *testing.T) {
 		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
 	}
 
-	var got []comicshttpLightComic
+	var got comicshttpPage
 	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
 
-	if len(got) != 1 || got[0].Slug != items[0].Slug {
-		t.Errorf("response = %+v, want %+v", got, items)
+	if got.Total != 42 {
+		t.Errorf("total = %d, want 42", got.Total)
 	}
 
-	wantCover := "/api/comics/" + items[0].ID.String() + "/cover"
-	if got[0].Cover != wantCover {
-		t.Errorf("cover = %q, want %q", got[0].Cover, wantCover)
+	if len(got.Items) != 1 || got.Items[0].Slug != "solo-leveling" {
+		t.Errorf("response = %+v, want %+v", got, getManyResult.Items)
+	}
+
+	if got.Items[0].Type != sources.SeriesTypeManhwa {
+		t.Errorf("type = %q, want %q", got.Items[0].Type, sources.SeriesTypeManhwa)
+	}
+
+	if got.Items[0].ChapterCount != 200 {
+		t.Errorf("chapterCount = %d, want 200", got.Items[0].ChapterCount)
+	}
+
+	wantCover := "/api/comics/" + comicID.String() + "/cover"
+	if got.Items[0].Cover != wantCover {
+		t.Errorf("cover = %q, want %q", got.Items[0].Cover, wantCover)
+	}
+}
+
+func TestGetManyUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRouter(t, &stubComicsService{}, nil)
+	req := httptest.NewRequest(http.MethodGet, comicsEndpoint+"/", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestGetManyInvalidQuery(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	r := newTestRouter(t, &stubComicsService{}, authenticatorFor(t, user))
+
+	queries := []string{
+		"?sort=created_at",
+		"?order=ASC",
+		"?source=not-a-source",
+		"?type=webtoon",
+		"?status=unknown",
+		"?limit=x",
+		"?offset=x",
+	}
+
+	for _, q := range queries {
+		t.Run(q, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, comicsEndpoint+"/?"+strings.TrimPrefix(q, "?"), nil)
+			req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400", rec.Code)
+			}
+		})
+	}
+}
+
+func TestGetManyPassesSearchSortAndUserID(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	svc := &stubComicsService{getManyResult: comics.Page{Items: []comics.Comic{}, Total: 0}}
+	r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		comicsEndpoint+"/?search=%20solo%20&sort=addedAt&order=desc&limit=5&offset=2",
+		nil,
+	)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	if svc.lastGetMany.Search != "solo" {
+		t.Errorf("Search = %q, want solo", svc.lastGetMany.Search)
+	}
+
+	if svc.lastGetMany.Sort != comics.ListSortAddedAt || svc.lastGetMany.Order != comics.ListOrderDesc {
+		t.Errorf("sort/order = %s %s", svc.lastGetMany.Sort, svc.lastGetMany.Order)
+	}
+
+	if svc.lastGetMany.UserID == nil || *svc.lastGetMany.UserID != user.ID {
+		t.Errorf("UserID = %v, want %s", svc.lastGetMany.UserID, user.ID)
+	}
+
+	if svc.lastGetMany.Limit != 5 || svc.lastGetMany.Offset != 2 {
+		t.Errorf("limit/offset = %d %d", svc.lastGetMany.Limit, svc.lastGetMany.Offset)
+	}
+}
+
+func TestGetByIDCamelCaseJSON(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	comic := &comics.Comic{
+		ID:           uuid.New(),
+		Title:        "Solo Leveling",
+		Slug:         "solo-leveling",
+		AltTitles:    []string{"Na Honjaman Level-Up"},
+		ChapterCount: 200,
+		Source:       sources.SourceAsuraScans,
+		Status:       sources.SeriesStatusCompleted,
+		Type:         sources.SeriesTypeManhwa,
+	}
+
+	r := newTestRouter(t, &stubComicsService{getByIDResult: comic}, authenticatorFor(t, user))
+	req := httptest.NewRequest(http.MethodGet, comicsEndpoint+"/"+comic.ID.String(), nil)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var got comicshttpDetail
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if got.ChapterCount != 200 || len(got.AltTitles) != 1 {
+		t.Errorf("detail = %+v", got)
 	}
 }
 

--- a/api/pkg/core/comics/gateway/http/dto.go
+++ b/api/pkg/core/comics/gateway/http/dto.go
@@ -15,7 +15,8 @@ type lightComic struct {
 	Cover        string               `json:"cover"`
 	Source       sources.SourceName   `json:"source"`
 	Status       sources.SeriesStatus `json:"status"`
-	ChapterCount int                  `json:"chapter_count"`
+	Type         sources.SeriesType   `json:"type"`
+	ChapterCount int                  `json:"chapterCount"`
 	ID           uuid.UUID            `json:"id"`
 }
 
@@ -32,7 +33,22 @@ func lightComicFromDomain(comic *comics.Comic) lightComic {
 		Cover:        comicCoverURL(comic.ID),
 		Source:       comic.Source,
 		Status:       comic.Status,
+		Type:         comic.Type,
 	}
+}
+
+type comicListResponse struct {
+	Items []lightComic `json:"items"`
+	Total int64        `json:"total"`
+}
+
+func comicListFromPage(page comics.Page) comicListResponse {
+	items := make([]lightComic, len(page.Items))
+	for i := range page.Items {
+		items[i] = lightComicFromDomain(&page.Items[i])
+	}
+
+	return comicListResponse{Items: items, Total: page.Total}
 }
 
 type createRequest struct {
@@ -51,8 +67,8 @@ type comicResponse struct {
 	Title        string               `json:"title"`
 	Cover        string               `json:"cover"`
 	Genres       []string             `json:"genres"`
-	AltTitles    []string             `json:"alt_titles"`
-	ChapterCount int                  `json:"chapter_count"`
+	AltTitles    []string             `json:"altTitles"`
+	ChapterCount int                  `json:"chapterCount"`
 	ID           uuid.UUID            `json:"id"`
 }
 

--- a/api/pkg/core/comics/refresh/app_test.go
+++ b/api/pkg/core/comics/refresh/app_test.go
@@ -30,7 +30,7 @@ func (f *fakeComicsService) GetByID(context.Context, comics.GetByIDOpts) (*comic
 	panic("GetByID must not be called")
 }
 
-func (f *fakeComicsService) GetMany(context.Context, comics.GetManyOpts) ([]comics.Comic, error) {
+func (f *fakeComicsService) GetMany(context.Context, comics.GetManyOpts) (comics.Page, error) {
 	panic("GetMany must not be called")
 }
 

--- a/api/pkg/core/comics/repository/pg/repository.go
+++ b/api/pkg/core/comics/repository/pg/repository.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -160,30 +161,81 @@ func (r *PGComicsRepository) Create(ctx context.Context, opts comics.CreateComic
 	return &ret, nil
 }
 
-func (r *PGComicsRepository) GetMany(ctx context.Context, opts comics.GetManyOpts) (comics.Page, error) {
-	q := r.db(ctx).Order("comics.created_at DESC")
+func likeContains(q string) string {
+	q = strings.ReplaceAll(q, `\`, `\\`)
+	q = strings.ReplaceAll(q, `%`, `\%`)
+	q = strings.ReplaceAll(q, `_`, `\_`)
+
+	return `%` + q + `%`
+}
+
+func (r *PGComicsRepository) getManyQuery(ctx context.Context, opts comics.GetManyOpts) *gorm.DB {
+	db := pgtx.From(ctx, r.deps.DB).Model(&pgmodels.Comic{})
+
 	if opts.UserID != nil {
-		q = q.Where(`EXISTS (
-			SELECT 1 FROM library_entries
-			WHERE library_entries.comic_id = comics.id AND library_entries.user_id = ?
-		)`, opts.UserID)
+		db = db.Joins(
+			"JOIN library_entries ON library_entries.comic_id = comics.id AND library_entries.user_id = ?",
+			*opts.UserID,
+		)
 	}
 
 	if opts.Source != nil {
-		q = q.Where("comics.source = ?", opts.Source)
+		db = db.Where("comics.source = ?", *opts.Source)
 	}
 
 	if opts.Type != nil {
-		q = q.Where("comics.type = ?", opts.Type)
+		db = db.Where("comics.comic_type = ?", *opts.Type)
 	}
 
 	if opts.Status != nil {
-		q = q.Where("comics.status = ?", opts.Status)
+		db = db.Where("comics.status = ?", *opts.Status)
 	}
 
-	models, err := q.Offset(opts.Offset).Limit(opts.Limit).Find(ctx)
+	if opts.Search != "" {
+		pattern := likeContains(opts.Search)
+		//nolint:lll
+		db = db.Where(
+			`(comics.title ILIKE ? ESCAPE '\' OR EXISTS (
+				SELECT 1 FROM unnest(comics.alt_titles) AS alt(title)
+				WHERE alt.title ILIKE ? ESCAPE '\'
+			))`,
+			pattern,
+			pattern,
+		)
+	}
+
+	return db
+}
+
+func getManyOrderSQL(opts comics.GetManyOpts) string {
+	dir := "ASC"
+	if opts.Order == comics.ListOrderDesc {
+		dir = "DESC"
+	}
+
+	if opts.Sort == comics.ListSortAddedAt {
+		return "library_entries.added_at " + dir
+	}
+
+	return "LOWER(comics.title) " + dir
+}
+
+func (r *PGComicsRepository) GetMany(ctx context.Context, opts comics.GetManyOpts) (comics.Page, error) {
+	var total int64
+
+	if err := r.getManyQuery(ctx, opts).Count(&total).Error; err != nil {
+		return comics.Page{}, fmt.Errorf("r.getManyQuery.Count: %w", err)
+	}
+
+	var models []pgmodels.Comic
+
+	err := r.getManyQuery(ctx, opts).
+		Order(getManyOrderSQL(opts)).
+		Offset(opts.Offset).
+		Limit(opts.Limit).
+		Find(&models).Error
 	if err != nil {
-		return comics.Page{}, fmt.Errorf("r.db(ctx).Where: %w", err)
+		return comics.Page{}, fmt.Errorf("r.getManyQuery.Find: %w", err)
 	}
 
 	ret := make([]comics.Comic, len(models))
@@ -191,7 +243,7 @@ func (r *PGComicsRepository) GetMany(ctx context.Context, opts comics.GetManyOpt
 		ret[i] = model.Domain()
 	}
 
-	return comics.Page{Items: ret}, nil
+	return comics.Page{Items: ret, Total: total}, nil
 }
 
 func (r *PGComicsRepository) ListByStatuses(

--- a/api/pkg/core/comics/repository/pg/repository.go
+++ b/api/pkg/core/comics/repository/pg/repository.go
@@ -160,7 +160,7 @@ func (r *PGComicsRepository) Create(ctx context.Context, opts comics.CreateComic
 	return &ret, nil
 }
 
-func (r *PGComicsRepository) GetMany(ctx context.Context, opts comics.GetManyOpts) ([]comics.Comic, error) {
+func (r *PGComicsRepository) GetMany(ctx context.Context, opts comics.GetManyOpts) (comics.Page, error) {
 	q := r.db(ctx).Order("comics.created_at DESC")
 	if opts.UserID != nil {
 		q = q.Where(`EXISTS (
@@ -183,7 +183,7 @@ func (r *PGComicsRepository) GetMany(ctx context.Context, opts comics.GetManyOpt
 
 	models, err := q.Offset(opts.Offset).Limit(opts.Limit).Find(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
+		return comics.Page{}, fmt.Errorf("r.db(ctx).Where: %w", err)
 	}
 
 	ret := make([]comics.Comic, len(models))
@@ -191,7 +191,7 @@ func (r *PGComicsRepository) GetMany(ctx context.Context, opts comics.GetManyOpt
 		ret[i] = model.Domain()
 	}
 
-	return ret, nil
+	return comics.Page{Items: ret}, nil
 }
 
 func (r *PGComicsRepository) ListByStatuses(

--- a/api/pkg/core/comics/repository/pg/repository_test.go
+++ b/api/pkg/core/comics/repository/pg/repository_test.go
@@ -47,6 +47,14 @@ func newComicsRepo(t *testing.T) (*pg.PGComicsRepository, sqlmock.Sqlmock) {
 	return r, mock
 }
 
+func comicSelectColumns() []string {
+	return []string{
+		"id", "source", "slug", "title", "status", "comic_type",
+		"chapter_count", "author", "artist", "description",
+		"genres", "alt_titles", "created_at", "updated_at",
+	}
+}
+
 func TestNewValidatesDeps(t *testing.T) {
 	t.Parallel()
 
@@ -269,36 +277,178 @@ func TestGetMany(t *testing.T) {
 	t.Parallel()
 
 	r, mock := newComicsRepo(t)
-
 	userID := uuid.New()
 	id := uuid.New()
 	created := time.Now().UTC().Truncate(time.Second)
-	updated := created
 
-	mock.ExpectQuery(`FROM "comics".*EXISTS`).
+	mock.ExpectQuery(`SELECT count\(\*\).*FROM "comics".*JOIN library_entries`).
+		WithArgs(userID).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(1)))
+
+	mock.ExpectQuery(`FROM "comics".*JOIN library_entries.*LOWER\(comics.title\)`).
 		WithArgs(userID, 10).
-		WillReturnRows(
-			sqlmock.NewRows([]string{
-				"id", "source", "slug", "title", "status", "comic_type",
-				"chapter_count", "author", "artist", "description",
-				"genres", "alt_titles", "created_at", "updated_at",
-			}).AddRow(
-				id, string(comicSource), comicSlug, comicTitle, string(comicStatus), string(comicType),
-				200, "Chugong", "Dubu", "desc",
-				"{}", "{}", created, updated,
-			),
-		)
+		WillReturnRows(sqlmock.NewRows(comicSelectColumns()).AddRow(
+			id, string(comicSource), comicSlug, comicTitle, string(comicStatus), string(comicType),
+			200, "Chugong", "Dubu", "desc",
+			"{}", "{}", created, created,
+		))
 
 	got, err := r.GetMany(context.Background(), comics.GetManyOpts{
 		UserID: &userID,
 		Limit:  10,
+		Sort:   comics.ListSortTitle,
+		Order:  comics.ListOrderAsc,
 	})
 	if err != nil {
 		t.Fatalf("GetMany: %v", err)
 	}
 
-	if len(got.Items) != 1 || got.Items[0].ID != id {
+	if got.Total != 1 || len(got.Items) != 1 || got.Items[0].ID != id {
 		t.Errorf("GetMany() = %+v", got)
+	}
+}
+
+func TestGetManyFiltersTypeOnComicTypeColumn(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newComicsRepo(t)
+	userID := uuid.New()
+	typ := comicType
+
+	mock.ExpectQuery(`SELECT count\(\*\).*comic_type`).
+		WithArgs(userID, string(typ)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(0)))
+
+	mock.ExpectQuery(`FROM "comics".*comic_type`).
+		WithArgs(userID, string(typ), 10).
+		WillReturnRows(sqlmock.NewRows(comicSelectColumns()))
+
+	got, err := r.GetMany(context.Background(), comics.GetManyOpts{
+		UserID: &userID,
+		Type:   &typ,
+		Limit:  10,
+		Sort:   comics.ListSortTitle,
+		Order:  comics.ListOrderAsc,
+	})
+	if err != nil {
+		t.Fatalf("GetMany: %v", err)
+	}
+
+	if got.Total != 0 || len(got.Items) != 0 {
+		t.Errorf("GetMany() = %+v", got)
+	}
+}
+
+func TestGetManySearchTitleOrAltTitles(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newComicsRepo(t)
+	userID := uuid.New()
+	pattern := `%solo%`
+
+	mock.ExpectQuery(`SELECT count\(\*\).*ILIKE`).
+		WithArgs(userID, pattern, pattern).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(2)))
+
+	mock.ExpectQuery(`FROM "comics".*ILIKE.*unnest`).
+		WithArgs(userID, pattern, pattern, 10).
+		WillReturnRows(sqlmock.NewRows(comicSelectColumns()))
+
+	got, err := r.GetMany(context.Background(), comics.GetManyOpts{
+		UserID: &userID,
+		Search: "solo",
+		Limit:  10,
+		Sort:   comics.ListSortTitle,
+		Order:  comics.ListOrderAsc,
+	})
+	if err != nil {
+		t.Fatalf("GetMany: %v", err)
+	}
+
+	if got.Total != 2 {
+		t.Errorf("Total = %d, want 2", got.Total)
+	}
+}
+
+func TestGetManySearchEscapesLikeMetacharacters(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newComicsRepo(t)
+	userID := uuid.New()
+	pattern := `%100\%%`
+
+	mock.ExpectQuery(`SELECT count\(\*\).*ILIKE`).
+		WithArgs(userID, pattern, pattern).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(0)))
+
+	mock.ExpectQuery(`FROM "comics".*ILIKE`).
+		WithArgs(userID, pattern, pattern, 10).
+		WillReturnRows(sqlmock.NewRows(comicSelectColumns()))
+
+	_, err := r.GetMany(context.Background(), comics.GetManyOpts{
+		UserID: &userID,
+		Search: "100%",
+		Limit:  10,
+		Sort:   comics.ListSortTitle,
+		Order:  comics.ListOrderAsc,
+	})
+	if err != nil {
+		t.Fatalf("GetMany: %v", err)
+	}
+}
+
+func TestGetManySortAddedAtDesc(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newComicsRepo(t)
+	userID := uuid.New()
+
+	mock.ExpectQuery(`SELECT count\(\*\).*JOIN library_entries`).
+		WithArgs(userID).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(0)))
+
+	mock.ExpectQuery(`FROM "comics".*library_entries.added_at DESC`).
+		WithArgs(userID, 10).
+		WillReturnRows(sqlmock.NewRows(comicSelectColumns()))
+
+	_, err := r.GetMany(context.Background(), comics.GetManyOpts{
+		UserID: &userID,
+		Limit:  10,
+		Sort:   comics.ListSortAddedAt,
+		Order:  comics.ListOrderDesc,
+	})
+	if err != nil {
+		t.Fatalf("GetMany: %v", err)
+	}
+}
+
+func TestGetManyOffset(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newComicsRepo(t)
+	userID := uuid.New()
+
+	mock.ExpectQuery(`SELECT count\(\*\)`).
+		WithArgs(userID).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(40)))
+
+	mock.ExpectQuery(`FROM "comics".*JOIN library_entries`).
+		WithArgs(userID, 10, 20).
+		WillReturnRows(sqlmock.NewRows(comicSelectColumns()))
+
+	got, err := r.GetMany(context.Background(), comics.GetManyOpts{
+		UserID: &userID,
+		Limit:  10,
+		Offset: 20,
+		Sort:   comics.ListSortTitle,
+		Order:  comics.ListOrderAsc,
+	})
+	if err != nil {
+		t.Fatalf("GetMany: %v", err)
+	}
+
+	if got.Total != 40 {
+		t.Errorf("Total = %d, want 40", got.Total)
 	}
 }
 

--- a/api/pkg/core/comics/repository/pg/repository_test.go
+++ b/api/pkg/core/comics/repository/pg/repository_test.go
@@ -297,7 +297,7 @@ func TestGetMany(t *testing.T) {
 		t.Fatalf("GetMany: %v", err)
 	}
 
-	if len(got) != 1 || got[0].ID != id {
+	if len(got.Items) != 1 || got.Items[0].ID != id {
 		t.Errorf("GetMany() = %+v", got)
 	}
 }

--- a/api/pkg/core/comics/service.go
+++ b/api/pkg/core/comics/service.go
@@ -239,13 +239,13 @@ func (s *Service) ServeCover(ctx context.Context, opts GetByIDOpts) (string, str
 	return path, contentType, nil
 }
 
-func (s *Service) GetMany(ctx context.Context, opts GetManyOpts) ([]Comic, error) {
-	comics, err := s.deps.ComicsRepository.GetMany(ctx, opts)
+func (s *Service) GetMany(ctx context.Context, opts GetManyOpts) (Page, error) {
+	page, err := s.deps.ComicsRepository.GetMany(ctx, opts)
 	if err != nil {
-		return nil, fmt.Errorf("s.deps.ComicsRepository.GetMany: %w", err)
+		return Page{}, fmt.Errorf("s.deps.ComicsRepository.GetMany: %w", err)
 	}
 
-	return comics, nil
+	return page, nil
 }
 
 func (s *Service) Delete(ctx context.Context, opts DeleteOpts) error {

--- a/api/pkg/core/comics/service_test.go
+++ b/api/pkg/core/comics/service_test.go
@@ -94,7 +94,7 @@ type fakeComicsRepository struct {
 	createResult           *comics.Comic
 	lastListByStatuses     comics.ListByStatusesOpts
 	listByStatusesResult   []comics.Comic
-	getManyResult          []comics.Comic
+	getManyResult          comics.Page
 	lastUpdateStatus       comics.UpdateStatusAndChapterCountOpts
 	lastCreateOpts         comics.CreateComicOpts
 	findBySourceSlugCalls  int
@@ -168,7 +168,7 @@ func (f *fakeComicsRepository) Delete(_ context.Context, id uuid.UUID) error {
 	return f.deleteErr
 }
 
-func (f *fakeComicsRepository) GetMany(_ context.Context, _ comics.GetManyOpts) ([]comics.Comic, error) {
+func (f *fakeComicsRepository) GetMany(_ context.Context, _ comics.GetManyOpts) (comics.Page, error) {
 	f.getManyCalls++
 
 	return f.getManyResult, f.getManyErr
@@ -770,7 +770,7 @@ func TestGetManyDelegatesToRepository(t *testing.T) {
 
 	userID := uuid.New()
 	items := []comics.Comic{{ID: uuid.New(), Slug: testSlug}}
-	repo := &fakeComicsRepository{getManyResult: items}
+	repo := &fakeComicsRepository{getManyResult: comics.Page{Items: items}}
 	deps := validServiceDeps()
 	deps.ComicsRepository = repo
 
@@ -784,8 +784,8 @@ func TestGetManyDelegatesToRepository(t *testing.T) {
 		t.Fatalf("GetMany: %v", err)
 	}
 
-	if len(got) != 1 || got[0].ID != items[0].ID {
-		t.Errorf("GetMany() = %+v, want %+v", got, items)
+	if len(got.Items) != 1 || got.Items[0].ID != items[0].ID {
+		t.Errorf("GetMany() = %+v, want %+v", got.Items, items)
 	}
 }
 

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -316,8 +316,8 @@ func (stubComicsRepository) Delete(context.Context, uuid.UUID) error {
 	return coredomain.ErrNotFound
 }
 
-func (stubComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]comics.Comic, error) {
-	return nil, nil
+func (stubComicsRepository) GetMany(context.Context, comics.GetManyOpts) (comics.Page, error) {
+	return comics.Page{}, nil
 }
 
 func (stubComicsRepository) ListByStatuses(context.Context, comics.ListByStatusesOpts) ([]comics.Comic, error) {
@@ -338,8 +338,8 @@ func (fakeComicsService) GetByID(context.Context, comics.GetByIDOpts) (*comics.C
 	return nil, errors.New(notImplemented)
 }
 
-func (fakeComicsService) GetMany(context.Context, comics.GetManyOpts) ([]comics.Comic, error) {
-	return nil, errors.New(notImplemented)
+func (fakeComicsService) GetMany(context.Context, comics.GetManyOpts) (comics.Page, error) {
+	return comics.Page{}, errors.New(notImplemented)
 }
 
 func (fakeComicsService) Delete(context.Context, comics.DeleteOpts) error {

--- a/api/pkg/sources/asurascans/pkg/core/app_test.go
+++ b/api/pkg/sources/asurascans/pkg/core/app_test.go
@@ -57,8 +57,8 @@ func (stubComicsRepository) Delete(context.Context, uuid.UUID) error {
 	return coredomain.ErrNotFound
 }
 
-func (stubComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]comics.Comic, error) {
-	return nil, nil
+func (stubComicsRepository) GetMany(context.Context, comics.GetManyOpts) (comics.Page, error) {
+	return comics.Page{}, nil
 }
 
 func (stubComicsRepository) ListByStatuses(context.Context, comics.ListByStatusesOpts) ([]comics.Comic, error) {
@@ -108,8 +108,8 @@ func (r libraryComicsRepository) Delete(context.Context, uuid.UUID) error {
 	return coredomain.ErrNotFound
 }
 
-func (r libraryComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]comics.Comic, error) {
-	return nil, nil
+func (r libraryComicsRepository) GetMany(context.Context, comics.GetManyOpts) (comics.Page, error) {
+	return comics.Page{}, nil
 }
 
 func (r libraryComicsRepository) ListByStatuses(context.Context, comics.ListByStatusesOpts) ([]comics.Comic, error) {
@@ -163,8 +163,8 @@ func (r inLibraryComicsRepository) Delete(context.Context, uuid.UUID) error {
 	return coredomain.ErrNotFound
 }
 
-func (r inLibraryComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]comics.Comic, error) {
-	return nil, nil
+func (r inLibraryComicsRepository) GetMany(context.Context, comics.GetManyOpts) (comics.Page, error) {
+	return comics.Page{}, nil
 }
 
 func (r inLibraryComicsRepository) ListByStatuses(context.Context, comics.ListByStatusesOpts) ([]comics.Comic, error) {

--- a/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
+++ b/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
@@ -67,8 +67,8 @@ func (stubComicsRepository) Delete(context.Context, uuid.UUID) error {
 	return coredomain.ErrNotFound
 }
 
-func (stubComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]comics.Comic, error) {
-	return nil, nil
+func (stubComicsRepository) GetMany(context.Context, comics.GetManyOpts) (comics.Page, error) {
+	return comics.Page{}, nil
 }
 
 func (stubComicsRepository) ListByStatuses(context.Context, comics.ListByStatusesOpts) ([]comics.Comic, error) {
@@ -117,8 +117,8 @@ func (r inLibraryComicsRepository) Delete(context.Context, uuid.UUID) error {
 	return coredomain.ErrNotFound
 }
 
-func (r inLibraryComicsRepository) GetMany(context.Context, comics.GetManyOpts) ([]comics.Comic, error) {
-	return nil, nil
+func (r inLibraryComicsRepository) GetMany(context.Context, comics.GetManyOpts) (comics.Page, error) {
+	return comics.Page{}, nil
 }
 
 func (r inLibraryComicsRepository) ListByStatuses(context.Context, comics.ListByStatusesOpts) ([]comics.Comic, error) {


### PR DESCRIPTION
## Summary

- Reworks `GET /api/comics` to return `{ items, total }` with camelCase fields (`chapterCount`, `cover`, etc.) instead of a raw array
- Adds `search` (title + alt titles, case-insensitive), `sort` (`title` | `addedAt`), and `order` (`asc` | `desc`) query params; defaults to title ascending
- Fixes the `type` filter to query `comic_type`, and scopes results to the authenticated user's library with filtered `total` for pagination

Closes #53

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] `GET /api/comics` returns `{ items, total }` with all required fields (`id`, `title`, `slug`, `source`, `status`, `type`, `chapterCount`, `cover`)
- [x] Filters: `source`, `type`, `status`, `search` work as expected
- [x] Sort: `sort=title|addedAt`, `order=asc|desc`; defaults to title + asc
- [x] Pagination via `limit` / `offset`; `total` reflects filtered count
- [x] Invalid query params → 400; unauthenticated → 401
- [x] User A cannot see user B's library entries