### PR TITLE
feat(web): nav + post-login landing on /feed

### DIFF
--- a/web/app/components/Organism/BottomNavigation/index.vue
+++ b/web/app/components/Organism/BottomNavigation/index.vue
@@ -8,17 +8,15 @@ defineProps<{
 </script>
 
 <template>
-  <footer class="">
-    <div
-      class="position-fixed bottom-0 w-100 pa-4 nvagation-bottom h-100 bg-surface border-thin elevation-down d-flex justify-space-evenly"
-      style="border-top-left-radius: 12px; border-top-right-radius: 12px;"
-    >
-      <OrganismBottomNavigationItem
-        v-for="(item, index) in items"
-        :key="index"
-        v-bind="item"
-      />
-    </div>
+  <footer
+    class="position-fixed bottom-0 w-100 nvagation-bottom h-100 bg-surface border-thin elevation-down d-flex justify-space-evenly"
+    style="border-top-left-radius: 12px; border-top-right-radius: 12px;"
+  >
+    <OrganismBottomNavigationItem
+      v-for="(item, index) in items"
+      :key="index"
+      v-bind="item"
+    />
   </footer>
 </template>
 

--- a/web/app/components/Organism/NavigationDrawer/index.vue
+++ b/web/app/components/Organism/NavigationDrawer/index.vue
@@ -1,6 +1,7 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script setup lang="ts">
 import type { NavigationDrawerListProps } from './List/index.vue'
+import { DEFAULT_PAGE } from '~/constants'
 
 defineProps<{
   logoutLoading: boolean
@@ -29,7 +30,7 @@ watch(compact, (value) => {
       style="border-radius: 16px;"
     >
       <div class="d-flex flex-column" :class="{ 'ga-6': !compact, 'ga-2': compact }">
-        <AtomLink to="/">
+        <AtomLink :to="DEFAULT_PAGE">
           <AtomProjectLogo :compact :class="{ 'mb-6': compact }" />
         </AtomLink>
 

--- a/web/app/constants/index.ts
+++ b/web/app/constants/index.ts
@@ -4,7 +4,7 @@ import type { RouteLocationRaw } from 'vue-router'
 export const APP_NAME = 'Uchiyomi'
 export const APP_DESCRIPTION = 'Self-hosted manga & webtoon server with a modern PWA.'
 
-export const DEFAULT_PAGE: RouteLocationRaw = '/'
+export const DEFAULT_PAGE: RouteLocationRaw = '/feed'
 
 export const ASURA_SCANS_URL = 'https://asurascans.com'
 

--- a/web/app/features/asura/components/Comic/Chapters/Item.vue
+++ b/web/app/features/asura/components/Comic/Chapters/Item.vue
@@ -119,6 +119,7 @@ const isChapterDownloadingError = computed(() => props.chapter.internalId && pro
 .readable-chapter {
   &:hover {
     color: rgb(var(--v-theme-primary));
+    background-color: rgba(var(--v-theme-surface-variant));
   }
 }
 

--- a/web/app/layouts/default.vue
+++ b/web/app/layouts/default.vue
@@ -40,6 +40,25 @@ const settingsNavItems = computed((): NavigationDrawerListItemProps[] => {
 
 const navigationDrawerItems = computed((): NavigationDrawerListProps[] => [
   {
+    title: t('reading.title'),
+    items: [
+      {
+        title: t('feed.title'),
+        to: '/feed',
+        icon: 'fa6-solid:clock-rotate-left',
+        isActiveFn: (route: RouteLocationNormalized) => route.path.startsWith('/feed'),
+        baseRoute: '/feed',
+      },
+      {
+        title: t('library.title'),
+        to: '/library',
+        icon: 'fa6-solid:book',
+        isActiveFn: (route: RouteLocationNormalized) => route.path.startsWith('/library'),
+        baseRoute: '/library',
+      },
+    ],
+  },
+  {
     title: t('browse.title'),
     items: [
       {
@@ -58,6 +77,18 @@ const navigationDrawerItems = computed((): NavigationDrawerListProps[] => [
 ])
 
 const bottomNavigationItems = computed((): BottomNavigationItemProps[] => [
+  {
+    to: '/feed',
+    icon: 'fa6-solid:clock-rotate-left',
+    isActiveFn: (route: RouteLocationNormalized) => route.path.startsWith('/feed'),
+    baseRoute: '/feed',
+  },
+  {
+    to: '/library',
+    icon: 'fa6-solid:book',
+    isActiveFn: (route: RouteLocationNormalized) => route.path.startsWith('/library'),
+    baseRoute: '/library',
+  },
   {
     to: '/browse',
     icon: 'fa6-solid:compass',

--- a/web/app/pages/feed.vue
+++ b/web/app/pages/feed.vue
@@ -5,6 +5,9 @@ import { AUTHENTICATED_ROUTE_GROUP } from '~/constants/auth'
 definePageMeta({
   layout: 'default',
   authGroups: [AUTHENTICATED_ROUTE_GROUP],
-  redirect: '/feed',
 })
 </script>
+
+<template>
+  <OrganismPageLayout :title="$t('feed.title')" />
+</template>

--- a/web/app/pages/library.vue
+++ b/web/app/pages/library.vue
@@ -5,6 +5,9 @@ import { AUTHENTICATED_ROUTE_GROUP } from '~/constants/auth'
 definePageMeta({
   layout: 'default',
   authGroups: [AUTHENTICATED_ROUTE_GROUP],
-  redirect: '/feed',
 })
 </script>
+
+<template>
+  <OrganismPageLayout :title="$t('library.title')" />
+</template>

--- a/web/app/utils/guards/auth-guard.test.ts
+++ b/web/app/utils/guards/auth-guard.test.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, expect, it } from 'vitest'
+import { DEFAULT_PAGE } from '~/constants'
 import { ADMIN_ROUTE_GROUP, AUTHENTICATED_ROUTE_GROUP, NOT_AUTHENTICATED_ROUTE_GROUP } from '~/constants/auth'
 import { requiresAuthCheck, resolveAuthGuard } from './auth-guard'
 import { routeStub } from './route.stub'
@@ -44,7 +45,7 @@ describe('resolveAuthGuard', () => {
   it('redirects an authenticated user on /login back to home', () => {
     const login = routeStub({ name: 'login', fullPath: '/login', meta: { authGroups: [NOT_AUTHENTICATED_ROUTE_GROUP] } })
 
-    expect(resolveAuthGuard({ to: login, ...USER })).toBe('/')
+    expect(resolveAuthGuard({ to: login, ...USER })).toBe(DEFAULT_PAGE)
     expect(resolveAuthGuard({ to: login, ...ANONYMOUS })).toBeUndefined()
   })
 })
@@ -57,7 +58,7 @@ describe('resolveAuthGuard, admin group', () => {
   })
 
   it('redirects authenticated user without rights to home', () => {
-    expect(resolveAuthGuard({ to: admin, ...USER })).toBe('/')
+    expect(resolveAuthGuard({ to: admin, ...USER })).toBe(DEFAULT_PAGE)
   })
 
   it('allows an admin through', () => {

--- a/web/app/utils/guards/setup-guard.test.ts
+++ b/web/app/utils/guards/setup-guard.test.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, expect, it } from 'vitest'
+import { DEFAULT_PAGE } from '~/constants'
 import { routeStub } from './route.stub'
 import { requiresSetupCheck, resolveSetupGuard } from './setup-guard'
 
@@ -33,7 +34,7 @@ describe('resolveSetupGuard', () => {
   })
 
   it('redirects completed setup to home', () => {
-    expect(resolveSetupGuard(setup, 'done')).toBe('/')
+    expect(resolveSetupGuard(setup, 'done')).toBe(DEFAULT_PAGE)
   })
 
   it('redirects to /status when status is indeterminate', () => {

--- a/web/app/utils/redirect.test.ts
+++ b/web/app/utils/redirect.test.ts
@@ -6,6 +6,7 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
 import { createMemoryHistory, createRouter } from 'vue-router'
+import { DEFAULT_PAGE } from '~/constants'
 import { safeRedirect } from './redirect'
 import { STATUS_PATH } from './routes'
 
@@ -55,46 +56,46 @@ describe('safeRedirect', () => {
     expect(safeRedirect('/library?page=2')).toBe('/library?page=2')
   })
 
-  it('falls back to / when the parameter is absent', () => {
-    expect(safeRedirect(undefined)).toBe('/')
+  it('falls back to the default page when the parameter is absent', () => {
+    expect(safeRedirect(undefined)).toBe(DEFAULT_PAGE)
   })
 
-  it('falls back to / when the key is repeated and vue-router returns an array', () => {
-    expect(safeRedirect(['/a', '/b'])).toBe('/')
+  it('falls back to the default page when the key is repeated and vue-router returns an array', () => {
+    expect(safeRedirect(['/a', '/b'])).toBe(DEFAULT_PAGE)
   })
 
   it('rejects an absolute URL', () => {
-    expect(safeRedirect('https://evil.com')).toBe('/')
+    expect(safeRedirect('https://evil.com')).toBe(DEFAULT_PAGE)
   })
 
   it('rejects a protocol-relative URL', () => {
-    expect(safeRedirect('//evil.com')).toBe('/')
+    expect(safeRedirect('//evil.com')).toBe(DEFAULT_PAGE)
   })
 
   it('rejects a backslash, which some browsers normalize to /', () => {
-    expect(safeRedirect(String.raw`/\evil.com`)).toBe('/')
+    expect(safeRedirect(String.raw`/\evil.com`)).toBe(DEFAULT_PAGE)
   })
 
   it('rejects a relative path without a leading /', () => {
-    expect(safeRedirect('library')).toBe('/')
+    expect(safeRedirect('library')).toBe(DEFAULT_PAGE)
   })
 
   it('rejects a path that matches no route', () => {
     resolve.fn = () => ({ matched: [] })
 
-    expect(safeRedirect('/nope')).toBe('/')
+    expect(safeRedirect('/nope')).toBe(DEFAULT_PAGE)
   })
 
   it('rejects /status, which would redirect to itself', () => {
-    expect(safeRedirect(STATUS_PATH)).toBe('/')
+    expect(safeRedirect(STATUS_PATH)).toBe(DEFAULT_PAGE)
   })
 
   it('rejects /status even when it carries a query string', () => {
-    expect(safeRedirect('/status?redirect=%2Flibrary')).toBe('/')
+    expect(safeRedirect('/status?redirect=%2Flibrary')).toBe(DEFAULT_PAGE)
   })
 
   it('rejects /status even when it carries a fragment', () => {
-    expect(safeRedirect('/status#bas')).toBe('/')
+    expect(safeRedirect('/status#bas')).toBe(DEFAULT_PAGE)
   })
 
   it('accepts a path only prefixed by /status', () => {
@@ -102,16 +103,16 @@ describe('safeRedirect', () => {
   })
 
   it('rejects /status with a trailing slash', () => {
-    expect(safeRedirect('/status/')).toBe('/')
+    expect(safeRedirect('/status/')).toBe(DEFAULT_PAGE)
   })
 
   it('rejects /status regardless of case', () => {
-    expect(safeRedirect('/Status')).toBe('/')
+    expect(safeRedirect('/Status')).toBe(DEFAULT_PAGE)
   })
 
   it('rejects /status carrying both a query and a fragment', () => {
-    expect(safeRedirect('/status?redirect=%2Fa#bas')).toBe('/')
-    expect(safeRedirect('/status#bas?redirect=%2Fa')).toBe('/')
+    expect(safeRedirect('/status?redirect=%2Fa#bas')).toBe(DEFAULT_PAGE)
+    expect(safeRedirect('/status#bas?redirect=%2Fa')).toBe(DEFAULT_PAGE)
   })
 })
 
@@ -144,10 +145,10 @@ describe('safeRedirect with router', () => {
   })
 
   it('rejects a missing parameter segment', () => {
-    expect(safeRedirect('/source')).toBe('/')
+    expect(safeRedirect('/source')).toBe(DEFAULT_PAGE)
   })
 
   it('rejects an absolute URL without even consulting the router', () => {
-    expect(safeRedirect('https://evil.com/x')).toBe('/')
+    expect(safeRedirect('https://evil.com/x')).toBe(DEFAULT_PAGE)
   })
 })

--- a/web/i18n/locales/en.json
+++ b/web/i18n/locales/en.json
@@ -301,5 +301,14 @@
       "author": "Author",
       "artist": "Artist"
     }
+  },
+  "library": {
+    "title": "Library"
+  },
+  "feed": {
+    "title": "Feed"
+  },
+  "reading": {
+    "title": "Reading"
   }
 }

--- a/web/i18n/locales/fr.json
+++ b/web/i18n/locales/fr.json
@@ -294,5 +294,14 @@
         "alreadyExists": " Série déjà en bibliothèque"
       }
     }
+  },
+  "library": {
+    "title": "Bibliothèque"
+  },
+  "feed": {
+    "title": "Flux"
+  },
+  "reading": {
+    "title": "Lire"
   }
 }


### PR DESCRIPTION
## Summary

Closes #57.

- Set `DEFAULT_PAGE` to `/feed` so password login and OIDC fallbacks land on Feed
- Redirect `/` to `/feed` (old links still work)
- Add authenticated stub pages for `/feed` and `/library`
- Extend desktop drawer with a Reading section (Feed, Library) above Browse
- Extend mobile bottom nav with Feed and Library (Feed, Library, Browse, Settings)
- Add `en` and `fr` i18n strings for new nav labels
- Update auth, setup, and redirect tests to use `DEFAULT_PAGE`

## Screenshots

### Desktop
<img width="2506" height="1357" alt="image" src="https://github.com/user-attachments/assets/3d031da4-30fb-49a2-8c0a-1da67468163e" />

### Mobile
<img width="317" height="678" alt="image" src="https://github.com/user-attachments/assets/e8a8c3e5-836d-41f6-83e3-ba274e5e8ee1" />


## Test plan

- [x] Visit `/` while authenticated → redirected to `/feed`
- [x] Password login without `?redirect=` → lands on `/feed`
- [x] OIDC callback with empty/unsafe redirect → lands on `/feed`
- [x] Desktop drawer shows Feed, Library, Sources, Settings (admin OIDC items unchanged)
- [x] Mobile bottom bar shows Feed, Library, Browse, Settings with correct active states
- [x] `/feed` and `/library` require authentication
- [x] `pnpm test`, `pnpm typecheck`, `pnpm lint` pass