### PR TITLE
feat(chapters): GET /api/chapters?comicId=

### DIFF
--- a/api/cmd/uchiyomiserver/setup.go
+++ b/api/cmd/uchiyomiserver/setup.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -17,6 +18,7 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
 	httpcomics "github.com/kharente-deuh/uchiyomi-server/pkg/core/comics/gateway/http"
 	comicrefresh "github.com/kharente-deuh/uchiyomi-server/pkg/core/comics/refresh"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
 	asura "github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/core"
 	asuradomain "github.com/kharente-deuh/uchiyomi-server/pkg/sources/asurascans/pkg/domain"
@@ -954,6 +956,7 @@ func setupChapters(deps chaptersDeps) (*chapters.Service, *download.App, error) 
 		Repository:        deps.ChaptersRepository,
 		ChapterDownloader: worker,
 		LibraryRepository: deps.LibraryRepository,
+		ComicLookup:       comicsExistsLookup{repo: deps.ComicsRepository},
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("chapters.NewService: %w", err)
@@ -972,4 +975,21 @@ func setupChapters(deps chaptersDeps) (*chapters.Service, *download.App, error) 
 	}
 
 	return svc, app, nil
+}
+
+type comicsExistsLookup struct {
+	repo comics.ComicsRepository
+}
+
+func (l comicsExistsLookup) Exists(ctx context.Context, id uuid.UUID) (bool, error) {
+	_, err := l.repo.FindByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("l.repo.FindByID: %w", err)
+	}
+
+	return true, nil
 }

