### PR TITLE
feat(feed): GET /api/feed with latest unlocked chapters

### DIFF
--- a/.vscode/uchiyomi.code-workspace
+++ b/.vscode/uchiyomi.code-workspace
@@ -32,8 +32,6 @@
             ".conductor": true,
             ".superpowers": true,
             ".nuxtrc": true,
-            "docs/superpowers/": true,
-            "docs/design/": true,
             "**/node_modules": true,
             "**/bower_components": true,
             "**/*.code-search": true,

--- a/api/cmd/uchiyomiserver/setup.go
+++ b/api/cmd/uchiyomiserver/setup.go
@@ -50,6 +50,9 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
 	httpcovers "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/gateway/http"
 	coversasura "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/source/asurascans"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/feed"
+	httpfeed "github.com/kharente-deuh/uchiyomi-server/pkg/core/feed/gateway/http"
+	pgfeed "github.com/kharente-deuh/uchiyomi-server/pkg/core/feed/repository/pg"
 	httphealth "github.com/kharente-deuh/uchiyomi-server/pkg/core/health/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/library"
 	pglibrary "github.com/kharente-deuh/uchiyomi-server/pkg/core/library/repository/pg"
@@ -133,6 +136,11 @@ func setupApp(cfg *cfg) (*core.App, error) {
 		return nil, fmt.Errorf("failed to init chapters: %w", err)
 	}
 