--- a/api/pkg/core/chapters/domain.go
+++ b/api/pkg/core/chapters/domain.go
@@ -50,6 +50,11 @@ type ChaptersService interface {
 	CleanupComic(context.Context, uuid.UUID, []Chapter) error
 	RetryDownload(context.Context, RetryDownloadOpts) error
 	GetByIds(context.Context, GetByIdsOpts) ([]Chapter, error)
+	ListForLibrary(context.Context, ListForLibraryOpts) ([]Chapter, error)
+}
+
+type ComicLookup interface {
+	Exists(context.Context, uuid.UUID) (bool, error)
 }
 
 type RetryDownloadOpts struct {
@@ -60,6 +65,11 @@ type RetryDownloadOpts struct {
 type GetByIdsOpts struct {
 	IDs    []uuid.UUID
 	UserID uuid.UUID
+}
+
+type ListForLibraryOpts struct {
+	UserID  uuid.UUID
+	ComicID uuid.UUID
 }
 
 type CreateOpts struct {

--- a/api/pkg/core/chapters/download/app_test.go
+++ b/api/pkg/core/chapters/download/app_test.go
@@ -63,6 +63,10 @@ func (f *fakeChaptersService) GetByIds(context.Context, chapters.GetByIdsOpts) (
 	panic("GetByIds must not be called")
 }
 
+func (f *fakeChaptersService) ListForLibrary(context.Context, chapters.ListForLibraryOpts) ([]chapters.Chapter, error) {
+	panic("ListForLibrary must not be called")
+}
+
 type blockingWorker struct {
 	started chan struct{}
 }

--- a/api/pkg/core/chapters/gateway/http/controller.go
+++ b/api/pkg/core/chapters/gateway/http/controller.go
@@ -83,6 +83,7 @@ func (c *Controller) InitRouter(r chi.Router) {
 	r.Route(c.cfg.Endpoint, func(r chi.Router) {
 		r.Use(c.cfg.Middlewares...)
 
+		r.Get("/", c.listForLibrary)
 		r.Post("/{id}/retry", c.retryDownload)
 		r.Post("/list", c.postList)
 	})
@@ -164,9 +165,63 @@ func (c *Controller) postList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	chapters := make([]postListResponseChapter, 0, len(res))
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, chapterHTTPList(res))
+}
+
+func (c *Controller) listForLibrary(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user, ok := httpsession.UserFrom(ctx)
+	if !ok {
+		c.deps.Logger.Error("user not found in context")
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+
+		return
+	}
+
+	rawComicID := strings.TrimSpace(r.URL.Query().Get("comicId"))
+	if rawComicID == "" {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "comicId is required")
+
+		return
+	}
+
+	comicID, err := uuid.Parse(rawComicID)
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "comicId must be a valid UUID")
+
+		return
+	}
+
+	res, err := c.deps.ChaptersService.ListForLibrary(ctx, chapters.ListForLibraryOpts{
+		UserID:  user.ID,
+		ComicID: comicID,
+	})
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusNotFound, "comic not found")
+
+			return
+		}
+
+		if errors.Is(err, domain.ErrForbidden) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusForbidden, "comic not in library")
+
+			return
+		}
+
+		c.deps.Logger.Error("failed to list chapters", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, chapterHTTPList(res))
+}
+
+func chapterHTTPList(res []chapters.Chapter) []postListResponseChapter {
+	out := make([]postListResponseChapter, 0, len(res))
 	for _, chapter := range res {
-		chapters = append(chapters, postListResponseChapter{
+		out = append(out, postListResponseChapter{
 			PublishedAt:       chapter.PublishedAt,
 			EarlyAccessUntil:  utils.OptionalTime(chapter.EarlyAccessUntil),
 			SourceChapterSlug: chapter.SourceChapterSlug,
@@ -179,5 +234,5 @@ func (c *Controller) postList(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, chapters)
+	return out
 }

--- a/api/pkg/core/chapters/gateway/http/controller_test.go
+++ b/api/pkg/core/chapters/gateway/http/controller_test.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//nolint:goconst,lll
 package http_test
 
 import (
@@ -34,10 +35,13 @@ const (
 )
 
 type stubChaptersService struct {
-	retryErr         error
-	getByIdsErr      error
-	getByIdsResult   []chapters.Chapter
-	lastGetByIdsOpts chapters.GetByIdsOpts
+	retryErr               error
+	getByIdsErr            error
+	listForLibraryErr      error
+	getByIdsResult         []chapters.Chapter
+	listForLibraryResult   []chapters.Chapter
+	lastGetByIdsOpts       chapters.GetByIdsOpts
+	lastListForLibraryOpts chapters.ListForLibraryOpts
 }
 
 func (s *stubChaptersService) CreateAll(
@@ -74,6 +78,14 @@ func (s *stubChaptersService) GetByIds(_ context.Context, opts chapters.GetByIds
 	s.lastGetByIdsOpts = opts
 
 	return s.getByIdsResult, s.getByIdsErr
+}
+
+func (s *stubChaptersService) ListForLibrary(
+	_ context.Context, opts chapters.ListForLibraryOpts,
+) ([]chapters.Chapter, error) {
+	s.lastListForLibraryOpts = opts
+
+	return s.listForLibraryResult, s.listForLibraryErr
 }
 
 type stubSessionService struct {
@@ -430,6 +442,179 @@ func TestPostListReturnsChapters(t *testing.T) {
 
 	if got[1].EarlyAccessUntil != nil {
 		t.Errorf("chapters[1].earlyAccessUntil = %v, want nil", got[1].EarlyAccessUntil)
+	}
+}
+
+func TestListForLibraryRequiresAuthentication(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: chaptersUsername}
+	r := newChaptersTestRouter(t, &stubChaptersService{}, chaptersAuthenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodGet, chaptersEndpoint+"?comicId="+uuid.New().String(), nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestListForLibraryMissingComicID(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: chaptersUsername}
+	r := newChaptersTestRouter(t, &stubChaptersService{}, chaptersAuthenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodGet, chaptersEndpoint, nil)
+	req.AddCookie(&http.Cookie{Name: chaptersCookie, Value: chaptersToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestListForLibraryInvalidComicID(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: chaptersUsername}
+	r := newChaptersTestRouter(t, &stubChaptersService{}, chaptersAuthenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodGet, chaptersEndpoint+"?comicId=not-a-uuid", nil)
+	req.AddCookie(&http.Cookie{Name: chaptersCookie, Value: chaptersToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestListForLibraryNotFoundWhenComicMissing(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: chaptersUsername}
+	comicID := uuid.New()
+	r := newChaptersTestRouter(t, &stubChaptersService{
+		listForLibraryErr: fmt.Errorf("s.deps.ComicLookup.Exists: %w", domain.ErrNotFound),
+	}, chaptersAuthenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodGet, chaptersEndpoint+"?comicId="+comicID.String(), nil)
+	req.AddCookie(&http.Cookie{Name: chaptersCookie, Value: chaptersToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d body=%s (404 when comic is missing)", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+}
+
+func TestListForLibraryForbiddenWhenNotInLibrary(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: chaptersUsername}
+	comicID := uuid.New()
+	r := newChaptersTestRouter(t, &stubChaptersService{
+		listForLibraryErr: domain.ErrForbidden,
+	}, chaptersAuthenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodGet, chaptersEndpoint+"?comicId="+comicID.String(), nil)
+	req.AddCookie(&http.Cookie{Name: chaptersCookie, Value: chaptersToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d body=%s (403 when comic exists but is not in the user's library)", rec.Code, http.StatusForbidden, rec.Body.String())
+	}
+}
+
+func TestListForLibraryInternalError(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: chaptersUsername}
+	r := newChaptersTestRouter(t, &stubChaptersService{
+		listForLibraryErr: errors.New("db down"),
+	}, chaptersAuthenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodGet, chaptersEndpoint+"?comicId="+uuid.New().String(), nil)
+	req.AddCookie(&http.Cookie{Name: chaptersCookie, Value: chaptersToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestListForLibraryReturnsChapters(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: chaptersUsername}
+	chapterID := uuid.New()
+	comicID := uuid.New()
+	publishedAt := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	earlyAccessUntil := time.Date(2026, 12, 1, 0, 0, 0, 0, time.UTC)
+	svc := &stubChaptersService{
+		listForLibraryResult: []chapters.Chapter{
+			{
+				PublishedAt:       publishedAt,
+				EarlyAccessUntil:  &earlyAccessUntil,
+				SourceChapterSlug: "chapter-3",
+				Title:             "Locked",
+				Number:            3,
+				PagesNb:           12,
+				Download:          0,
+				ID:                chapterID,
+				ComicID:           comicID,
+			},
+			{
+				PublishedAt:       publishedAt,
+				SourceChapterSlug: "chapter-1",
+				Title:             "Chapter 1",
+				Number:            1,
+				PagesNb:           20,
+				Download:          100,
+				ID:                uuid.New(),
+				ComicID:           comicID,
+			},
+		},
+	}
+	r := newChaptersTestRouter(t, svc, chaptersAuthenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodGet, chaptersEndpoint+"?comicId="+comicID.String(), nil)
+	req.AddCookie(&http.Cookie{Name: chaptersCookie, Value: chaptersToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	if svc.lastListForLibraryOpts.UserID != user.ID || svc.lastListForLibraryOpts.ComicID != comicID {
+		t.Errorf("ListForLibrary opts = %+v, want user=%s comic=%s", svc.lastListForLibraryOpts, user.ID, comicID)
+	}
+
+	var got []postListHTTPChapter
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("len(chapters) = %d, want 2", len(got))
+	}
+
+	if got[0].ID != chapterID || got[0].Number != 3 || got[0].Download != 0 {
+		t.Errorf("chapters[0] = %+v", got[0])
+	}
+
+	if got[0].EarlyAccessUntil == nil || !got[0].EarlyAccessUntil.Equal(earlyAccessUntil) {
+		t.Errorf("locked chapter earlyAccessUntil = %v, want %v", got[0].EarlyAccessUntil, earlyAccessUntil)
+	}
+
+	if got[1].EarlyAccessUntil != nil || got[1].Download != 100 {
+		t.Errorf("chapters[1] = %+v", got[1])
 	}
 }
 

--- a/api/pkg/core/chapters/service.go
+++ b/api/pkg/core/chapters/service.go
@@ -3,9 +3,11 @@
 package chapters
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -21,6 +23,7 @@ type Deps struct {
 	Repository        ChaptersRepository
 	ChapterDownloader ChapterDownloader
 	LibraryRepository library.LibraryRepository
+	ComicLookup       ComicLookup
 }
 
 func (deps *Deps) Validate() error {
@@ -34,6 +37,10 @@ func (deps *Deps) Validate() error {
 
 	if deps.LibraryRepository == nil {
 		return errors.New("libraryRepository is required")
+	}
+
+	if deps.ComicLookup == nil {
+		return errors.New("comicLookup is required")
 	}
 
 	return nil
@@ -194,6 +201,41 @@ func isDownloadable(chapter Chapter, now time.Time) bool {
 	}
 
 	return true
+}
+
+func (s *Service) ListForLibrary(ctx context.Context, opts ListForLibraryOpts) ([]Chapter, error) {
+	inLibrary, err := s.deps.LibraryRepository.ExistsByUserAndComic(ctx, opts.UserID, opts.ComicID)
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.LibraryRepository.ExistsByUserAndComic: %w", err)
+	}
+
+	if !inLibrary {
+		exists, lookupErr := s.deps.ComicLookup.Exists(ctx, opts.ComicID)
+		if lookupErr != nil {
+			return nil, fmt.Errorf("s.deps.ComicLookup.Exists: %w", lookupErr)
+		}
+
+		if !exists {
+			return nil, domain.ErrNotFound
+		}
+
+		return nil, domain.ErrForbidden
+	}
+
+	chapterList, err := s.deps.Repository.ListByComicID(ctx, opts.ComicID)
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.Repository.ListByComicID: %w", err)
+	}
+
+	slices.SortFunc(chapterList, func(a, b Chapter) int {
+		return cmp.Compare(b.Number, a.Number)
+	})
+
+	if chapterList == nil {
+		chapterList = []Chapter{}
+	}
+
+	return chapterList, nil
 }
 
 func (s *Service) GetByIds(ctx context.Context, opts GetByIdsOpts) ([]Chapter, error) {

--- a/api/pkg/core/chapters/service_test.go
+++ b/api/pkg/core/chapters/service_test.go
@@ -195,6 +195,20 @@ func (f *fakeLibraryRepository) ExistsByUserAndComic(
 	return f.existsByUserAndComic, f.existsErr
 }
 
+type fakeComicLookup struct {
+	existsErr error
+	lastID    uuid.UUID
+	exists    bool
+	calls     int
+}
+
+func (f *fakeComicLookup) Exists(_ context.Context, id uuid.UUID) (bool, error) {
+	f.calls++
+	f.lastID = id
+
+	return f.exists, f.existsErr
+}
+
 func newTestService(
 	repo *fakeChaptersRepository,
 	downloader *fakeChapterDownloader,
@@ -204,6 +218,7 @@ func newTestService(
 		Repository:        repo,
 		ChapterDownloader: downloader,
 		LibraryRepository: libraryRepo,
+		ComicLookup:       &fakeComicLookup{exists: true},
 	})
 	if err != nil {
 		panic(err)
@@ -629,5 +644,236 @@ func TestServiceGetByIdsLibraryError(t *testing.T) {
 
 	if got != nil {
 		t.Errorf("GetByIds returned %+v in addition to the error", got)
+	}
+}
+
+func TestServiceListForLibraryReturnsDescendingIncludingLocked(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	comicID := uuid.New()
+	lockedUntil := time.Date(2026, time.December, 1, 0, 0, 0, 0, time.UTC)
+	low := chapters.Chapter{ID: uuid.New(), ComicID: comicID, Number: 1, Title: "One", Download: 100}
+	locked := chapters.Chapter{
+		ID: uuid.New(), ComicID: comicID, Number: 3, Title: "Locked", Download: 0, EarlyAccessUntil: &lockedUntil,
+	}
+	mid := chapters.Chapter{ID: uuid.New(), ComicID: comicID, Number: 2, Title: "Two", Download: 40}
+	repo := &fakeChaptersRepository{listByComicIDResult: []chapters.Chapter{low, locked, mid}}
+	libraryRepo := &fakeLibraryRepository{existsByUserAndComic: true}
+	svc := newTestService(repo, &fakeChapterDownloader{}, libraryRepo)
+
+	got, err := svc.ListForLibrary(context.Background(), chapters.ListForLibraryOpts{
+		UserID:  userID,
+		ComicID: comicID,
+	})
+	if err != nil {
+		t.Fatalf("ListForLibrary: %v", err)
+	}
+
+	if libraryRepo.lastUserID != userID || libraryRepo.lastComicID != comicID {
+		t.Errorf("library check user/comic = %s/%s, want %s/%s",
+			libraryRepo.lastUserID, libraryRepo.lastComicID, userID, comicID)
+	}
+
+	if repo.listByComicIDCalls != 1 || repo.lastListByComicID != comicID {
+		t.Errorf("ListByComicID comic = %s, calls = %d", repo.lastListByComicID, repo.listByComicIDCalls)
+	}
+
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+
+	if got[0].Number != 3 || got[1].Number != 2 || got[2].Number != 1 {
+		t.Errorf("order = %v, %v, %v, want 3, 2, 1", got[0].Number, got[1].Number, got[2].Number)
+	}
+
+	if got[0].EarlyAccessUntil == nil || !got[0].EarlyAccessUntil.Equal(lockedUntil) {
+		t.Errorf("locked chapter missing earlyAccessUntil: %+v", got[0])
+	}
+}
+
+func TestServiceListForLibraryEmpty(t *testing.T) {
+	t.Parallel()
+
+	svc := newTestService(
+		&fakeChaptersRepository{},
+		&fakeChapterDownloader{},
+		&fakeLibraryRepository{existsByUserAndComic: true},
+	)
+
+	got, err := svc.ListForLibrary(context.Background(), chapters.ListForLibraryOpts{
+		UserID:  uuid.New(),
+		ComicID: uuid.New(),
+	})
+	if err != nil {
+		t.Fatalf("ListForLibrary: %v", err)
+	}
+
+	if got == nil || len(got) != 0 {
+		t.Errorf("ListForLibrary() = %+v, want empty slice", got)
+	}
+}
+
+func TestServiceListForLibraryForbiddenWhenComicExistsButNotInLibrary(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	lookup := &fakeComicLookup{exists: true}
+	svc, err := chapters.NewService(chapters.Deps{
+		Repository:        &fakeChaptersRepository{listByComicIDResult: []chapters.Chapter{{Number: 1}}},
+		ChapterDownloader: &fakeChapterDownloader{},
+		LibraryRepository: &fakeLibraryRepository{existsByUserAndComic: false},
+		ComicLookup:       lookup,
+	})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	got, err := svc.ListForLibrary(context.Background(), chapters.ListForLibraryOpts{
+		UserID:  uuid.New(),
+		ComicID: comicID,
+	})
+	if !errors.Is(err, domain.ErrForbidden) {
+		t.Fatalf("ListForLibrary = %v, want domain.ErrForbidden", err)
+	}
+
+	if got != nil {
+		t.Errorf("ListForLibrary returned %+v in addition to the error", got)
+	}
+
+	if lookup.calls != 1 || lookup.lastID != comicID {
+		t.Errorf("ComicLookup.Exists comic = %s, calls = %d", lookup.lastID, lookup.calls)
+	}
+}
+
+func TestServiceListForLibraryNotFoundWhenComicMissing(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	lookup := &fakeComicLookup{exists: false}
+	svc, err := chapters.NewService(chapters.Deps{
+		Repository:        &fakeChaptersRepository{},
+		ChapterDownloader: &fakeChapterDownloader{},
+		LibraryRepository: &fakeLibraryRepository{existsByUserAndComic: false},
+		ComicLookup:       lookup,
+	})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	got, err := svc.ListForLibrary(context.Background(), chapters.ListForLibraryOpts{
+		UserID:  uuid.New(),
+		ComicID: comicID,
+	})
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("ListForLibrary = %v, want domain.ErrNotFound", err)
+	}
+
+	if got != nil {
+		t.Errorf("ListForLibrary returned %+v in addition to the error", got)
+	}
+
+	if lookup.calls != 1 || lookup.lastID != comicID {
+		t.Errorf("ComicLookup.Exists comic = %s, calls = %d", lookup.lastID, lookup.calls)
+	}
+}
+
+func TestServiceListForLibraryDoesNotLookupComicWhenInLibrary(t *testing.T) {
+	t.Parallel()
+
+	lookup := &fakeComicLookup{exists: false}
+	svc, err := chapters.NewService(chapters.Deps{
+		Repository:        &fakeChaptersRepository{},
+		ChapterDownloader: &fakeChapterDownloader{},
+		LibraryRepository: &fakeLibraryRepository{existsByUserAndComic: true},
+		ComicLookup:       lookup,
+	})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	_, err = svc.ListForLibrary(context.Background(), chapters.ListForLibraryOpts{
+		UserID:  uuid.New(),
+		ComicID: uuid.New(),
+	})
+	if err != nil {
+		t.Fatalf("ListForLibrary: %v", err)
+	}
+
+	if lookup.calls != 0 {
+		t.Errorf("ComicLookup.Exists called %d times, want 0", lookup.calls)
+	}
+}
+
+func TestServiceListForLibraryLibraryError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("library down")
+	svc := newTestService(
+		&fakeChaptersRepository{},
+		&fakeChapterDownloader{},
+		&fakeLibraryRepository{existsErr: sentinel},
+	)
+
+	got, err := svc.ListForLibrary(context.Background(), chapters.ListForLibraryOpts{
+		UserID:  uuid.New(),
+		ComicID: uuid.New(),
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("ListForLibrary = %v, want wrapped library sentinel", err)
+	}
+
+	if got != nil {
+		t.Errorf("ListForLibrary returned %+v in addition to the error", got)
+	}
+}
+
+func TestServiceListForLibraryListError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("db down")
+	svc := newTestService(
+		&fakeChaptersRepository{listByComicIDErr: sentinel},
+		&fakeChapterDownloader{},
+		&fakeLibraryRepository{existsByUserAndComic: true},
+	)
+
+	got, err := svc.ListForLibrary(context.Background(), chapters.ListForLibraryOpts{
+		UserID:  uuid.New(),
+		ComicID: uuid.New(),
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("ListForLibrary = %v, want wrapped list sentinel", err)
+	}
+
+	if got != nil {
+		t.Errorf("ListForLibrary returned %+v in addition to the error", got)
+	}
+}
+
+func TestServiceListForLibraryLookupError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("comics down")
+	svc, err := chapters.NewService(chapters.Deps{
+		Repository:        &fakeChaptersRepository{},
+		ChapterDownloader: &fakeChapterDownloader{},
+		LibraryRepository: &fakeLibraryRepository{existsByUserAndComic: false},
+		ComicLookup:       &fakeComicLookup{existsErr: sentinel},
+	})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	got, err := svc.ListForLibrary(context.Background(), chapters.ListForLibraryOpts{
+		UserID:  uuid.New(),
+		ComicID: uuid.New(),
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("ListForLibrary = %v, want wrapped lookup sentinel", err)
+	}
+
+	if got != nil {
+		t.Errorf("ListForLibrary returned %+v in addition to the error", got)
 	}
 }

--- a/api/pkg/core/comics/service_test.go
+++ b/api/pkg/core/comics/service_test.go
@@ -335,6 +335,10 @@ func (f *fakeChaptersService) RetryDownload(context.Context, chapters.RetryDownl
 	return nil
 }
 
+func (f *fakeChaptersService) ListForLibrary(context.Context, chapters.ListForLibraryOpts) ([]chapters.Chapter, error) {
+	panic("ListForLibrary must not be called")
+}
+
 //nolint:govet // fieldalignment on a test fake is not worth the unreadable field order
 type fakeSource struct {
 	infos             *sources.GetInfosBySlugResponse

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -392,6 +392,10 @@ func (fakeChaptersService) GetByIds(context.Context, chapters.GetByIdsOpts) ([]c
 	return nil, errors.New(notImplemented)
 }
 
+func (fakeChaptersService) ListForLibrary(context.Context, chapters.ListForLibraryOpts) ([]chapters.Chapter, error) {
+	return nil, errors.New(notImplemented)
+}
+
 type fakeFeedService struct{}
 
 func (fakeFeedService) Get(context.Context, feed.GetOpts) (feed.Page, error) {

--- a/api/pkg/sources/asurascans/pkg/core/app_test.go
+++ b/api/pkg/sources/asurascans/pkg/core/app_test.go
@@ -216,6 +216,10 @@ func (s libraryChaptersService) GetByIds(context.Context, chapters.GetByIdsOpts)
 	return nil, nil
 }
 
+func (s libraryChaptersService) ListForLibrary(context.Context, chapters.ListForLibraryOpts) ([]chapters.Chapter, error) {
+	return nil, nil
+}
+
 func newCache[P any, T any](
 	t *testing.T, key func(P) string, fn func(context.Context, P) (*T, error),
 ) *fncache.Cache[P, T] {

--- a/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
+++ b/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
@@ -169,6 +169,10 @@ func (s libraryChaptersService) GetByIds(context.Context, chapters.GetByIdsOpts)
 	return nil, nil
 }
 
+func (s libraryChaptersService) ListForLibrary(context.Context, chapters.ListForLibraryOpts) ([]chapters.Chapter, error) {
+	return nil, nil
+}
+
 func newTestAsuraApp(t *testing.T) *asura.App {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

Closes #55.

- Add authenticated `GET /api/chapters?comicId={uuid}` returning the full stored chapter list for a library comic (JSON array, not `{ items, total }`)
- Include `id`, `title`, `number`, `publishedAt`, `earlyAccessUntil`, `download`, and `pagesNb`; order by chapter number descending
- Keep locked chapters in the list so the library comic page can display locks like the Asura series page
- Match retry HTTP mapping: 400 for missing/invalid `comicId`, 404 when the comic is unknown, 403 when it exists but is not in the current user's library

## Test plan

- [x] `GET /api/chapters?comicId=` returns all stored chapters with download progress
- [x] Unauthenticated request → 401
- [x] Missing or invalid `comicId` → 400
- [x] Unknown comic → 404; comic not in the user's library → 403
- [x] Locked chapters are present
- [x] `go test ./...` and `golangci-lint run ./...` pass