+	feedSvc, err := feed.NewService(feed.Deps{FeedRepository: dbr.FeedRepository, Now: time.Now})
+	if err != nil {
+		return nil, fmt.Errorf("failed to init feedSvc: %w", err)
+	}
+
 	asuraApp.BindChaptersService(chaptersSvc)
 
 	comicsSvc, err := comics.NewService(comics.Deps{
@@ -165,6 +173,7 @@ func setupApp(cfg *cfg) (*core.App, error) {
 		Logger:               logger,
 		ComicsService:        comicsSvc,
 		ChaptersService:      chaptersSvc,
+		FeedService:          feedSvc,
 		SessionsService:      services.Sessions,
 		SetupService:         services.Setup,
 		AuthService:          services.Auth,
@@ -193,6 +202,7 @@ func setupApp(cfg *cfg) (*core.App, error) {
 			OIDCProvidersCtrl: ctrls.OIDCProviders,
 			ComicsCtrl:        ctrls.Comics,
 			ChaptersCtrl:      ctrls.Chapters,
+			FeedCtrl:          ctrls.Feed,
 
 			Health:             registry,
 			Logger:             logger,
@@ -222,6 +232,7 @@ type dbRelated struct {
 	ComicsRepository              *pgcomics.PGComicsRepository
 	ChaptersRepository            *pgchapters.PGChaptersRepository
 	LibraryRepository             *pglibrary.PGLibraryRepository
+	FeedRepository                *pgfeed.PGFeedRepository
 }
 
 func setupDBRelated(c *cfg, logger *slog.Logger) (*dbRelated, error) {
@@ -286,6 +297,11 @@ func setupDBRelated(c *cfg, logger *slog.Logger) (*dbRelated, error) {
 		return nil, fmt.Errorf("failed to init libraryRepository: %w", err)
 	}
 
+	feedRepository, err := pgfeed.New(pgfeed.Deps{DB: pgdb.DB})
+	if err != nil {
+		return nil, fmt.Errorf("failed to init feedRepository: %w", err)
+	}
+
 	dbr := &dbRelated{
 		PGDB:                          pgdb,
 		Txor:                          txor,
@@ -297,6 +313,7 @@ func setupDBRelated(c *cfg, logger *slog.Logger) (*dbRelated, error) {
 		ComicsRepository:              comicsRepository,
 		ChaptersRepository:            chaptersRepository,
 		LibraryRepository:             libraryRepository,
+		FeedRepository:                feedRepository,
 	}
 
 	return dbr, nil
@@ -701,9 +718,11 @@ type ctrls struct {
 	OIDCProviders *httpoidcproviders.Controller
 	Comics        *httpcomics.Controller
 	Chapters      *httpchapters.Controller
+	Feed          *httpfeed.Controller
 }
 
 type ctrlsDeps struct {
+	FeedService          feed.FeedService
 	AsuraApp             *asura.App
 	CoversService        *covers.Service
 	SetupService         *setup.Service
@@ -861,6 +880,20 @@ func setupCtrls(deps ctrlsDeps) (*ctrls, error) {
 		return nil, fmt.Errorf("failed to init chapters controller: %w", err)
 	}
 
+	feedCtrl, err := httpfeed.New(
+		httpfeed.Config{
+			Endpoint:    "/feed",
+			Middlewares: chi.Middlewares{authenticator.Middleware},
+		},
+		httpfeed.Deps{
+			Logger:      deps.Logger,
+			FeedService: deps.FeedService,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init feed controller: %w", err)
+	}
+
 	c := &ctrls{
 		Asura:         asuraCtrl,
 		Covers:        coversCtrl,
@@ -871,6 +904,7 @@ func setupCtrls(deps ctrlsDeps) (*ctrls, error) {
 		OIDCProviders: oidcProvidersCtrl,
 		Comics:        comicsCtrl,
 		Chapters:      chaptersCtrl,
+		Feed:          feedCtrl,
 	}
 
 	return c, nil

--- a/api/cmd/uchiyomiserver/setup_internal_test.go
+++ b/api/cmd/uchiyomiserver/setup_internal_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
 	coredomain "github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/feed"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/users"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/health"
 )
@@ -68,6 +69,12 @@ func (stubComicsRepository) ListByStatuses(context.Context, comics.ListByStatuse
 
 func (stubComicsRepository) UpdateStatusAndChapterCount(context.Context, comics.UpdateStatusAndChapterCountOpts) error {
 	return nil
+}
+
+type stubFeedService struct{}
+
+func (stubFeedService) Get(context.Context, feed.GetOpts) (feed.Page, error) {
+	return feed.Page{Items: []feed.Item{}, Total: 0}, nil
 }
 
 type emptyOIDCProvidersRepository struct{}
@@ -241,6 +248,7 @@ func newTestCtrlsForUser(t *testing.T, user *users.User) *ctrls {
 		Logger:               logger,
 		Registry:             health.NewRegistry(),
 		OIDCProvidersService: newTestOIDCProvidersService(t),
+		FeedService:          stubFeedService{},
 	})
 	if err != nil {
 		t.Fatalf("setupCtrls: %v", err)

--- a/api/pkg/core/app.go
+++ b/api/pkg/core/app.go
@@ -20,6 +20,7 @@ import (
 	httpcomics "github.com/kharente-deuh/uchiyomi-server/pkg/core/comics/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
 	httpcovers "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/gateway/http"
+	httpfeed "github.com/kharente-deuh/uchiyomi-server/pkg/core/feed/gateway/http"
 	httphealth "github.com/kharente-deuh/uchiyomi-server/pkg/core/health/gateway/http"
 	httpsetup "github.com/kharente-deuh/uchiyomi-server/pkg/core/setup/gateway/http"
 	httpusers "github.com/kharente-deuh/uchiyomi-server/pkg/core/users/gateway/http"
@@ -74,6 +75,7 @@ type Deps struct {
 	UsersCtrl         *httpusers.Controller
 	ComicsCtrl        *httpcomics.Controller
 	ChaptersCtrl      *httpchapters.Controller
+	FeedCtrl          *httpfeed.Controller
 	OIDCProvidersCtrl *httpoidcproviders.Controller
 
 	Logger *slog.Logger
@@ -154,6 +156,10 @@ func (deps *Deps) Validate() error {
 
 	if deps.ChaptersCtrl == nil {
 		return errors.New("chaptersCtrl is required")
+	}
+
+	if deps.FeedCtrl == nil {
+		return errors.New("feedCtrl is required")
 	}
 
 	if deps.Health == nil {
@@ -293,6 +299,7 @@ func (a *App) newRouter(ui http.Handler) chi.Router {
 			a.deps.OIDCProvidersCtrl.InitRouter(r)
 			a.deps.ComicsCtrl.InitRouter(r)
 			a.deps.ChaptersCtrl.InitRouter(r)
+			a.deps.FeedCtrl.InitRouter(r)
 			r.Route("/sources", func(r chi.Router) {
 				a.deps.CoversCtrl.InitRouter(r)
 				a.deps.AsuraCtrl.InitRouter(r)

--- a/api/pkg/core/app_internal_test.go
+++ b/api/pkg/core/app_internal_test.go
@@ -28,6 +28,21 @@ func TestRouterMountsTheOIDCProvidersRoutes(t *testing.T) {
 	}
 }
 
+func TestRouterMountsTheFeedRoute(t *testing.T) {
+	t.Parallel()
+
+	app, _ := newTestApp(t, &fakeDB{}, gatePort)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/feed/", nil)
+	rec := httptest.NewRecorder()
+
+	app.newRouter(nil).ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusNotFound {
+		t.Errorf("GET /api/feed/ = 404, want the route to be mounted")
+	}
+}
+
 func TestRouterMountsTheOIDCCallbackAdvertisedAsRedirectURI(t *testing.T) {
 	t.Parallel()
 

--- a/api/pkg/core/feed/domain.go
+++ b/api/pkg/core/feed/domain.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package feed
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+)
+
+type LatestChapter struct {
+	PublishedAt      time.Time
+	EarlyAccessUntil time.Time
+	Title            string
+	Number           float64
+	Download         int
+	ID               uuid.UUID
+	ComicID          uuid.UUID
+}
+
+type Item struct {
+	Title          string
+	Slug           string
+	Source         sources.SourceName
+	Status         sources.SeriesStatus
+	Type           sources.SeriesType
+	LatestChapters []LatestChapter
+	ID             uuid.UUID
+}
+
+type Page struct {
+	Items []Item
+	Total int64
+}
+
+type GetOpts struct {
+	Source *sources.SourceName
+	Type   *sources.SeriesType
+	Status *sources.SeriesStatus
+	UserID uuid.UUID
+	Limit  int
+	Offset int
+}
+
+type ListPageOpts struct {
+	Now    time.Time
+	Source *sources.SourceName
+	Type   *sources.SeriesType
+	Status *sources.SeriesStatus
+	UserID uuid.UUID
+	Limit  int
+	Offset int
+}
+
+type ListChaptersOpts struct {
+	Now      time.Time
+	ComicIDs []uuid.UUID
+}
+
+type FeedRepository interface {
+	ListPage(context.Context, ListPageOpts) (Page, error)
+	ListUnlockedChapters(context.Context, ListChaptersOpts) ([]LatestChapter, error)
+}
+
+type FeedService interface {
+	Get(context.Context, GetOpts) (Page, error)
+}
+
+func IsUnlocked(earlyAccessUntil, now time.Time) bool {
+	return !earlyAccessUntil.After(now)
+}
+
+func AvailabilityAt(publishedAt, earlyAccessUntil, now time.Time) time.Time {
+	if !earlyAccessUntil.IsZero() && !earlyAccessUntil.After(now) {
+		return earlyAccessUntil
+	}
+
+	return publishedAt
+}

--- a/api/pkg/core/feed/domain_test.go
+++ b/api/pkg/core/feed/domain_test.go
@@ -20,9 +20,9 @@ func TestIsUnlocked(t *testing.T) {
 		now   time.Time
 		want  bool
 	}{
-		"zero is unlocked":          {until: time.Time{}, now: now, want: true},
+		"zero is unlocked":           {until: time.Time{}, now: now, want: true},
 		"future early access locked": {until: aug20, now: now, want: false},
-		"equal now is unlocked":     {until: now, now: now, want: true},
+		"equal now is unlocked":      {until: now, now: now, want: true},
 		"past early access unlocked": {until: aug20, now: time.Date(2026, time.August, 21, 0, 0, 0, 0, time.UTC), want: true},
 	}
 
@@ -52,7 +52,11 @@ func TestAvailabilityAtAugustScenario(t *testing.T) {
 	}
 
 	if got := feed.AvailabilityAt(published10, early20, aug16); !got.Equal(published10) {
-		t.Errorf("ch11 still locked on 16 Aug availability = %v, want publishedAt (caller must not use this for ranking locked chapters)", got)
+		t.Errorf(
+			"ch11 still locked on 16 Aug availability = %v, want publishedAt "+
+				"(caller must not use this for ranking locked chapters)",
+			got,
+		)
 	}
 
 	if got := feed.AvailabilityAt(published10, early20, aug21); !got.Equal(early20) {

--- a/api/pkg/core/feed/domain_test.go
+++ b/api/pkg/core/feed/domain_test.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package feed_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/feed"
+)
+
+func TestIsUnlocked(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 16, 12, 0, 0, 0, time.UTC)
+	aug20 := time.Date(2026, time.August, 20, 0, 0, 0, 0, time.UTC)
+
+	tests := map[string]struct {
+		until time.Time
+		now   time.Time
+		want  bool
+	}{
+		"zero is unlocked":          {until: time.Time{}, now: now, want: true},
+		"future early access locked": {until: aug20, now: now, want: false},
+		"equal now is unlocked":     {until: now, now: now, want: true},
+		"past early access unlocked": {until: aug20, now: time.Date(2026, time.August, 21, 0, 0, 0, 0, time.UTC), want: true},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := feed.IsUnlocked(tc.until, tc.now); got != tc.want {
+				t.Errorf("IsUnlocked() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAvailabilityAtAugustScenario(t *testing.T) {
+	t.Parallel()
+
+	published10 := time.Date(2026, time.August, 10, 0, 0, 0, 0, time.UTC)
+	early20 := time.Date(2026, time.August, 20, 0, 0, 0, 0, time.UTC)
+	published1 := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+
+	aug16 := time.Date(2026, time.August, 16, 12, 0, 0, 0, time.UTC)
+	aug21 := time.Date(2026, time.August, 21, 0, 0, 0, 0, time.UTC)
+
+	if got := feed.AvailabilityAt(published1, time.Time{}, aug16); !got.Equal(published1) {
+		t.Errorf("ch10 on 16 Aug = %v, want publishedAt", got)
+	}
+
+	if got := feed.AvailabilityAt(published10, early20, aug16); !got.Equal(published10) {
+		t.Errorf("ch11 still locked on 16 Aug availability = %v, want publishedAt (caller must not use this for ranking locked chapters)", got)
+	}
+
+	if got := feed.AvailabilityAt(published10, early20, aug21); !got.Equal(early20) {
+		t.Errorf("ch11 on 21 Aug = %v, want earlyAccessUntil 20 Aug", got)
+	}
+}

--- a/api/pkg/core/feed/gateway/http/controller.go
+++ b/api/pkg/core/feed/gateway/http/controller.go
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package http
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	httpsession "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/feed"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/httputils"
+)
+
+type Config struct {
+	Endpoint    string
+	Middlewares chi.Middlewares
+}
+
+func (cfg *Config) Validate() error {
+	if cfg.Endpoint == "" {
+		return errors.New("endpoint is required")
+	}
+
+	if !strings.HasPrefix(cfg.Endpoint, "/") {
+		return fmt.Errorf("endpoint must start with '/', got %q", cfg.Endpoint)
+	}
+
+	hasNilMiddlewares := slices.ContainsFunc(cfg.Middlewares, func(m func(http.Handler) http.Handler) bool {
+		return m == nil
+	})
+
+	if hasNilMiddlewares {
+		return errors.New("all middlewares must not be nil")
+	}
+
+	return nil
+}
+
+type Deps struct {
+	FeedService feed.FeedService
+	Logger      *slog.Logger
+}
+
+func (deps *Deps) Validate() error {
+	if deps.FeedService == nil {
+		return errors.New("feed service is required")
+	}
+
+	if deps.Logger == nil {
+		return errors.New("logger is required")
+	}
+
+	return nil
+}
+
+type Controller struct {
+	deps Deps
+	cfg  Config
+}
+
+func New(cfg Config, deps Deps) (*Controller, error) {
+	var err error
+	if err = cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("cfg.Validate: %w", err)
+	}
+
+	if err = deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	return &Controller{deps: deps, cfg: cfg}, nil
+}
+
+func (c *Controller) InitRouter(r chi.Router) {
+	r.Route(c.cfg.Endpoint, func(r chi.Router) {
+		r.Use(c.cfg.Middlewares...)
+
+		r.Get("/", c.get)
+	})
+}
+
+func (c *Controller) get(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user, ok := httpsession.UserFrom(ctx)
+	if !ok {
+		c.deps.Logger.Error("user not found in context")
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+
+		return
+	}
+
+	opts, err := c.getQuery(r)
+	if err != nil {
+		c.deps.Logger.Error("failed to get feed", "error", err)
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "invalid query parameters")
+
+		return
+	}
+
+	opts.UserID = user.ID
+
+	page, err := c.deps.FeedService.Get(ctx, opts)
+	if err != nil {
+		c.deps.Logger.Error("failed to get feed", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, listFromPage(page))
+}
+
+func (c *Controller) getQuery(r *http.Request) (feed.GetOpts, error) {
+	opts := feed.GetOpts{}
+
+	source := r.URL.Query().Get("source")
+	if source != "" {
+		parsed, err := sources.ParseSourceName(source)
+		if err != nil {
+			return feed.GetOpts{}, fmt.Errorf("sources.ParseSourceName: %w", err)
+		}
+
+		opts.Source = &parsed
+	}
+
+	comicType := r.URL.Query().Get("type")
+	if comicType != "" {
+		parsed, err := sources.ParseSeriesType(comicType)
+		if err != nil {
+			//nolint:wrapcheck
+			return feed.GetOpts{}, err
+		}
+
+		opts.Type = &parsed
+	}
+
+	comicStatus := r.URL.Query().Get("status")
+	if comicStatus != "" {
+		parsed, err := sources.ParseSeriesStatus(comicStatus)
+		if err != nil {
+			//nolint:wrapcheck
+			return feed.GetOpts{}, err
+		}
+
+		opts.Status = &parsed
+	}
+
+	limit, err := parseQueryLimit(r.URL.Query().Get("limit"))
+	if err != nil {
+		return feed.GetOpts{}, fmt.Errorf("parseQueryLimit: %w", err)
+	}
+
+	opts.Limit = limit
+
+	offset, err := parseQueryOffset(r.URL.Query().Get("offset"))
+	if err != nil {
+		return feed.GetOpts{}, fmt.Errorf("parseQueryOffset: %w", err)
+	}
+
+	opts.Offset = offset
+
+	return opts, nil
+}
+
+func parseQueryLimit(q string) (int, error) {
+	if q == "" {
+		return 10, nil
+	}
+
+	limit, err := strconv.Atoi(q)
+	if err != nil {
+		return 0, fmt.Errorf("invalid limit: %w", err)
+	}
+
+	if limit < 1 {
+		return 10, nil
+	}
+
+	if limit > 100 {
+		return 100, nil
+	}
+
+	return limit, nil
+}
+
+func parseQueryOffset(q string) (int, error) {
+	if q == "" {
+		return 0, nil
+	}
+
+	offset, err := strconv.Atoi(q)
+	if err != nil {
+		return 0, fmt.Errorf("invalid offset: %w", err)
+	}
+
+	if offset < 0 {
+		return 0, nil
+	}
+
+	return offset, nil
+}

--- a/api/pkg/core/feed/gateway/http/controller_test.go
+++ b/api/pkg/core/feed/gateway/http/controller_test.go
@@ -1,0 +1,453 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package http_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
+	sessionshttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/feed"
+	feedhttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/feed/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/users"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+)
+
+const (
+	feedEndpoint = "/feed"
+	cookieName   = "uchiyomi_session"
+	testToken    = "letoken"
+	testUsername = "alice"
+)
+
+type stubFeedService struct {
+	getErr    error
+	getResult feed.Page
+	lastGet   feed.GetOpts
+}
+
+func (s *stubFeedService) Get(_ context.Context, opts feed.GetOpts) (feed.Page, error) {
+	s.lastGet = opts
+
+	return s.getResult, s.getErr
+}
+
+type stubSessionService struct {
+	result *sessions.AuthenticatedSession
+}
+
+func (s *stubSessionService) Authenticate(_ context.Context, _ string) (*sessions.AuthenticatedSession, error) {
+	if s.result == nil {
+		return nil, sessions.ErrInvalidSession
+	}
+
+	return s.result, nil
+}
+
+func testLogger() (*slog.Logger, *bytes.Buffer) {
+	var buf bytes.Buffer
+
+	return slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})), &buf
+}
+
+func frozenNow() time.Time {
+	return time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
+}
+
+func authenticatorFor(t *testing.T, user *users.User) chi.Middlewares {
+	t.Helper()
+
+	logger, _ := testLogger()
+
+	cookies, err := sessionshttp.NewCookieManager(sessionshttp.CookieConfig{Name: cookieName, Path: "/"})
+	if err != nil {
+		t.Fatalf("NewCookieManager: %v", err)
+	}
+
+	a, err := sessionshttp.NewAuthenticator(sessionshttp.AuthenticatorDeps{
+		SessionService: &stubSessionService{result: &sessions.AuthenticatedSession{
+			User:    user,
+			Session: sessions.Session{ID: uuid.New(), UserID: user.ID, ExpiresAt: frozenNow().Add(time.Hour)},
+		}},
+		Cookies: cookies,
+		Logger:  logger,
+		Now:     frozenNow,
+	})
+	if err != nil {
+		t.Fatalf("NewAuthenticator: %v", err)
+	}
+
+	return chi.Middlewares{a.Middleware}
+}
+
+func newTestRouter(t *testing.T, svc feed.FeedService, mws chi.Middlewares) chi.Router {
+	t.Helper()
+
+	logger := slog.New(slog.DiscardHandler)
+
+	c, err := feedhttp.New(
+		feedhttp.Config{Endpoint: feedEndpoint, Middlewares: mws},
+		feedhttp.Deps{Logger: logger, FeedService: svc},
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	r := chi.NewRouter()
+	c.InitRouter(r)
+
+	return r
+}
+
+type feedItemResponse struct {
+	Title          string                `json:"title"`
+	Slug           string                `json:"slug"`
+	Cover          string                `json:"cover"`
+	Source         sources.SourceName    `json:"source"`
+	Status         sources.SeriesStatus  `json:"status"`
+	Type           sources.SeriesType    `json:"type"`
+	LatestChapters []feedChapterResponse `json:"latestChapters"`
+	ID             uuid.UUID             `json:"id"`
+}
+
+type feedChapterResponse struct {
+	PublishedAt      time.Time `json:"publishedAt"`
+	EarlyAccessUntil time.Time `json:"earlyAccessUntil"`
+	Title            string    `json:"title"`
+	Number           float64   `json:"number"`
+	Download         int       `json:"download"`
+	ID               uuid.UUID `json:"id"`
+}
+
+type feedPageResponse struct {
+	Items []feedItemResponse `json:"items"`
+	Total int64              `json:"total"`
+}
+
+func TestConfigValidate(t *testing.T) {
+	t.Parallel()
+
+	passthrough := func(next http.Handler) http.Handler { return next }
+
+	tests := map[string]struct {
+		wantErr string
+		cfg     feedhttp.Config
+	}{
+		"valid": {cfg: feedhttp.Config{Endpoint: feedEndpoint}},
+		"empty": {cfg: feedhttp.Config{}, wantErr: "endpoint is required"},
+		"without leading slash": {
+			cfg:     feedhttp.Config{Endpoint: "feed"},
+			wantErr: `endpoint must start with '/', got "feed"`,
+		},
+		"nil middleware": {
+			cfg:     feedhttp.Config{Endpoint: feedEndpoint, Middlewares: chi.Middlewares{passthrough, nil}},
+			wantErr: "all middlewares must not be nil",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.cfg.Validate()
+
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() = %v, want nil", err)
+				}
+
+				return
+			}
+
+			if err == nil || err.Error() != tc.wantErr {
+				t.Errorf("Validate() = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestDepsValidate(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+
+	tests := map[string]struct {
+		deps    feedhttp.Deps
+		wantErr string
+	}{
+		"valid": {
+			deps: feedhttp.Deps{
+				Logger:      logger,
+				FeedService: &stubFeedService{},
+			},
+		},
+		"missing service": {
+			deps:    feedhttp.Deps{Logger: logger},
+			wantErr: "feed service is required",
+		},
+		"missing logger": {
+			deps:    feedhttp.Deps{FeedService: &stubFeedService{}},
+			wantErr: "logger is required",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.deps.Validate()
+
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() = %v, want nil", err)
+				}
+
+				return
+			}
+
+			if err == nil || err.Error() != tc.wantErr {
+				t.Errorf("Validate() = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestGetUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRouter(t, &stubFeedService{}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, feedEndpoint+"/", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestGetInvalidQuery(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	r := newTestRouter(t, &stubFeedService{}, authenticatorFor(t, user))
+
+	queries := []string{
+		"?source=not-a-source",
+		"?type=webtoon",
+		"?status=unknown",
+		"?limit=x",
+		"?offset=x",
+	}
+
+	for _, q := range queries {
+		t.Run(q, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, feedEndpoint+"/?"+strings.TrimPrefix(q, "?"), nil)
+			req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400", rec.Code)
+			}
+		})
+	}
+}
+
+func TestGetDefaultsLimitAndOffset(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	svc := &stubFeedService{getResult: feed.Page{Items: []feed.Item{}, Total: 0}}
+	r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodGet, feedEndpoint+"/", nil)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	if svc.lastGet.Limit != 10 {
+		t.Errorf("Limit = %d, want 10", svc.lastGet.Limit)
+	}
+
+	if svc.lastGet.Offset != 0 {
+		t.Errorf("Offset = %d, want 0", svc.lastGet.Offset)
+	}
+
+	if svc.lastGet.UserID != user.ID {
+		t.Errorf("UserID = %v, want %s", svc.lastGet.UserID, user.ID)
+	}
+}
+
+func TestGetClampsLimit(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+
+	tests := map[string]struct {
+		query string
+		want  int
+	}{
+		"limit zero": {query: "?limit=0", want: 10},
+		"limit huge": {query: "?limit=500", want: 100},
+		"offset neg": {query: "?offset=-1", want: 0},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			svc := &stubFeedService{getResult: feed.Page{Items: []feed.Item{}, Total: 0}}
+			r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+			req := httptest.NewRequest(http.MethodGet, feedEndpoint+"/"+tc.query, nil)
+			req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+			}
+
+			got := svc.lastGet.Limit
+			if strings.Contains(tc.query, "offset") {
+				got = svc.lastGet.Offset
+			}
+
+			if got != tc.want {
+				t.Errorf("got = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetJSON(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	comicID := uuid.New()
+	chapterID := uuid.New()
+	publishedAt := time.Date(2026, time.January, 15, 8, 0, 0, 0, time.UTC)
+	earlyAccessUntil := time.Date(2026, time.January, 20, 8, 0, 0, 0, time.UTC)
+
+	getResult := feed.Page{
+		Items: []feed.Item{{
+			ID:     comicID,
+			Title:  "",
+			Slug:   "solo-leveling",
+			Source: sources.SourceAsuraScans,
+			Status: sources.SeriesStatusCompleted,
+			Type:   sources.SeriesTypeManhwa,
+			LatestChapters: []feed.LatestChapter{{
+				ID:               chapterID,
+				ComicID:          comicID,
+				Title:            "Chapter 1",
+				Number:           1,
+				PublishedAt:      publishedAt,
+				EarlyAccessUntil: earlyAccessUntil,
+				Download:         2,
+			}},
+		}},
+		Total: 1,
+	}
+
+	r := newTestRouter(t, &stubFeedService{getResult: getResult}, authenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodGet, feedEndpoint+"/", nil)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var got feedPageResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if got.Total != 1 {
+		t.Errorf("total = %d, want 1", got.Total)
+	}
+
+	if len(got.Items) != 1 {
+		t.Fatalf("items len = %d, want 1", len(got.Items))
+	}
+
+	item := got.Items[0]
+	wantCover := "/api/comics/" + comicID.String() + "/cover"
+	if item.Cover != wantCover {
+		t.Errorf("cover = %q, want %q", item.Cover, wantCover)
+	}
+
+	if item.Title != "" {
+		t.Errorf("title = %q, want empty string", item.Title)
+	}
+
+	if len(item.LatestChapters) != 1 {
+		t.Fatalf("latestChapters len = %d, want 1", len(item.LatestChapters))
+	}
+
+	if item.LatestChapters[0].Download != 2 {
+		t.Errorf("download = %d, want 2", item.LatestChapters[0].Download)
+	}
+}
+
+func TestGetEmptyItemsIsArray(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	r := newTestRouter(t, &stubFeedService{
+		getResult: feed.Page{Items: nil, Total: 0},
+	}, authenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodGet, feedEndpoint+"/", nil)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `"items":[]`) {
+		t.Errorf("body = %s, want items:[]", body)
+	}
+}
+
+func TestGetServiceError(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	sentinel := errors.New("db down")
+
+	r := newTestRouter(t, &stubFeedService{getErr: sentinel}, authenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodGet, feedEndpoint+"/", nil)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+}

--- a/api/pkg/core/feed/gateway/http/dto.go
+++ b/api/pkg/core/feed/gateway/http/dto.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package http
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/feed"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+)
+
+type latestChapterResponse struct {
+	PublishedAt      time.Time `json:"publishedAt"`
+	EarlyAccessUntil time.Time `json:"earlyAccessUntil"`
+	Title            string    `json:"title"`
+	Number           float64   `json:"number"`
+	Download         int       `json:"download"`
+	ID               uuid.UUID `json:"id"`
+}
+
+type itemResponse struct {
+	Title          string                  `json:"title"`
+	Slug           string                  `json:"slug"`
+	Cover          string                  `json:"cover"`
+	Source         sources.SourceName      `json:"source"`
+	Status         sources.SeriesStatus    `json:"status"`
+	Type           sources.SeriesType      `json:"type"`
+	LatestChapters []latestChapterResponse `json:"latestChapters"`
+	ID             uuid.UUID               `json:"id"`
+}
+
+type listResponse struct {
+	Items []itemResponse `json:"items"`
+	Total int64          `json:"total"`
+}
+
+func comicCoverURL(id uuid.UUID) string {
+	return "/api/comics/" + id.String() + "/cover"
+}
+
+func listFromPage(page feed.Page) listResponse {
+	items := make([]itemResponse, 0, len(page.Items))
+	for i := range page.Items {
+		items = append(items, itemFromDomain(&page.Items[i]))
+	}
+
+	return listResponse{Items: items, Total: page.Total}
+}
+
+func itemFromDomain(item *feed.Item) itemResponse {
+	chs := make([]latestChapterResponse, 0, len(item.LatestChapters))
+	for i := range item.LatestChapters {
+		ch := item.LatestChapters[i]
+		chs = append(chs, latestChapterResponse{
+			ID:               ch.ID,
+			Title:            ch.Title,
+			Number:           ch.Number,
+			PublishedAt:      ch.PublishedAt,
+			EarlyAccessUntil: ch.EarlyAccessUntil,
+			Download:         ch.Download,
+		})
+	}
+
+	return itemResponse{
+		ID:             item.ID,
+		Title:          item.Title,
+		Slug:           item.Slug,
+		Cover:          comicCoverURL(item.ID),
+		Source:         item.Source,
+		Status:         item.Status,
+		Type:           item.Type,
+		LatestChapters: chs,
+	}
+}

--- a/api/pkg/core/feed/repository/pg/repository.go
+++ b/api/pkg/core/feed/repository/pg/repository.go
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package pg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/feed"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/transaction/pgtx"
+	"gorm.io/gorm"
+)
+
+var _ feed.FeedRepository = (*PGFeedRepository)(nil)
+
+const availabilitySQL = `CASE
+  WHEN chapters.early_access_until > TIMESTAMPTZ '0001-01-01 00:00:00+00'
+   AND chapters.early_access_until <= ?
+  THEN chapters.early_access_until
+  ELSE chapters.published_at
+END`
+
+type Deps struct {
+	DB *gorm.DB
+}
+
+func (deps *Deps) Validate() error {
+	if deps.DB == nil {
+		return errors.New("db is required")
+	}
+
+	return nil
+}
+
+type PGFeedRepository struct {
+	deps Deps
+}
+
+func New(deps Deps) (*PGFeedRepository, error) {
+	if err := deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	r := &PGFeedRepository{deps: deps}
+
+	return r, nil
+}
+
+type pageRow struct {
+	Title  string
+	Slug   string
+	Source sources.SourceName
+	Status sources.SeriesStatus
+	Type   sources.SeriesType `gorm:"column:comic_type"`
+	ID     uuid.UUID
+}
+
+type chapterRow struct {
+	PublishedAt      time.Time
+	EarlyAccessUntil time.Time
+	Title            string
+	Number           float64
+	Download         int
+	ID               uuid.UUID
+	ComicID          uuid.UUID
+}
+
+func (r *PGFeedRepository) ListPage(ctx context.Context, opts feed.ListPageOpts) (feed.Page, error) {
+	countSQL, countArgs := listPageCountSQL(opts)
+
+	var total int64
+
+	err := pgtx.From(ctx, r.deps.DB).Raw(countSQL, countArgs...).Scan(&total).Error
+	if err != nil {
+		return feed.Page{}, fmt.Errorf("count: %w", err)
+	}
+
+	pageSQL, pageArgs := listPageSQL(opts)
+
+	var rows []pageRow
+
+	err = pgtx.From(ctx, r.deps.DB).Raw(pageSQL, pageArgs...).Scan(&rows).Error
+	if err != nil {
+		return feed.Page{}, fmt.Errorf("page: %w", err)
+	}
+
+	items := make([]feed.Item, len(rows))
+	for i := range rows {
+		items[i] = feed.Item{
+			ID:     rows[i].ID,
+			Title:  rows[i].Title,
+			Slug:   rows[i].Slug,
+			Source: rows[i].Source,
+			Status: rows[i].Status,
+			Type:   rows[i].Type,
+		}
+	}
+
+	return feed.Page{Items: items, Total: total}, nil
+}
+
+func (r *PGFeedRepository) ListUnlockedChapters(
+	ctx context.Context, opts feed.ListChaptersOpts,
+) ([]feed.LatestChapter, error) {
+	if len(opts.ComicIDs) == 0 {
+		return nil, nil
+	}
+
+	const sql = `
+SELECT id, comic_id, title, number, published_at, early_access_until, download
+FROM chapters
+WHERE comic_id IN ? AND early_access_until <= ?
+`
+
+	var rows []chapterRow
+
+	err := pgtx.From(ctx, r.deps.DB).Raw(sql, opts.ComicIDs, opts.Now).Scan(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("chapters: %w", err)
+	}
+
+	ret := make([]feed.LatestChapter, len(rows))
+	for i := range rows {
+		ret[i] = feed.LatestChapter{
+			ID:               rows[i].ID,
+			ComicID:          rows[i].ComicID,
+			Title:            rows[i].Title,
+			Number:           rows[i].Number,
+			PublishedAt:      rows[i].PublishedAt,
+			EarlyAccessUntil: rows[i].EarlyAccessUntil,
+			Download:         rows[i].Download,
+		}
+	}
+
+	return ret, nil
+}
+
+func listPageCountSQL(opts feed.ListPageOpts) (string, []any) {
+	sql := `
+SELECT COUNT(DISTINCT comics.id)
+FROM comics
+INNER JOIN library_entries ON library_entries.comic_id = comics.id AND library_entries.user_id = ?
+INNER JOIN chapters ON chapters.comic_id = comics.id AND chapters.early_access_until <= ?
+`
+
+	args := make([]any, 0, 5)
+	args = append(args, opts.UserID, opts.Now)
+
+	return appendPageFilters(sql, args, opts)
+}
+
+func listPageSQL(opts feed.ListPageOpts) (string, []any) {
+	sql := `
+SELECT comics.id, comics.source, comics.slug, comics.title, comics.status, comics.comic_type
+FROM comics
+INNER JOIN library_entries ON library_entries.comic_id = comics.id AND library_entries.user_id = ?
+INNER JOIN chapters ON chapters.comic_id = comics.id AND chapters.early_access_until <= ?
+`
+
+	args := make([]any, 0, 8)
+	args = append(args, opts.UserID, opts.Now)
+	sql, args = appendPageFilters(sql, args, opts)
+
+	sql += `
+GROUP BY comics.id, comics.source, comics.slug, comics.title, comics.status, comics.comic_type
+ORDER BY MAX(` + availabilitySQL + `) DESC, comics.title ASC
+LIMIT ? OFFSET ?
+`
+	args = append(args, opts.Now, opts.Limit, opts.Offset)
+
+	return sql, args
+}
+
+func appendPageFilters(sql string, args []any, opts feed.ListPageOpts) (string, []any) {
+	if opts.Source != nil {
+		sql += " AND comics.source = ?"
+		args = append(args, *opts.Source)
+	}
+
+	if opts.Type != nil {
+		sql += " AND comics.comic_type = ?"
+		args = append(args, *opts.Type)
+	}
+
+	if opts.Status != nil {
+		sql += " AND comics.status = ?"
+		args = append(args, *opts.Status)
+	}
+
+	return sql, args
+}

--- a/api/pkg/core/feed/repository/pg/repository_test.go
+++ b/api/pkg/core/feed/repository/pg/repository_test.go
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//nolint:goconst
+package pg_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/feed"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/feed/repository/pg"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/repository/pgtest"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+)
+
+const (
+	comicSource = sources.SourceAsuraScans
+	comicSlug   = "solo-leveling"
+	comicTitle  = "Solo Leveling"
+	comicStatus = sources.SeriesStatusCompleted
+	comicType   = sources.SeriesTypeManhwa
+)
+
+func newFeedRepo(t *testing.T) (*pg.PGFeedRepository, sqlmock.Sqlmock) {
+	t.Helper()
+
+	db, mock := pgtest.New(t)
+
+	r, err := pg.New(pg.Deps{DB: db})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	return r, mock
+}
+
+func TestNewValidatesDeps(t *testing.T) {
+	t.Parallel()
+
+	r, err := pg.New(pg.Deps{})
+	if err == nil {
+		t.Fatal("New without DB must fail")
+	}
+
+	if r != nil {
+		t.Error("New returned a repository in addition to the error")
+	}
+
+	if want := "deps.Validate: db is required"; err.Error() != want {
+		t.Errorf("err = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestListPageCountAndOrderSQL(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newFeedRepo(t)
+
+	userID := uuid.New()
+	comicID := uuid.New()
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+
+	// count: userID, now
+	mock.ExpectQuery(`COUNT\(DISTINCT comics.id\)`).
+		WithArgs(userID, now).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(1)))
+
+	// page: userID, now (unlock join), now (availability CASE), limit, offset
+	mock.ExpectQuery(`early_access_until.*ORDER BY.*comics.title`).
+		WithArgs(userID, now, now, 10, 0).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "source", "slug", "title", "status", "comic_type",
+		}).AddRow(
+			comicID, string(comicSource), comicSlug, comicTitle, string(comicStatus), string(comicType),
+		))
+
+	got, err := r.ListPage(context.Background(), feed.ListPageOpts{
+		Now:    now,
+		UserID: userID,
+		Limit:  10,
+		Offset: 0,
+	})
+	if err != nil {
+		t.Fatalf("ListPage: %v", err)
+	}
+
+	if got.Total != 1 || len(got.Items) != 1 {
+		t.Fatalf("ListPage() = %+v", got)
+	}
+
+	item := got.Items[0]
+	if item.ID != comicID || item.Source != comicSource || item.Slug != comicSlug ||
+		item.Title != comicTitle || item.Status != comicStatus || item.Type != comicType {
+		t.Errorf("Item = %+v", item)
+	}
+}
+
+func TestListPageFilters(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newFeedRepo(t)
+
+	userID := uuid.New()
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	src := comicSource
+	typ := comicType
+	st := comicStatus
+
+	// count: userID, now, source, type, status
+	mock.ExpectQuery(`COUNT\(DISTINCT comics.id\).*comics.source.*comic_type.*comics.status`).
+		WithArgs(userID, now, string(src), string(typ), string(st)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(0)))
+
+	// page: userID, now, source, type, status, now (CASE), limit, offset
+	mock.ExpectQuery(`comics.source.*comic_type.*comics.status`).
+		WithArgs(userID, now, string(src), string(typ), string(st), now, 10, 0).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "source", "slug", "title", "status", "comic_type",
+		}))
+
+	got, err := r.ListPage(context.Background(), feed.ListPageOpts{
+		Now:    now,
+		Source: &src,
+		Type:   &typ,
+		Status: &st,
+		UserID: userID,
+		Limit:  10,
+	})
+	if err != nil {
+		t.Fatalf("ListPage: %v", err)
+	}
+
+	if got.Total != 0 || len(got.Items) != 0 {
+		t.Errorf("ListPage() = %+v", got)
+	}
+}
+
+func TestListPageOffsetLimit(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newFeedRepo(t)
+
+	userID := uuid.New()
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(`COUNT\(DISTINCT comics.id\)`).
+		WithArgs(userID, now).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(40)))
+
+	mock.ExpectQuery(`early_access_until.*LIMIT`).
+		WithArgs(userID, now, now, 10, 20).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "source", "slug", "title", "status", "comic_type",
+		}))
+
+	got, err := r.ListPage(context.Background(), feed.ListPageOpts{
+		Now:    now,
+		UserID: userID,
+		Limit:  10,
+		Offset: 20,
+	})
+	if err != nil {
+		t.Fatalf("ListPage: %v", err)
+	}
+
+	if got.Total != 40 {
+		t.Errorf("Total = %d, want 40", got.Total)
+	}
+}
+
+func TestListUnlockedChaptersEmptyIDsSkipsQuery(t *testing.T) {
+	t.Parallel()
+
+	r, _ := newFeedRepo(t)
+
+	got, err := r.ListUnlockedChapters(context.Background(), feed.ListChaptersOpts{
+		Now:      time.Now().UTC(),
+		ComicIDs: nil,
+	})
+	if err != nil {
+		t.Fatalf("ListUnlockedChapters: %v", err)
+	}
+
+	if got != nil {
+		t.Errorf("ListUnlockedChapters() = %+v, want nil", got)
+	}
+}
+
+func TestListUnlockedChaptersFiltersLocked(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newFeedRepo(t)
+
+	comicID := uuid.New()
+	chapterID := uuid.New()
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	published := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	until := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
+
+	// GORM expands IN ? to ($1) with PreferSimpleProtocol: comicID, now
+	mock.ExpectQuery(`comic_id IN.*early_access_until <=`).
+		WithArgs(comicID, now).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "comic_id", "title", "number", "published_at", "early_access_until", "download",
+		}).AddRow(chapterID, comicID, "Ch 10", 10.0, published, until, 2))
+
+	got, err := r.ListUnlockedChapters(context.Background(), feed.ListChaptersOpts{
+		Now:      now,
+		ComicIDs: []uuid.UUID{comicID},
+	})
+	if err != nil {
+		t.Fatalf("ListUnlockedChapters: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+
+	ch := got[0]
+	if ch.ID != chapterID || ch.ComicID != comicID || ch.Title != "Ch 10" ||
+		ch.Number != 10.0 || ch.Download != 2 || !ch.PublishedAt.Equal(published) ||
+		!ch.EarlyAccessUntil.Equal(until) {
+		t.Errorf("LatestChapter = %+v", ch)
+	}
+}

--- a/api/pkg/core/feed/service.go
+++ b/api/pkg/core/feed/service.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package feed
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var _ FeedService = (*Service)(nil)
+
+const maxLatestChapters = 3
+
+type Deps struct {
+	FeedRepository FeedRepository
+	Now            func() time.Time
+}
+
+func (deps *Deps) Validate() error {
+	if deps.FeedRepository == nil {
+		return errors.New("feed repository is required")
+	}
+
+	if deps.Now == nil {
+		return errors.New("now is required")
+	}
+
+	return nil
+}
+
+type Service struct {
+	deps Deps
+}
+
+func NewService(deps Deps) (*Service, error) {
+	if err := deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	return &Service{deps: deps}, nil
+}
+
+func (s *Service) Get(ctx context.Context, opts GetOpts) (Page, error) {
+	now := s.deps.Now()
+
+	page, err := s.deps.FeedRepository.ListPage(ctx, ListPageOpts{
+		Now:    now,
+		Source: opts.Source,
+		Type:   opts.Type,
+		Status: opts.Status,
+		UserID: opts.UserID,
+		Limit:  opts.Limit,
+		Offset: opts.Offset,
+	})
+	if err != nil {
+		return Page{}, fmt.Errorf("s.deps.FeedRepository.ListPage: %w", err)
+	}
+
+	if len(page.Items) == 0 {
+		if page.Items == nil {
+			page.Items = []Item{}
+		}
+
+		return page, nil
+	}
+
+	ids := make([]uuid.UUID, len(page.Items))
+	for i := range page.Items {
+		ids[i] = page.Items[i].ID
+	}
+
+	chapters, err := s.deps.FeedRepository.ListUnlockedChapters(ctx, ListChaptersOpts{
+		Now:      now,
+		ComicIDs: ids,
+	})
+	if err != nil {
+		return Page{}, fmt.Errorf("s.deps.FeedRepository.ListUnlockedChapters: %w", err)
+	}
+
+	byComic := map[uuid.UUID][]LatestChapter{}
+	for i := range chapters {
+		ch := chapters[i]
+		byComic[ch.ComicID] = append(byComic[ch.ComicID], ch)
+	}
+
+	for i := range page.Items {
+		chs := byComic[page.Items[i].ID]
+		sort.SliceStable(chs, func(a, b int) bool {
+			aa := AvailabilityAt(chs[a].PublishedAt, chs[a].EarlyAccessUntil, now)
+			bb := AvailabilityAt(chs[b].PublishedAt, chs[b].EarlyAccessUntil, now)
+			if !aa.Equal(bb) {
+				return aa.After(bb)
+			}
+
+			return chs[a].Number > chs[b].Number
+		})
+
+		if len(chs) > maxLatestChapters {
+			chs = chs[:maxLatestChapters]
+		}
+
+		if chs == nil {
+			chs = []LatestChapter{}
+		}
+
+		page.Items[i].LatestChapters = chs
+	}
+
+	return page, nil
+}

--- a/api/pkg/core/feed/service_test.go
+++ b/api/pkg/core/feed/service_test.go
@@ -15,14 +15,14 @@ import (
 )
 
 type fakeFeedRepository struct {
-	page           feed.Page
-	pageErr        error
-	chapters       []feed.LatestChapter
-	chaptersErr    error
-	lastPageOpts   feed.ListPageOpts
-	lastChapters   feed.ListChaptersOpts
-	pageCalls      int
-	chaptersCalls  int
+	pageErr       error
+	chaptersErr   error
+	lastChapters  feed.ListChaptersOpts
+	chapters      []feed.LatestChapter
+	page          feed.Page
+	lastPageOpts  feed.ListPageOpts
+	pageCalls     int
+	chaptersCalls int
 }
 
 func (f *fakeFeedRepository) ListPage(_ context.Context, opts feed.ListPageOpts) (feed.Page, error) {

--- a/api/pkg/core/feed/service_test.go
+++ b/api/pkg/core/feed/service_test.go
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//nolint:goconst
+package feed_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/feed"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+)
+
+type fakeFeedRepository struct {
+	page           feed.Page
+	pageErr        error
+	chapters       []feed.LatestChapter
+	chaptersErr    error
+	lastPageOpts   feed.ListPageOpts
+	lastChapters   feed.ListChaptersOpts
+	pageCalls      int
+	chaptersCalls  int
+}
+
+func (f *fakeFeedRepository) ListPage(_ context.Context, opts feed.ListPageOpts) (feed.Page, error) {
+	f.pageCalls++
+	f.lastPageOpts = opts
+
+	return f.page, f.pageErr
+}
+
+func (f *fakeFeedRepository) ListUnlockedChapters(
+	_ context.Context, opts feed.ListChaptersOpts,
+) ([]feed.LatestChapter, error) {
+	f.chaptersCalls++
+	f.lastChapters = opts
+
+	return f.chapters, f.chaptersErr
+}
+
+func frozenAug16() time.Time {
+	return time.Date(2026, time.August, 16, 12, 0, 0, 0, time.UTC)
+}
+
+func frozenAug21() time.Time {
+	return time.Date(2026, time.August, 21, 0, 0, 0, 0, time.UTC)
+}
+
+func newService(t *testing.T, repo feed.FeedRepository, now func() time.Time) *feed.Service {
+	t.Helper()
+
+	svc, err := feed.NewService(feed.Deps{FeedRepository: repo, Now: now})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	return svc
+}
+
+func TestNewServiceValidatesDeps(t *testing.T) {
+	t.Parallel()
+
+	_, err := feed.NewService(feed.Deps{})
+	if err == nil {
+		t.Fatal("NewService with empty deps must fail")
+	}
+}
+
+func TestGetSkipsChaptersWhenPageEmpty(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeFeedRepository{page: feed.Page{Items: nil, Total: 0}}
+	svc := newService(t, repo, frozenAug16)
+	userID := uuid.New()
+
+	got, err := svc.Get(context.Background(), feed.GetOpts{UserID: userID, Limit: 10})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if repo.chaptersCalls != 0 {
+		t.Errorf("ListUnlockedChapters calls = %d, want 0", repo.chaptersCalls)
+	}
+
+	if got.Total != 0 || len(got.Items) != 0 {
+		t.Errorf("Get() = %+v", got)
+	}
+
+	if repo.lastPageOpts.UserID != userID || !repo.lastPageOpts.Now.Equal(frozenAug16()) {
+		t.Errorf("ListPage opts = %+v", repo.lastPageOpts)
+	}
+}
+
+func TestGetOmitsAllLockedWhenRepoReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeFeedRepository{page: feed.Page{Items: []feed.Item{}, Total: 0}}
+	svc := newService(t, repo, frozenAug16)
+
+	got, err := svc.Get(context.Background(), feed.GetOpts{UserID: uuid.New(), Limit: 10})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Total != 0 || len(got.Items) != 0 {
+		t.Errorf("all-locked comic must be absent, got %+v", got)
+	}
+}
+
+func TestGetAugustScenarioLatestChapters(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	ch10ID := uuid.New()
+	ch11ID := uuid.New()
+	item := feed.Item{
+		ID:     comicID,
+		Title:  "Solo Leveling",
+		Slug:   "solo-leveling",
+		Source: sources.SourceAsuraScans,
+		Status: sources.SeriesStatusOngoing,
+		Type:   sources.SeriesTypeManhwa,
+	}
+	ch10 := feed.LatestChapter{
+		ID:          ch10ID,
+		ComicID:     comicID,
+		Number:      10,
+		PublishedAt: time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC),
+		Download:    100,
+	}
+	ch11 := feed.LatestChapter{
+		ID:               ch11ID,
+		ComicID:          comicID,
+		Number:           11,
+		PublishedAt:      time.Date(2026, time.August, 10, 0, 0, 0, 0, time.UTC),
+		EarlyAccessUntil: time.Date(2026, time.August, 20, 0, 0, 0, 0, time.UTC),
+		Download:         0,
+	}
+
+	t.Run("16 Aug only ch10", func(t *testing.T) {
+		t.Parallel()
+
+		repo := &fakeFeedRepository{
+			page:     feed.Page{Items: []feed.Item{item}, Total: 1},
+			chapters: []feed.LatestChapter{ch10},
+		}
+		svc := newService(t, repo, frozenAug16)
+
+		got, err := svc.Get(context.Background(), feed.GetOpts{UserID: uuid.New(), Limit: 10})
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+
+		if len(got.Items) != 1 || len(got.Items[0].LatestChapters) != 1 {
+			t.Fatalf("items/chapters = %+v", got.Items)
+		}
+
+		if got.Items[0].LatestChapters[0].ID != ch10ID {
+			t.Errorf("chapter = %s, want ch10", got.Items[0].LatestChapters[0].ID)
+		}
+	})
+
+	t.Run("21 Aug ch11 first then ch10", func(t *testing.T) {
+		t.Parallel()
+
+		repo := &fakeFeedRepository{
+			page:     feed.Page{Items: []feed.Item{item}, Total: 1},
+			chapters: []feed.LatestChapter{ch10, ch11},
+		}
+		svc := newService(t, repo, frozenAug21)
+
+		got, err := svc.Get(context.Background(), feed.GetOpts{UserID: uuid.New(), Limit: 10})
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+
+		chs := got.Items[0].LatestChapters
+		if len(chs) != 2 || chs[0].ID != ch11ID || chs[1].ID != ch10ID {
+			t.Errorf("latestChapters = %+v, want ch11 then ch10", chs)
+		}
+	})
+}
+
+func TestGetCapsLatestChaptersAtThree(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	item := feed.Item{ID: comicID, Title: "A"}
+	now := frozenAug21()
+	var chs []feed.LatestChapter
+	for i := 1; i <= 5; i++ {
+		chs = append(chs, feed.LatestChapter{
+			ID:          uuid.New(),
+			ComicID:     comicID,
+			Number:      float64(i),
+			PublishedAt: now.Add(time.Duration(i) * time.Hour),
+			Download:    100,
+		})
+	}
+
+	repo := &fakeFeedRepository{
+		page:     feed.Page{Items: []feed.Item{item}, Total: 1},
+		chapters: chs,
+	}
+	svc := newService(t, repo, frozenAug21)
+
+	got, err := svc.Get(context.Background(), feed.GetOpts{UserID: uuid.New(), Limit: 10})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	gotChs := got.Items[0].LatestChapters
+	if len(gotChs) != 3 {
+		t.Fatalf("len = %d, want 3", len(gotChs))
+	}
+
+	if gotChs[0].Number != 5 || gotChs[1].Number != 4 || gotChs[2].Number != 3 {
+		t.Errorf("order by availability desc = %v %v %v", gotChs[0].Number, gotChs[1].Number, gotChs[2].Number)
+	}
+}
+
+func TestGetPreservesPageOrderAndTotal(t *testing.T) {
+	t.Parallel()
+
+	a := uuid.New()
+	b := uuid.New()
+	repo := &fakeFeedRepository{
+		page: feed.Page{
+			Items: []feed.Item{{ID: a, Title: "A"}, {ID: b, Title: "B"}},
+			Total: 12,
+		},
+		chapters: []feed.LatestChapter{
+			{ID: uuid.New(), ComicID: b, Number: 1, PublishedAt: frozenAug16()},
+			{ID: uuid.New(), ComicID: a, Number: 2, PublishedAt: frozenAug16()},
+		},
+	}
+	svc := newService(t, repo, frozenAug16)
+
+	got, err := svc.Get(context.Background(), feed.GetOpts{UserID: uuid.New(), Limit: 10, Offset: 0})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Total != 12 || got.Items[0].ID != a || got.Items[1].ID != b {
+		t.Errorf("page = %+v", got)
+	}
+
+	if len(got.Items[0].LatestChapters) != 1 || len(got.Items[1].LatestChapters) != 1 {
+		t.Errorf("chapters not attached per comic: %+v", got.Items)
+	}
+}
+
+func TestGetPassesFiltersAndNow(t *testing.T) {
+	t.Parallel()
+
+	src := sources.SourceAsuraScans
+	typ := sources.SeriesTypeManhwa
+	st := sources.SeriesStatusOngoing
+	userID := uuid.New()
+	repo := &fakeFeedRepository{page: feed.Page{Items: nil, Total: 0}}
+	svc := newService(t, repo, frozenAug16)
+
+	_, err := svc.Get(context.Background(), feed.GetOpts{
+		UserID: userID,
+		Source: &src,
+		Type:   &typ,
+		Status: &st,
+		Limit:  5,
+		Offset: 2,
+	})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	o := repo.lastPageOpts
+	if o.UserID != userID || o.Limit != 5 || o.Offset != 2 || o.Source == nil || *o.Source != src {
+		t.Errorf("ListPage opts = %+v", o)
+	}
+
+	if o.Type == nil || *o.Type != typ || o.Status == nil || *o.Status != st {
+		t.Errorf("filters = %+v", o)
+	}
+
+	if !o.Now.Equal(frozenAug16()) {
+		t.Errorf("Now = %v", o.Now)
+	}
+}
+
+func TestGetWrapsRepositoryError(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeFeedRepository{pageErr: errors.New("db down")}
+	svc := newService(t, repo, frozenAug16)
+
+	_, err := svc.Get(context.Background(), feed.GetOpts{UserID: uuid.New()})
+	if err == nil {
+		t.Fatal("error expected")
+	}
+}

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -31,6 +31,8 @@ import (
 	httpcovers "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/gateway/http"
 	coversasura "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/source/asurascans"
 	coredomain "github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/feed"
+	httpfeed "github.com/kharente-deuh/uchiyomi-server/pkg/core/feed/gateway/http"
 	healthhttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/health/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/setup"
 	httpsetup "github.com/kharente-deuh/uchiyomi-server/pkg/core/setup/gateway/http"
@@ -386,6 +388,12 @@ func (fakeChaptersService) RetryDownload(context.Context, chapters.RetryDownload
 	return errors.New(notImplemented)
 }
 
+type fakeFeedService struct{}
+
+func (fakeFeedService) Get(context.Context, feed.GetOpts) (feed.Page, error) {
+	return feed.Page{Items: []feed.Item{}, Total: 0}, nil
+}
+
 func newTestCache[P any, T any](t *testing.T, name string, logger *slog.Logger) *fncache.Cache[P, T] {
 	t.Helper()
 
@@ -549,6 +557,14 @@ func newTestApp(t *testing.T, db Database, port int) (*App, *health.Registry) {
 		t.Fatalf("httpchapters.New: %v", err)
 	}
 
+	feedCtrl, err := httpfeed.New(
+		httpfeed.Config{Endpoint: "/feed"},
+		httpfeed.Deps{Logger: logger, FeedService: fakeFeedService{}},
+	)
+	if err != nil {
+		t.Fatalf("httpfeed.New: %v", err)
+	}
+
 	app, err := New(
 		Config{ServerPort: port, AllowedOrigins: []string{"*"}},
 		Deps{
@@ -562,6 +578,7 @@ func newTestApp(t *testing.T, db Database, port int) (*App, *health.Registry) {
 			OIDCProvidersCtrl:  oidcProvidersCtrl,
 			ComicsCtrl:         comicsCtrl,
 			ChaptersCtrl:       chaptersCtrl,
+			FeedCtrl:           feedCtrl,
 			Logger:             logger,
 			Health:             registry,
 			Asura:              asuraApp,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ services:
     ports:
       - "${API_EXPOSED_PORT:-3000}:3000"
     environment:
+      GOMEMLIMIT: 450MiB
+      GOMAXPROCS: "2"
       DB_HOST: uchiyomi-db
       DB_PORT: 5432
       PUID: ${PUID:-65532}
@@ -54,6 +56,14 @@ services:
     volumes:
       - ./.data:/data
     stop_grace_period: 15s
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 512M    
+        reservations:
+          cpus: "0.25"
+          memory: 128M
 
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary

Implements authenticated `GET /api/feed` ([#54](https://github.com/Kharente-Deuh/Uchiyomi/issues/54)): a paginated feed of the current user's library comics that have at least one unlocked chapter, ranked by chapter availability date, each item embedding up to three latest unlocked chapters with download progress.

- New read-only bounded context `pkg/core/feed/` (domain, service, HTTP gateway, Postgres repository)
- Unlock rule: `earlyAccessUntil` unset or `<= now`; availability date uses `earlyAccessUntil` when set and past, otherwise `publishedAt`
- Comics with only locked chapters are omitted from `items` and `total`
- Query params: `source`, `type`, `status`, `limit` (default 10, max 100), `offset` (default 0)
- Cover URLs follow the comics list convention (`/api/comics/{id}/cover`)

## Test plan

- [x] `go test ./pkg/core/feed/...` — domain helpers, service assembly, HTTP gateway, Postgres queries
- [x] `go test ./pkg/core/...` — app mount test for `/api/feed`
- [x] `golangci-lint run ./...`
- [x] Authenticated `GET /api/feed` returns `{ items, total }` with pagination
- [x] Unauthenticated request returns 401
- [x] Comics with only locked chapters are absent from feed and `total`
- [x] 16 Aug vs 21 Aug scenario: comic ranks on ch.10 availability until ch.11 unlocks, then on ch.11 `earlyAccessUntil`
- [x] Filters `source`, `type`, `status` and invalid enum values return 400
- [x] User isolation: feed only shows the logged-in user's library