### PR TITLE
feat(web): library comic page

### DIFF
--- a/api/pkg/core/chapters/domain.go
+++ b/api/pkg/core/chapters/domain.go
@@ -26,7 +26,7 @@ type ChaptersRepository interface {
 	Create(context.Context, CreateOpts) (*Chapter, error)
 	CreateMany(context.Context, []CreateOpts) ([]Chapter, error)
 	ListByComicID(context.Context, uuid.UUID) ([]Chapter, error)
-	ListResumable(context.Context) ([]Chapter, error)
+	ListResumable(context.Context, time.Time) ([]Chapter, error)
 	ListEarlyAccessUnlocked(context.Context, time.Time) ([]Chapter, error)
 	GetByID(context.Context, uuid.UUID) (*Chapter, error)
 	UpdateDownload(context.Context, uuid.UUID, int) error

--- a/api/pkg/core/chapters/download/worker_test.go
+++ b/api/pkg/core/chapters/download/worker_test.go
@@ -40,7 +40,7 @@ func (f *fakeChaptersRepository) ListByComicID(context.Context, uuid.UUID) ([]ch
 	panic("not implemented")
 }
 
-func (f *fakeChaptersRepository) ListResumable(context.Context) ([]chapters.Chapter, error) {
+func (f *fakeChaptersRepository) ListResumable(context.Context, time.Time) ([]chapters.Chapter, error) {
 	panic("not implemented")
 }
 

--- a/api/pkg/core/chapters/repository/pg/repository.go
+++ b/api/pkg/core/chapters/repository/pg/repository.go
@@ -89,9 +89,12 @@ func (r *PGChaptersRepository) ListByComicID(ctx context.Context, comicID uuid.U
 	return ret, nil
 }
 
-func (r *PGChaptersRepository) ListResumable(ctx context.Context) ([]chapters.Chapter, error) {
+func (r *PGChaptersRepository) ListResumable(ctx context.Context, now time.Time) ([]chapters.Chapter, error) {
+	resumableWhere := "(download > 0 AND download < 100) OR download = -1" +
+		" OR (download = 0 AND (early_access_until IS NULL OR early_access_until <= ?))"
+
 	models, err := r.db(ctx).
-		Where("(download > 0 AND download < 100) OR download = -1").
+		Where(resumableWhere, now).
 		Find(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)

--- a/api/pkg/core/chapters/repository/pg/repository_test.go
+++ b/api/pkg/core/chapters/repository/pg/repository_test.go
@@ -224,24 +224,26 @@ func TestChaptersListResumable(t *testing.T) {
 	comicID := uuid.New()
 	id := uuid.New()
 	publishedAt := time.Now().UTC().Truncate(time.Second)
+	now := time.Now().UTC().Truncate(time.Second)
 
-	mock.ExpectQuery(`FROM "chapters".*download > 0 AND download < 100\) OR download = -1`).
+	mock.ExpectQuery(`FROM "chapters".*\(download > 0 AND download < 100\) OR download = -1 OR \(download = 0 AND \(early_access_until IS NULL OR early_access_until <= \$1\)\)`).
+		WithArgs(now).
 		WillReturnRows(
 			sqlmock.NewRows([]string{
 				"id", "comic_id", "source_chapter_slug", "number", "title",
 				"pages_nb", "published_at", "early_access_until", "download",
 			}).AddRow(
 				id, comicID, chapterSlug, 1.0, chapterTitle,
-				42, publishedAt, publishedAt, 42,
+				42, publishedAt, nil, 0,
 			),
 		)
 
-	got, err := r.ListResumable(context.Background())
+	got, err := r.ListResumable(context.Background(), now)
 	if err != nil {
 		t.Fatalf("ListResumable: %v", err)
 	}
 
-	if len(got) != 1 || got[0].ID != id || got[0].Download != 42 {
+	if len(got) != 1 || got[0].ID != id || got[0].Download != 0 {
 		t.Errorf("ListResumable() = %+v", got)
 	}
 }

--- a/api/pkg/core/chapters/service.go
+++ b/api/pkg/core/chapters/service.go
@@ -118,7 +118,7 @@ func (s *Service) EnqueueDownloadable(ctx context.Context, chapters []Chapter) e
 }
 
 func (s *Service) EnqueueResumable(ctx context.Context) error {
-	chapterList, err := s.deps.Repository.ListResumable(ctx)
+	chapterList, err := s.deps.Repository.ListResumable(ctx, time.Now())
 	if err != nil {
 		return fmt.Errorf("s.deps.Repository.ListResumable: %w", err)
 	}

--- a/api/pkg/core/chapters/service_test.go
+++ b/api/pkg/core/chapters/service_test.go
@@ -73,7 +73,7 @@ func (f *fakeChaptersRepository) ListByComicID(_ context.Context, comicID uuid.U
 	return f.listByComicIDResult, nil
 }
 
-func (f *fakeChaptersRepository) ListResumable(context.Context) ([]chapters.Chapter, error) {
+func (f *fakeChaptersRepository) ListResumable(context.Context, time.Time) ([]chapters.Chapter, error) {
 	f.listResumableCalls++
 
 	return f.listResumableResult, nil

--- a/web/app/features/asura/components/Comic/GeneralInfos.test.ts
+++ b/web/app/features/asura/components/Comic/GeneralInfos.test.ts
@@ -3,11 +3,23 @@
 
 import type { VueWrapper } from '@vue/test-utils'
 import type { AsuraComicInfos } from '../../types'
-import { mountSuspended } from '@nuxt/test-utils/runtime'
-import { describe, expect, it } from 'vitest'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { h } from 'vue'
 import { VApp } from 'vuetify/components'
 import GeneralInfos from './GeneralInfos.vue'
+
+const { smAndDown } = await vi.hoisted(async () => {
+  const { ref } = await import('vue')
+
+  return { smAndDown: ref(true) }
+})
+
+function displayStub(): { smAndDown: typeof smAndDown } {
+  return { smAndDown }
+}
+
+mockNuxtImport('useDisplay', () => displayStub)
 
 function comic(overrides: Partial<AsuraComicInfos> = {}): AsuraComicInfos {
   return {
@@ -37,6 +49,10 @@ async function mount(value: AsuraComicInfos = comic()): Promise<VueWrapper> {
   })
 }
 
+beforeEach(() => {
+  smAndDown.value = true
+})
+
 describe('asuraComicGeneralInfos', () => {
   it('strips HTML and newlines from the description', async () => {
     const wrapper = await mount()
@@ -47,6 +63,18 @@ describe('asuraComicGeneralInfos', () => {
   it('joins alternate titles', async () => {
     const wrapper = await mount()
     expect(wrapper.text()).toContain('나 혼자만 레벨업, Only I Level Up')
+  })
+
+  it('renders genres', async () => {
+    const wrapper = await mount()
+    expect(wrapper.text()).toContain('action')
+  })
+
+  it('starts expanded on desktop', async () => {
+    smAndDown.value = false
+    const wrapper = await mount()
+    expect(wrapper.text()).toContain('Show less')
+    expect(wrapper.find('.text-truncate').exists()).toBe(false)
   })
 
   it('expands truncated text when show more is clicked', async () => {

--- a/web/app/features/asura/components/Comic/StatusInfos.test.ts
+++ b/web/app/features/asura/components/Comic/StatusInfos.test.ts
@@ -79,15 +79,14 @@ async function mount(comic: AsuraComicInfos): Promise<{ wrapper: VueWrapper, com
 }
 
 describe('asuraComicStatusInfos', () => {
-  it('renders status, type, author, artist and genres', async () => {
+  it('renders status, type, author and artist', async () => {
     const { wrapper } = await mount(infos())
 
     expect(wrapper.text()).toContain('Ongoing')
     expect(wrapper.text()).toContain('Manhwa')
     expect(wrapper.text()).toContain('Chugong')
     expect(wrapper.text()).toContain('Jang')
-    expect(wrapper.text()).toContain('action')
-    expect(wrapper.text()).toContain('fantasy')
+    expect(wrapper.text()).not.toContain('action')
     expect(wrapper.find('[data-test="origin"]').attributes('href')).toBe('https://asurascans.com/series/solo-leveling')
   })
 

--- a/web/app/features/asura/components/Comic/StatusInfos.vue
+++ b/web/app/features/asura/components/Comic/StatusInfos.vue
@@ -87,16 +87,5 @@ watch(() => comic.value.internalId, () => {
       <span class="text-body-large text-medium-emphasis text-uppercase text-truncate">{{ $t('comic.fields.artist') }}</span>
       <span class="text-body-large font-weight-bold text-truncate">{{ comic.artist }}</span>
     </div>
-    <template v-if="comic.genres.length">
-      <VDivider />
-      <div class="d-flex flex-wrap ga-3">
-        <span
-          v-for="(genre, i) in comic.genres"
-          :key="i"
-          class="text-capitalize px-2 py-1 bg-background border-thin"
-          style="border-radius: 12px;"
-        >{{ genre }}</span>
-      </div>
-    </template>
   </div>
 </template>

--- a/web/app/features/asura/composables/asura-chapters.composable.test.ts
+++ b/web/app/features/asura/composables/asura-chapters.composable.test.ts
@@ -30,7 +30,7 @@ function routeStub(): { params: { slug: string } } {
 mockNuxtImport('useI18n', () => i18nStub)
 mockNuxtImport('useRoute', () => routeStub)
 // eslint-disable-next-line unicorn/consistent-function-scoping
-mockNuxtImport('useChaptersApi', () => () => ({ retryDownload: retryDownloadApi }))
+mockNuxtImport('createChaptersApi', () => () => ({ retryDownload: retryDownloadApi }))
 
 function chapter(overrides: Partial<AsuraComicChapter> = {}): AsuraComicChapter {
   return {

--- a/web/app/features/asura/composables/asura-chapters.composable.test.ts
+++ b/web/app/features/asura/composables/asura-chapters.composable.test.ts
@@ -27,10 +27,17 @@ function routeStub(): { params: { slug: string } } {
   return { params: { slug: 'solo-leveling' } }
 }
 
+function createChaptersApiStub(): ChaptersApi {
+  return {
+    retryDownload: retryDownloadApi,
+    getByIds: vi.fn(),
+    getByComicId: vi.fn(),
+  }
+}
+
 mockNuxtImport('useI18n', () => i18nStub)
 mockNuxtImport('useRoute', () => routeStub)
-// eslint-disable-next-line unicorn/consistent-function-scoping
-mockNuxtImport('createChaptersApi', () => () => ({ retryDownload: retryDownloadApi }))
+mockNuxtImport('createChaptersApi', () => createChaptersApiStub)
 
 function chapter(overrides: Partial<AsuraComicChapter> = {}): AsuraComicChapter {
   return {

--- a/web/app/features/asura/composables/asura-chapters.composable.ts
+++ b/web/app/features/asura/composables/asura-chapters.composable.ts
@@ -21,7 +21,7 @@ export function isChapterDownloadInProgress(chapter: AsuraComicChapter): boolean
 export function useAsuraChapters(): AsuraChaptersComposable {
   const store = useAsuraChaptersStore()
   const api = createAsuraApi()
-  const chaptersApi = useChaptersApi()
+  const chaptersApi = createChaptersApi()
   const toast = useToast()
   const { t } = useI18n()
   const route = useRoute('browse-sources-asura-slug')

--- a/web/app/features/chapters/composables/chapters.api.test.ts
+++ b/web/app/features/chapters/composables/chapters.api.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { useChaptersApi } from './chapters.api'
+import { createChaptersApi } from './chapters.api'
 
 const call = vi.fn()
 
@@ -14,11 +14,11 @@ beforeEach(() => {
   call.mockReset()
 })
 
-describe('useChaptersApi().retryDownload', () => {
+describe('createChaptersApi().retryDownload', () => {
   it('posts retry for the chapter id', async () => {
     call.mockResolvedValue(undefined)
 
-    const res = await useChaptersApi().retryDownload('ch-1')
+    const res = await createChaptersApi().retryDownload('ch-1')
 
     expect(call).toHaveBeenCalledWith('/ch-1/retry', { method: 'POST' })
     expect(res).toEqual({ success: true, data: undefined })
@@ -27,7 +27,7 @@ describe('useChaptersApi().retryDownload', () => {
   it('surfaces a 409 with its status', async () => {
     call.mockRejectedValue({ statusCode: 409, data: {} })
 
-    const res = await useChaptersApi().retryDownload('ch-1')
+    const res = await createChaptersApi().retryDownload('ch-1')
 
     expect(res.success === false && res.error.status).toBe(409)
   })

--- a/web/app/features/chapters/composables/chapters.api.test.ts
+++ b/web/app/features/chapters/composables/chapters.api.test.ts
@@ -14,6 +14,46 @@ beforeEach(() => {
   call.mockReset()
 })
 
+describe('createChaptersApi().getByComicId', () => {
+  it('lists chapters for the comic', async () => {
+    const chapters = [{ id: 'ch-1', comicId: 'c1', number: 1 }]
+    call.mockResolvedValue(chapters)
+
+    const res = await createChaptersApi().getByComicId('c1')
+
+    expect(call).toHaveBeenCalledWith('/', { params: { comicId: 'c1' } })
+    expect(res).toEqual({ success: true, data: chapters })
+  })
+
+  it('surfaces a 404 with its status', async () => {
+    call.mockRejectedValue({ statusCode: 404, data: {} })
+
+    const res = await createChaptersApi().getByComicId('missing')
+
+    expect(res.success === false && res.error.status).toBe(404)
+  })
+})
+
+describe('createChaptersApi().getByIds', () => {
+  it('posts the chapter ids', async () => {
+    const chapters = [{ id: 'ch-1', comicId: 'c1', number: 1 }]
+    call.mockResolvedValue(chapters)
+
+    const res = await createChaptersApi().getByIds(['ch-1', 'ch-2'])
+
+    expect(call).toHaveBeenCalledWith('/list', { method: 'POST', body: { ids: ['ch-1', 'ch-2'] } })
+    expect(res).toEqual({ success: true, data: chapters })
+  })
+
+  it('surfaces a failure with its status', async () => {
+    call.mockRejectedValue({ statusCode: 502, data: {} })
+
+    const res = await createChaptersApi().getByIds(['ch-1'])
+
+    expect(res.success === false && res.error.status).toBe(502)
+  })
+})
+
 describe('createChaptersApi().retryDownload', () => {
   it('posts retry for the chapter id', async () => {
     call.mockResolvedValue(undefined)

--- a/web/app/features/chapters/composables/chapters.api.ts
+++ b/web/app/features/chapters/composables/chapters.api.ts
@@ -5,9 +5,10 @@ import { ApiError, initApi } from '~/utils/api'
 export interface ChaptersApi {
   retryDownload: (chapterId: string) => Promise<ApiResponse<void>>
   getByIds: (ids: string[]) => Promise<ApiResponse<Chapter[]>>
+  getByComicId: (comicId: string) => Promise<ApiResponse<Chapter[]>>
 }
 
-export function useChaptersApi(): ChaptersApi {
+export function createChaptersApi(): ChaptersApi {
   const api = initApi('/chapters')
 
   async function retryDownload(chapterId: string): Promise<ApiResponse<void>> {
@@ -30,8 +31,19 @@ export function useChaptersApi(): ChaptersApi {
     }
   }
 
+  async function getByComicId(comicId: string): Promise<ApiResponse<Chapter[]>> {
+    try {
+      const response = await api<Chapter[]>(`/list`, { method: 'POST', body: { comicId } })
+
+      return { success: true, data: response }
+    } catch (error) {
+      return { success: false, error: ApiError.fromFetchError(error) }
+    }
+  }
+
   return {
     retryDownload,
     getByIds,
+    getByComicId,
   }
 }

--- a/web/app/features/chapters/composables/chapters.api.ts
+++ b/web/app/features/chapters/composables/chapters.api.ts
@@ -33,7 +33,7 @@ export function createChaptersApi(): ChaptersApi {
 
   async function getByComicId(comicId: string): Promise<ApiResponse<Chapter[]>> {
     try {
-      const response = await api<Chapter[]>(`/list`, { method: 'POST', body: { comicId } })
+      const response = await api<Chapter[]>(`/`, { params: { comicId } })
 
       return { success: true, data: response }
     } catch (error) {

--- a/web/app/features/comics/components/Chapters/Item.test.ts
+++ b/web/app/features/comics/components/Chapters/Item.test.ts
@@ -23,11 +23,11 @@ function chapter(overrides: Partial<Chapter> = {}): Chapter {
   }
 }
 
-async function mount(value: Chapter = chapter(), retryLoading = false): Promise<VueWrapper> {
+async function mount(value: Chapter = chapter(), isRetryLoading = false): Promise<VueWrapper> {
   return mountSuspended({
     render: () => h(VApp, () => [h(Item, {
       chapter: value,
-      retryLoading,
+      retryLoading: isRetryLoading,
       onRetry: vi.fn(),
     })]),
   })

--- a/web/app/features/comics/components/Chapters/Item.test.ts
+++ b/web/app/features/comics/components/Chapters/Item.test.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { VueWrapper } from '@vue/test-utils'
+import type { Chapter } from '~/features/chapters/types'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it, vi } from 'vitest'
+import { h } from 'vue'
+import { VApp, VProgressCircular } from 'vuetify/components'
+import Item from './Item.vue'
+
+function chapter(overrides: Partial<Chapter> = {}): Chapter {
+  return {
+    id: 'ch-1',
+    comicId: 'c1',
+    title: 'The beginning',
+    number: 12,
+    publishedAt: new Date('2026-08-18T12:00:00.000Z'),
+    sourceChapterSlug: '12',
+    pagesNb: 20,
+    download: 100,
+    ...overrides,
+  }
+}
+
+async function mount(value: Chapter = chapter(), retryLoading = false): Promise<VueWrapper> {
+  return mountSuspended({
+    render: () => h(VApp, () => [h(Item, {
+      chapter: value,
+      retryLoading,
+      onRetry: vi.fn(),
+    })]),
+  })
+}
+
+describe('comicsChaptersItem', () => {
+  it('renders the chapter number and title', async () => {
+    const wrapper = await mount()
+    expect(wrapper.text()).toContain('Chapter 12')
+    expect(wrapper.text()).toContain('The beginning')
+    expect(wrapper.find('.readable-chapter').exists()).toBe(true)
+  })
+
+  it('marks an early-access chapter', async () => {
+    const wrapper = await mount(chapter({
+      earlyAccessUntil: new Date('2099-01-01'),
+    }))
+
+    expect(wrapper.find('.early-access-chapter').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Unlocks')
+  })
+
+  it('shows a check when the chapter is downloaded', async () => {
+    const wrapper = await mount(chapter({ download: 100 }))
+    expect(wrapper.find('.v-icon').exists()).toBe(true)
+  })
+
+  it('shows progress while a past early-access chapter is downloading', async () => {
+    const wrapper = await mount(chapter({
+      download: 40,
+      earlyAccessUntil: new Date('2020-01-01'),
+    }))
+
+    expect(wrapper.findComponent(VProgressCircular).props('modelValue')).toBe(40)
+  })
+
+  it('emits retry from the error icon', async () => {
+    const onRetry = vi.fn()
+    const wrapper = await mountSuspended({
+      render: () => h(VApp, () => [h(Item, {
+        chapter: chapter({ download: -1 }),
+        retryLoading: false,
+        onRetry,
+      })]),
+    })
+
+    await wrapper.find('.v-icon').trigger('click')
+
+    expect(onRetry).toHaveBeenCalled()
+  })
+})

--- a/web/app/features/comics/components/Chapters/Item.vue
+++ b/web/app/features/comics/components/Chapters/Item.vue
@@ -1,0 +1,125 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+import type { Chapter } from '~/features/chapters/types'
+import { formatRelativeTime } from '~/utils/date.utils'
+
+const props = defineProps<{
+  chapter: Chapter
+  retryLoading: boolean
+}>()
+
+defineEmits<{ retry: [] }>()
+
+const { locale } = useI18n()
+
+const date = computed(() => {
+  const aMonthAgo = new Date()
+  aMonthAgo.setMonth(aMonthAgo.getMonth() - 1)
+
+  const d = props.chapter.earlyAccessUntil || props.chapter.publishedAt
+
+  if (d < aMonthAgo) {
+    return d.toLocaleDateString(locale.value, { dateStyle: 'medium' })
+  }
+
+  return formatRelativeTime(d, { locale: locale.value })
+})
+
+const isEarlyAccess = computed(() => props.chapter.earlyAccessUntil && props.chapter.earlyAccessUntil > new Date())
+
+const isChapterDownloading = computed(() => props.chapter.download !== undefined
+  && props.chapter.download >= 0
+  && props.chapter.download < 100
+  && (!props.chapter.earlyAccessUntil || props.chapter.earlyAccessUntil < new Date()))
+
+const isChapterDownloaded = computed(() => props.chapter.download === 100)
+const isChapterDownloadingError = computed(() => props.chapter.download === -1 && !props.retryLoading)
+</script>
+
+<template>
+  <div
+    class="d-flex justify-space-between ga-6 pa-4 border-b-thin bg-surface align-center text-truncate transition-smooth"
+    :class="{
+      'early-access-chapter': isEarlyAccess,
+      'readable-chapter': !isEarlyAccess,
+    }"
+  >
+    <div class="d-flex align-center ga-4">
+      <div v-if="isEarlyAccess" class="d-flex flex-column items-center justify-center border-thin-gold pa-2 text-body-small rounded-lg early-access-icon">
+        <VIcon
+          icon="fa6-solid:lock"
+          size="x-small"
+          color="gold"
+        />
+      </div>
+      <div
+        class="d-flex flex-wrap text-truncate"
+        :class="{
+          'flex-column': isEarlyAccess,
+          'align-center': !isEarlyAccess,
+          'ga-4': !isEarlyAccess,
+        }"
+      >
+        <span class="text-body-large font-weight-bold">{{ $t('sources.asurascans.comic.chapter', { number: chapter.number }) }}</span>
+        <span v-if="chapter.title && !isEarlyAccess" class="text-body-medium text-medium-emphasis text-truncate">{{ chapter.title }}</span>
+        <span
+          v-else-if="isEarlyAccess"
+          class="text-body-medium text-medium-emphasis text-truncate text-gold"
+        >
+          {{ $t('sources.asurascans.comic.chapterUnlocksIn', { time: formatRelativeTime(chapter.earlyAccessUntil as Date, { locale, direction: 'future' }) }) }}
+        </span>
+      </div>
+    </div>
+
+    <div class="d-flex align-center ga-3">
+      <VProgressCircular
+        v-if="isChapterDownloading"
+        :model-value="chapter.download"
+        size="18"
+        :indeterminate="chapter.download === 0"
+        width="2"
+        color="primary"
+      />
+      <VIcon
+        v-if="isChapterDownloaded"
+        icon="fa6-solid:check"
+        size="x-small"
+        color="success"
+      />
+      <VIcon
+        v-if="isChapterDownloadingError && !props.retryLoading"
+        v-tooltip:bottom="$t('sources.asurascans.comic.retryDownloadChapter.tooltip')"
+        icon="fa6-solid:exclamation"
+        classs="cursor-pointer"
+        size="x-small"
+        color="error"
+        @click.prevent="$emit('retry')"
+      />
+      <VProgressCircular
+        v-if="isChapterDownloadingError && props.retryLoading"
+        indeterminate
+        size="18"
+        width="2"
+        color="error"
+      />
+      <span class="text-body-medium text-medium-emphasis" :class="{ 'text-gold': isEarlyAccess }">{{ date }}</span>
+    </div>
+  </div>
+</template>
+
+<style lang="scss">
+.readable-chapter {
+  &:hover {
+    color: rgb(var(--v-theme-primary));
+    background-color: rgba(var(--v-theme-surface-variant));
+  }
+}
+
+.early-access-chapter {
+  background: linear-gradient(90deg, rgba(var(--v-theme-gold), 0.05) 0%, rgba(0, 0, 0, 0) 80%);
+}
+
+.early-access-icon {
+  background-color: rgb(var(--v-theme-gold), 0.1);
+}
+</style>

--- a/web/app/features/comics/components/Chapters/index.test.ts
+++ b/web/app/features/comics/components/Chapters/index.test.ts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { VueWrapper } from '@vue/test-utils'
+import type { Chapter } from '~/features/chapters/types'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { VApp } from 'vuetify/components'
+import Chapters from './index.vue'
+
+const { getByComicId, getByIds, retryDownload, pause, resume } = vi.hoisted(() => ({
+  getByComicId: vi.fn(),
+  getByIds: vi.fn(),
+  retryDownload: vi.fn(),
+  pause: vi.fn(),
+  resume: vi.fn(),
+}))
+
+function chaptersApiStub(): {
+  getByComicId: typeof getByComicId
+  getByIds: typeof getByIds
+  retryDownload: typeof retryDownload
+} {
+  return { getByComicId, getByIds, retryDownload }
+}
+
+function intervalStub(_fn: () => void): { pause: typeof pause, resume: typeof resume } {
+  return { pause, resume }
+}
+
+mockNuxtImport('createChaptersApi', () => chaptersApiStub)
+mockNuxtImport('useIntervalFn', () => intervalStub)
+
+const ItemStub = defineComponent({
+  name: 'ComicsChaptersItem',
+  props: {
+    chapter: { type: Object, required: true },
+    retryLoading: { type: Boolean, default: false },
+  },
+  emits: ['retry'],
+  template: '<button data-test="chapter" @click="$emit(\'retry\')">{{ chapter.number }}</button>',
+})
+
+function chapter(overrides: Partial<Chapter> = {}): Chapter {
+  return {
+    id: 'ch-1',
+    comicId: 'c1',
+    title: 'One',
+    number: 1,
+    publishedAt: new Date('2026-01-01'),
+    sourceChapterSlug: '1',
+    pagesNb: 10,
+    download: 100,
+    ...overrides,
+  }
+}
+
+async function mount(id = 'c1'): Promise<VueWrapper> {
+  return mountSuspended(
+    { render: () => h(VApp, () => [h(Chapters, { id })]) },
+    {
+      global: {
+        stubs: {
+          ComicsChaptersItem: ItemStub,
+          VVirtualScroll: false,
+        },
+      },
+    },
+  )
+}
+
+beforeEach(() => {
+  getByComicId.mockReset()
+  getByIds.mockReset()
+  retryDownload.mockReset()
+  pause.mockReset()
+  resume.mockReset()
+  getByComicId.mockResolvedValue({ success: true, data: [] })
+  getByIds.mockResolvedValue({ success: true, data: [] })
+  retryDownload.mockResolvedValue({ success: true, data: undefined })
+})
+
+describe('comicsChapters', () => {
+  it('fetches chapters on mount', async () => {
+    await mount()
+    expect(getByComicId).toHaveBeenCalledWith('c1')
+  })
+
+  it('shows an empty state when there are no chapters', async () => {
+    const wrapper = await mount()
+    await vi.waitFor(() => expect(wrapper.text()).toContain('No chapters'))
+  })
+
+  it('renders a row per chapter', async () => {
+    getByComicId.mockResolvedValue({ success: true, data: [chapter({ id: 'ch-2', number: 2 }), chapter()] })
+    const wrapper = await mount()
+
+    await vi.waitFor(() => expect(wrapper.findAll('[data-test="chapter"]').map(n => n.text())).toEqual(['2', '1']))
+  })
+
+  it('toggles sort between latest and oldest', async () => {
+    getByComicId.mockResolvedValue({ success: true, data: [chapter({ id: 'ch-2', number: 2 }), chapter()] })
+    const wrapper = await mount()
+    await vi.waitFor(() => expect(wrapper.findAll('[data-test="chapter"]').length).toBe(2))
+
+    expect(wrapper.text()).toContain('Latest')
+
+    await wrapper.findAll('button').at(0)!.trigger('click')
+
+    expect(wrapper.text()).toContain('Oldest')
+    expect(wrapper.findAll('[data-test="chapter"]').map(n => n.text())).toEqual(['1', '2'])
+  })
+
+  it('resumes polling when a download is in progress', async () => {
+    getByComicId.mockResolvedValue({ success: true, data: [chapter({ download: 40 })] })
+    await mount()
+
+    await vi.waitFor(() => expect(resume).toHaveBeenCalled())
+  })
+
+  it('retries a failed download from the chapter row', async () => {
+    getByComicId.mockResolvedValue({ success: true, data: [chapter({ download: -1 })] })
+    const wrapper = await mount()
+    await vi.waitFor(() => expect(wrapper.find('[data-test="chapter"]').exists()).toBe(true))
+
+    await wrapper.find('[data-test="chapter"]').trigger('click')
+
+    expect(retryDownload).toHaveBeenCalledWith('ch-1')
+  })
+})

--- a/web/app/features/comics/components/Chapters/index.vue
+++ b/web/app/features/comics/components/Chapters/index.vue
@@ -1,0 +1,164 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+import type { Chapter } from '~/features/chapters/types'
+
+const props = defineProps<{ id: string }>()
+
+const POLL_INTERVAL_MS = 2000
+
+const { t } = useI18n()
+const toast = useToast()
+const api = createChaptersApi()
+
+const chapters = ref<Chapter[]>([])
+const loading = ref(false)
+const sort = ref<'asc' | 'desc'>('desc')
+
+const sortedChapters = computed(() => chapters.value.toSorted((a, b) => sort.value === 'asc'
+  ? a.number - b.number
+  : b.number - a.number))
+
+async function fetchChapters(): Promise<void> {
+  loading.value = true
+  const res = await api.getByComicId(props.id)
+  if (!res.success) {
+    console.error('api.getChapters failed', res.error)
+    toast.error(res.error.status === 404
+      ? t('sources.asura.comic.notFound')
+      : t('error.unknown'))
+
+    loading.value = false
+
+    return
+  }
+
+  chapters.value = res.data
+  loading.value = false
+
+  syncPolling()
+}
+
+const { pause, resume } = useIntervalFn(() => {
+  void pollChapters()
+}, POLL_INTERVAL_MS, { immediate: false })
+
+function syncPolling(): void {
+  if (chapters.value.some(chapter => chapter.download >= 0 && chapter.download < 100)) {
+    resume()
+  } else {
+    pause()
+  }
+}
+
+const isInFlight = ref(false)
+async function pollChapters(): Promise<void> {
+  if (isInFlight.value || loading.value) {
+    return
+  }
+
+  const chaptersIds: string[] = []
+  for (const chapter of chapters.value) {
+    if (chapter.download >= 0 && chapter.download < 100) {
+      chaptersIds.push(chapter.id)
+    }
+  }
+
+  isInFlight.value = true
+
+  const res = await api.getByIds(chaptersIds)
+  if (res.success) {
+    for (const chapter of res.data) {
+      const i = chapters.value.findIndex(c => c.id === chapter.id)
+      if (i === -1) {
+        continue
+      }
+
+      if (chapter.download === chapters.value[i]!.download) {
+        continue
+      }
+
+      chapters.value[i] = chapter
+    }
+  }
+
+  isInFlight.value = false
+  syncPolling()
+}
+
+watch(() => props.id, () => {
+  fetchChapters()
+}, { immediate: true })
+
+const retryChaptersLoading = ref<Record<string, boolean>>({})
+
+async function retryChapter(chapterId: string): Promise<void> {
+  if (retryChaptersLoading.value[chapterId]) {
+    return
+  }
+
+  retryChaptersLoading.value[chapterId] = true
+
+  const res = await api.retryDownload(chapterId)
+  if (res.success) {
+    await fetchChapters()
+
+    delete retryChaptersLoading.value[chapterId]
+
+    return
+  }
+
+  console.error('chaptersApi.retryDownload', res.error)
+
+  switch (res.error.status) {
+    case 404:
+      toast.error(t('sources.asura.comic.chapters.error.retry.notFound'))
+      break
+    case 403:
+      toast.error(t('sources.asura.comic.chapters.error.retry.forbidden'))
+      break
+    case 409:
+      toast.error(t('sources.asura.comic.chapters.error.retry.conflict'))
+      break
+    default:
+      toast.error(t('error.unknown'))
+      break
+  }
+
+  delete retryChaptersLoading.value[chapterId]
+}
+</script>
+
+<template>
+  <div class="d-flex flex-column w-100 position-relative bg-surface" style="border-radius: 12px; max-height: 40rem;">
+    <div class="d-flex justify-space-between ga-6 pa-4 border-b-thin bg-surface align-center" style="z-index: 1; border-top-left-radius: 12px; border-top-right-radius: 12px;">
+      <span class="text-title-large font-weight-bold">{{ $t('sources.asurascans.comic.chaptersCount', { count: chapters.length }) }}</span>
+      <VBtn
+        variant="tonal"
+        class="text-body-medium"
+        color="surfaceVariant"
+        :text="sort === 'asc' ? $t('common.sort.oldest') : $t('common.sort.latest')"
+        :prepend-icon="sort === 'desc' ? 'fa6-solid:arrow-down-short-wide' : 'fa6-solid:arrow-up-short-wide'"
+        @click="sort = sort === 'asc' ? 'desc' : 'asc'"
+      />
+    </div>
+
+    <div v-if="loading || chapters.length === 0" class="d-flex justify-center align-center w-100 pa-4">
+      <VProgressCircular
+        v-if="loading"
+        class="m-auto"
+        indeterminate
+        color="primary"
+      />
+      <span v-else class="text-medium-emphasis">{{ $t('sources.asurascans.comic.chaptersCount', { count: 0 }) }}</span>
+    </div>
+    <VVirtualScroll :items="sortedChapters" style="border-bottom-left-radius: 12px; border-bottom-right-radius: 12px;">
+      <template #default="{ item }">
+        <ComicsChaptersItem
+          :chapter="item"
+          :retry-loading="!!retryChaptersLoading[item.id]"
+          @retry="retryChapter(item.id)"
+        />
+      </template>
+    </VVirtualScroll>
+  </div>
+</template>

--- a/web/app/features/comics/components/GeneralInfos.test.ts
+++ b/web/app/features/comics/components/GeneralInfos.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { VueWrapper } from '@vue/test-utils'
+import type { Comic } from '../types'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it } from 'vitest'
+import { h } from 'vue'
+import { VApp } from 'vuetify/components'
+import { ASURA_SOURCE_NAME } from '~/constants'
+import GeneralInfos from './GeneralInfos.vue'
+
+function comic(overrides: Partial<Comic> = {}): Comic {
+  return {
+    id: 'c1',
+    title: 'Solo Leveling',
+    slug: 'solo-leveling',
+    source: ASURA_SOURCE_NAME,
+    status: 'ongoing',
+    type: 'manhwa',
+    author: 'Chugong',
+    artist: 'Jang',
+    description: '<p>A hunter.</p>\nSecond line',
+    cover: '/cover',
+    genres: ['action'],
+    altTitles: ['나 혼자만 레벨업', 'Only I Level Up'],
+    chapterCount: 1,
+    ...overrides,
+  }
+}
+
+async function mount(value: Comic = comic()): Promise<VueWrapper> {
+  return mountSuspended({
+    render: () => h(VApp, () => [h(GeneralInfos, { comic: value })]),
+  })
+}
+
+describe('comicsGeneralInfos', () => {
+  it('strips HTML and newlines from the description', async () => {
+    const wrapper = await mount()
+    expect(wrapper.text()).toContain('A hunter. Second line')
+    expect(wrapper.text()).not.toContain('<p>')
+  })
+
+  it('joins alternate titles', async () => {
+    const wrapper = await mount()
+    expect(wrapper.text()).toContain('나 혼자만 레벨업, Only I Level Up')
+  })
+
+  it('hides genres until show more is clicked', async () => {
+    const wrapper = await mount()
+    expect(wrapper.text()).toContain('Show more')
+    expect(wrapper.text()).not.toContain('action')
+    expect(wrapper.find('.text-truncate').exists()).toBe(true)
+
+    await wrapper.findAll('button').at(-1)!.trigger('click')
+
+    expect(wrapper.text()).toContain('Show less')
+    expect(wrapper.text()).toContain('action')
+    expect(wrapper.find('.text-truncate').exists()).toBe(false)
+  })
+})

--- a/web/app/features/comics/components/GeneralInfos.vue
+++ b/web/app/features/comics/components/GeneralInfos.vue
@@ -1,19 +1,16 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script setup lang="ts">
-import type { AsuraComicInfos } from '../../types'
+import type { Comic } from '../types'
 
-const props = defineProps<{
-  comic: AsuraComicInfos
-}>()
+const props = defineProps<{ comic: Comic }>()
 
-const { smAndDown } = useDisplay()
-const showMore = ref(!smAndDown.value)
+const showMore = ref(false)
 
 const sanitzedDescription = computed(() => props.comic.description.replace(/<[^>]*>?/g, '').replaceAll('\n', ' '))
 </script>
 
 <template>
-  <div class="d-flex flex-column ga-4 transition-smooth pa-4 bg-surface w-100" style="border-radius: 12px;">
+  <div class="d-flex flex-column ga-3 transition-smooth pa-4 bg-surface w-100" style="border-radius: 12px;">
     <span
       v-if="sanitzedDescription"
       class="text-body-large transition-smooth"
@@ -26,7 +23,7 @@ const sanitzedDescription = computed(() => props.comic.description.replace(/<[^>
       :class="{ 'text-truncate': !showMore }"
     >{{ comic.altTitles.join(', ') }}</span>
 
-    <div v-if="comic.genres.length" class="d-flex flex-wrap ga-3">
+    <div v-if="comic.genres.length && showMore" class="d-flex flex-wrap ga-3">
       <span
         v-for="(genre, i) in comic.genres"
         :key="i"

--- a/web/app/features/comics/components/Modal/Delete.test.ts
+++ b/web/app/features/comics/components/Modal/Delete.test.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { VueWrapper } from '@vue/test-utils'
+import type { Comic } from '../../types'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, ref } from 'vue'
+import { VApp } from 'vuetify/components'
+import { ASURA_SOURCE_NAME } from '~/constants'
+import Delete from './Delete.vue'
+
+const { deleteById } = vi.hoisted(() => ({
+  deleteById: vi.fn(),
+}))
+
+function comicsApiStub(): { deleteById: typeof deleteById } {
+  return { deleteById }
+}
+
+mockNuxtImport('createComicsApi', () => comicsApiStub)
+
+const ConfirmationStub = defineComponent({
+  name: 'OrganismModalConfirmation',
+  props: {
+    modelValue: { type: Boolean, default: false },
+    text: { type: String, default: '' },
+    loading: { type: Boolean, default: false },
+  },
+  emits: ['confirm'],
+  template: '<button data-test="confirm" @click="$emit(\'confirm\')" />',
+})
+
+function comic(): Comic {
+  return {
+    id: 'c1',
+    title: 'Solo Leveling',
+    slug: 'solo-leveling',
+    source: ASURA_SOURCE_NAME,
+    status: 'ongoing',
+    type: 'manhwa',
+    author: '',
+    artist: '',
+    description: '',
+    cover: '/cover',
+    genres: [],
+    altTitles: [],
+    chapterCount: 1,
+  }
+}
+
+async function mount(): Promise<{ wrapper: VueWrapper, deleted: ReturnType<typeof vi.fn> }> {
+  const show = ref(true)
+  const deleted = vi.fn()
+
+  const wrapper = await mountSuspended(
+    {
+      render: () => h(VApp, () => [h(Delete, {
+        'modelValue': show.value,
+        'comic': comic(),
+        'onUpdate:modelValue': (isShown: boolean) => {
+          show.value = isShown
+        },
+        'onDeleted': deleted,
+      })]),
+    },
+    { global: { stubs: { OrganismModalConfirmation: ConfirmationStub } } },
+  )
+
+  return { wrapper, deleted }
+}
+
+beforeEach(() => {
+  deleteById.mockReset()
+  deleteById.mockResolvedValue({ success: true, data: undefined })
+})
+
+describe('comicsModalDelete', () => {
+  it('names the comic in the confirmation text', async () => {
+    const { wrapper } = await mount()
+    expect(wrapper.findComponent(ConfirmationStub).props('text')).toContain('Solo Leveling')
+  })
+
+  it('deletes the comic on confirmation', async () => {
+    const { wrapper, deleted } = await mount()
+
+    await wrapper.find('[data-test="confirm"]').trigger('click')
+
+    expect(deleteById).toHaveBeenCalledWith('c1')
+    expect(deleted).toHaveBeenCalled()
+  })
+
+  it('does not emit deleted when the request fails', async () => {
+    deleteById.mockResolvedValue({ success: false, error: { status: 404, message: 'missing' } })
+    const { wrapper, deleted } = await mount()
+
+    await wrapper.find('[data-test="confirm"]').trigger('click')
+
+    expect(deleted).not.toHaveBeenCalled()
+  })
+})

--- a/web/app/features/comics/components/Modal/Delete.vue
+++ b/web/app/features/comics/components/Modal/Delete.vue
@@ -1,0 +1,47 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+import type { Comic } from '../../types'
+
+const props = defineProps<{ comic: Comic }>()
+const emits = defineEmits<{ deleted: [] }>()
+const show = defineModel<boolean>({ required: true })
+
+const toast = useToast()
+const { t } = useI18n()
+const api = createComicsApi()
+
+const loading = ref(false)
+
+watch(show, (value) => {
+  if (!value) {
+    loading.value = false
+  }
+})
+
+async function handleDelete(): Promise<void> {
+  loading.value = true
+
+  const res = await api.deleteById(props.comic.id)
+  if (!res.success) {
+    console.error('api.deleteById failed', res.error)
+    toast.error(res.error.status === 404
+      ? t('sources.asura.comic.notFound')
+      : t('error.unknown'))
+
+    return
+  } else {
+    emits('deleted')
+  }
+
+  show.value = false
+}
+</script>
+
+<template>
+  <OrganismModalConfirmation
+    v-model="show"
+    :loading
+    :text="$t('sources.asura.delete.confirmation', { name: comic?.title ?? '' })"
+    @confirm="handleDelete"
+  />
+</template>

--- a/web/app/features/comics/components/StatusInfos.test.ts
+++ b/web/app/features/comics/components/StatusInfos.test.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { VueWrapper } from '@vue/test-utils'
+import type { Comic } from '../types'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { VApp, VBtn } from 'vuetify/components'
+import { ASURA_SOURCE_NAME } from '~/constants'
+import StatusInfos from './StatusInfos.vue'
+
+const DeleteStub = defineComponent({
+  name: 'ComicsModalDelete',
+  props: {
+    modelValue: { type: Boolean, default: false },
+    comic: { type: Object, required: true },
+  },
+  template: '<div data-test="delete-modal" />',
+})
+
+function comic(overrides: Partial<Comic> = {}): Comic {
+  return {
+    id: 'c1',
+    title: 'Solo Leveling',
+    slug: 'solo-leveling',
+    source: ASURA_SOURCE_NAME,
+    status: 'ongoing',
+    type: 'manhwa',
+    author: 'Chugong',
+    artist: 'Jang',
+    description: 'A hunter',
+    cover: '/cover',
+    genres: ['action'],
+    altTitles: [],
+    chapterCount: 1,
+    ...overrides,
+  }
+}
+
+async function mount(value: Comic = comic()): Promise<VueWrapper> {
+  return mountSuspended(
+    { render: () => h(VApp, () => [h(StatusInfos, { comic: value })]) },
+    { global: { stubs: { ComicsModalDelete: DeleteStub } } },
+  )
+}
+
+describe('comicsStatusInfos', () => {
+  it('renders status, type, author and artist', async () => {
+    const wrapper = await mount()
+
+    expect(wrapper.text()).toContain('Ongoing')
+    expect(wrapper.text()).toContain('Manhwa')
+    expect(wrapper.text()).toContain('Chugong')
+    expect(wrapper.text()).toContain('Jang')
+    expect(wrapper.find('[data-test="delete-modal"]').exists()).toBe(true)
+  })
+
+  it('shows the remove-from-library action', async () => {
+    const wrapper = await mount()
+
+    expect(wrapper.text()).toContain('Remove from library')
+    expect(wrapper.findComponent(VBtn).props('color')).toBe('error')
+  })
+})

--- a/web/app/features/comics/components/StatusInfos.vue
+++ b/web/app/features/comics/components/StatusInfos.vue
@@ -1,0 +1,45 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+import type { Comic } from '../types'
+
+defineProps<{ comic: Comic }>()
+defineEmits<{ deleted: [] }>()
+const showDeleteModal = ref(false)
+</script>
+
+<template>
+  <ComicsModalDelete
+    v-if="comic"
+    v-model="showDeleteModal"
+    :comic
+    @deleted="$emit('deleted')"
+  />
+
+  <div
+    class="d-flex flex-column ga-4 pa-4 bg-surface"
+    style="border-radius: 12px"
+  >
+    <div class="d-flex flex-wrap ga-4">
+      <ComicsChipStatus :status="comic.status" />
+      <ComicsChipType :type="comic.type" />
+    </div>
+
+    <VBtn
+      variant="tonal"
+      class="w-100 border-thin-error"
+      color="error"
+      prepend-icon="fa6-solid:trash"
+      size="large"
+      :text="$t('comics.remove.title')"
+      @click="showDeleteModal = true"
+    />
+    <div v-if="comic.author" class="d-flex ga-2 justify-space-between">
+      <span class="text-body-large text-medium-emphasis text-uppercase text-truncate">{{ $t('comic.fields.author') }}</span>
+      <span class="text-body-large font-weight-bold text-truncate">{{ comic.author }}</span>
+    </div>
+    <div v-if="comic.artist" class="d-flex ga-2 justify-space-between">
+      <span class="text-body-large text-medium-emphasis text-uppercase text-truncate">{{ $t('comic.fields.artist') }}</span>
+      <span class="text-body-large font-weight-bold text-truncate">{{ comic.artist }}</span>
+    </div>
+  </div>
+</template>

--- a/web/app/features/comics/composables/comics.api.test.ts
+++ b/web/app/features/comics/composables/comics.api.test.ts
@@ -54,6 +54,26 @@ describe('createComicsApi().deleteById', () => {
   })
 })
 
+describe('createComicsApi().getById', () => {
+  it('gets the comic by id', async () => {
+    const full = { ...comic, title: 'Solo Leveling', author: 'Chugong', artist: 'Jang', type: 'manhwa', description: '', cover: '/cover', genres: [], altTitles: [] }
+    call.mockResolvedValue(full)
+
+    const res = await createComicsApi().getById('c1')
+
+    expect(call).toHaveBeenCalledWith('/c1', { method: 'GET' })
+    expect(res).toEqual({ success: true, data: full })
+  })
+
+  it('surfaces a 404 with its status', async () => {
+    call.mockRejectedValue({ statusCode: 404, data: {} })
+
+    const res = await createComicsApi().getById('missing')
+
+    expect(res.success === false && res.error.status).toBe(404)
+  })
+})
+
 describe('createComicsApi().search', () => {
   it('requests / with pagination', async () => {
     call.mockResolvedValue({ items: [comic], total: 1 })

--- a/web/app/features/comics/composables/comics.api.ts
+++ b/web/app/features/comics/composables/comics.api.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import type { LightComic, SearchComicParams, SearchComicResponse } from '../types'
+import type { Comic, LightComic, SearchComicParams, SearchComicResponse } from '../types'
 import type { ApiResponse } from '~/utils/api'
 import { ApiError, initApi } from '~/utils/api'
 
@@ -8,6 +8,7 @@ export interface ComicsApi {
   create: (params: CreateComicParams) => Promise<ApiResponse<LightComic>>
   deleteById: (id: string) => Promise<ApiResponse<void>>
   search: (params: SearchComicParams) => Promise<ApiResponse<SearchComicResponse>>
+  getById: (id: string) => Promise<ApiResponse<Comic>>
 }
 
 export interface CreateComicParams {
@@ -59,9 +60,20 @@ export function createComicsApi(): ComicsApi {
     }
   }
 
+  async function getById(id: string): Promise<ApiResponse<Comic>> {
+    try {
+      const response = await api<Comic>(`/${id}`, { method: 'GET' })
+
+      return { success: true, data: response }
+    } catch (error) {
+      return { success: false, error: ApiError.fromFetchError(error) }
+    }
+  }
+
   return {
     create,
     deleteById,
     search,
+    getById,
   }
 }

--- a/web/app/features/comics/types.ts
+++ b/web/app/features/comics/types.ts
@@ -32,3 +32,19 @@ export type SearchComicParams = {
   limit: number
   offset: number
 }
+
+export interface Comic {
+  id: string
+  artist: string
+  type: ComicType
+  description: string
+  source: ComicSource
+  author: string
+  status: ComicStatus
+  slug: string
+  title: string
+  cover: string
+  genres: string[]
+  altTitles: string[]
+  chapterCount: number
+}

--- a/web/app/features/feed/composables/feed.composable.test.ts
+++ b/web/app/features/feed/composables/feed.composable.test.ts
@@ -31,14 +31,14 @@ function debounceStub<T extends (...args: never[]) => unknown>(fn: T): T {
   return fn
 }
 
-function useChaptersApiStub(): { getByIds: (ids: string[]) => Promise<{ success: true, data: Chapter[] }> } {
+function createChaptersApiStub(): { getByIds: (ids: string[]) => Promise<{ success: true, data: Chapter[] }> } {
   return { getByIds }
 }
 
 mockNuxtImport('useI18n', () => i18nStub)
 mockNuxtImport('useDisplay', () => displayStub)
 mockNuxtImport('useDebounceFn', debounceStub)
-mockNuxtImport('useChaptersApi', () => useChaptersApiStub)
+mockNuxtImport('createChaptersApi', () => createChaptersApiStub)
 
 function item(overrides: Partial<FeedItem> = {}): FeedItem {
   return {

--- a/web/app/features/feed/composables/feed.composable.ts
+++ b/web/app/features/feed/composables/feed.composable.ts
@@ -16,7 +16,7 @@ export interface FeedComposable {
 
 export function useFeed(): FeedComposable {
   const api = createFeedApi()
-  const chaptersApi = useChaptersApi()
+  const chaptersApi = createChaptersApi()
 
   const { t } = useI18n()
   const toast = useToast()

--- a/web/app/layouts/default.vue
+++ b/web/app/layouts/default.vue
@@ -80,13 +80,13 @@ const bottomNavigationItems = computed((): BottomNavigationItemProps[] => [
   {
     to: '/feed',
     icon: 'fa6-solid:newspaper',
-    isActiveFn: (route: RouteLocationNormalized) => route.path.startsWith('/feed'),
+    isActiveFn: (route: RouteLocationNormalized) => route.path.startsWith('/feed') || route.query.from === 'feed',
     baseRoute: '/feed',
   },
   {
     to: '/library',
     icon: 'fa6-solid:book',
-    isActiveFn: (route: RouteLocationNormalized) => route.path.startsWith('/library'),
+    isActiveFn: (route: RouteLocationNormalized) => route.path.startsWith('/library') || route.query.from === 'library',
     baseRoute: '/library',
   },
   {

--- a/web/app/pages/browse/sources/asura/[slug].vue
+++ b/web/app/pages/browse/sources/asura/[slug].vue
@@ -20,7 +20,6 @@ const api = createAsuraApi()
 
 const fetchInfosLoading = ref(false)
 const infos = ref<AsuraComicInfos>()
-const chaptersComponent = useTemplateRef<InstanceType<typeof AsuraComicChapters>>('chaptersComponent')
 
 const coverSrc = ref<string>()
 
@@ -114,7 +113,6 @@ const comicOriginUrl = computed(() => {
         />
         <AsuraComicGeneralInfos :comic="infos" />
         <AsuraComicChapters
-          ref="chaptersComponent"
           :slug="route.params.slug"
           :comic-origin-url="comicOriginUrl"
         />

--- a/web/app/pages/comic/[id]/index.test.ts
+++ b/web/app/pages/comic/[id]/index.test.ts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { VueWrapper } from '@vue/test-utils'
+import type { Comic } from '~/features/comics/types'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { VApp } from 'vuetify/components'
+import { ASURA_SOURCE_NAME } from '~/constants'
+import ComicPage from './index.vue'
+
+const { getById, smAndDown, navigateTo, params, query } = await vi.hoisted(async () => {
+  const { ref } = await import('vue')
+
+  return {
+    getById: vi.fn(),
+    smAndDown: ref(false),
+    navigateTo: vi.fn(),
+    params: { id: 'c1' },
+    query: { from: undefined as string | undefined },
+  }
+})
+
+function comicsApiStub(): { getById: typeof getById } {
+  return { getById }
+}
+
+function displayStub(): { smAndDown: typeof smAndDown } {
+  return { smAndDown }
+}
+
+function routeStub(): { params: typeof params, query: typeof query } {
+  return { params, query }
+}
+
+mockNuxtImport('createComicsApi', () => comicsApiStub)
+mockNuxtImport('useDisplay', () => displayStub)
+mockNuxtImport('useRoute', () => routeStub)
+mockNuxtImport('navigateTo', () => navigateTo)
+
+const StatusStub = defineComponent({
+  name: 'ComicsStatusInfos',
+  props: { comic: { type: Object, required: true } },
+  emits: ['deleted'],
+  template: '<div data-test="status-infos">{{ comic.title }}</div>',
+})
+
+const GeneralStub = defineComponent({
+  name: 'ComicsGeneralInfos',
+  props: { comic: { type: Object, required: true } },
+  template: '<div data-test="general-infos" />',
+})
+
+const ChaptersStub = defineComponent({
+  name: 'ComicsChapters',
+  props: { id: { type: String, required: true } },
+  template: '<div data-test="chapters">{{ id }}</div>',
+})
+
+function comic(overrides: Partial<Comic> = {}): Comic {
+  return {
+    id: 'c1',
+    title: 'Solo Leveling',
+    slug: 'solo-leveling',
+    source: ASURA_SOURCE_NAME,
+    status: 'ongoing',
+    type: 'manhwa',
+    author: 'Chugong',
+    artist: 'Jang',
+    description: 'A hunter',
+    cover: '/cover',
+    genres: [],
+    altTitles: [],
+    chapterCount: 1,
+    ...overrides,
+  }
+}
+
+async function mount(): Promise<VueWrapper> {
+  return mountSuspended(
+    { render: () => h(VApp, () => [h(ComicPage)]) },
+    {
+      global: {
+        stubs: {
+          ComicsStatusInfos: StatusStub,
+          ComicsGeneralInfos: GeneralStub,
+          ComicsChapters: ChaptersStub,
+          OrganismPageLayout: false,
+        },
+      },
+    },
+  )
+}
+
+beforeEach(() => {
+  getById.mockReset()
+  navigateTo.mockReset()
+  smAndDown.value = false
+  params.id = 'c1'
+  query.from = undefined
+  getById.mockResolvedValue({ success: true, data: comic() })
+})
+
+describe('comicPage', () => {
+  it('loads the comic and renders its sections', async () => {
+    const wrapper = await mount()
+
+    await vi.waitFor(() => expect(wrapper.find('[data-test="status-infos"]').text()).toBe('Solo Leveling'))
+    expect(getById).toHaveBeenCalledWith('c1')
+    expect(wrapper.find('[data-test="general-infos"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="chapters"]').text()).toBe('c1')
+  })
+
+  it('redirects to the library when the comic is missing', async () => {
+    getById.mockResolvedValue({ success: false, error: { status: 404, message: 'missing' } })
+
+    await mount()
+
+    await vi.waitFor(() => expect(navigateTo).toHaveBeenCalledWith({ name: 'library' }))
+  })
+
+  it('redirects to the feed when opened from the feed and the comic is missing', async () => {
+    query.from = 'feed'
+    getById.mockResolvedValue({ success: false, error: { status: 404, message: 'missing' } })
+
+    await mount()
+
+    await vi.waitFor(() => expect(navigateTo).toHaveBeenCalledWith({ name: 'feed' }))
+  })
+})

--- a/web/app/pages/comic/[id]/index.vue
+++ b/web/app/pages/comic/[id]/index.vue
@@ -1,13 +1,139 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script setup lang="ts">
+import type { RouteRecordName } from 'vue-router'
+import type { PageLayoutBackRoute } from '~/components/Organism/PageLayout.vue'
+import type { Comic } from '~/features/comics/types'
+import defaultCover from '~/assets/images/default/comic-cover.webp'
 import { AUTHENTICATED_ROUTE_GROUP } from '~/constants/auth'
+
+const FEED_ROUTE_NAME: RouteRecordName = 'feed'
+const LIBRARY_ROUTE_NAME: RouteRecordName = 'library'
 
 definePageMeta({
   layout: 'default',
   authGroups: [AUTHENTICATED_ROUTE_GROUP],
 })
+
+const route = useRoute('comic-id')
+const { t } = useI18n()
+const toast = useToast()
+const { smAndDown } = useDisplay()
+const api = createComicsApi()
+
+const isLoading = ref(true)
+const comic = ref<Comic>()
+const coverSrc = ref<string>()
+
+const from = computed(() => route.query.from as string)
+
+onMounted(() => {
+  fetchComic()
+})
+
+async function fetchComic(): Promise<void> {
+  isLoading.value = true
+
+  const res = await api.getById(route.params.id)
+  if (!res.success) {
+    console.error('api.getById', res.error)
+    toast.error(res.error.status === 404
+      ? t('sources.asura.comic.notFound')
+      : t('error.unknown'))
+
+    if (from.value === FEED_ROUTE_NAME) {
+      await navigateTo({ name: FEED_ROUTE_NAME })
+    } else {
+      await navigateTo({ name: LIBRARY_ROUTE_NAME })
+    }
+
+    return
+  }
+
+  comic.value = res.data
+  coverSrc.value = res.data.cover
+
+  isLoading.value = false
+}
+
+function onDelete(): void {
+  navigateTo({ name: from.value === FEED_ROUTE_NAME ? FEED_ROUTE_NAME : LIBRARY_ROUTE_NAME })
+}
+
+const backRoutes = computed((): PageLayoutBackRoute[] => from.value === FEED_ROUTE_NAME
+  ? [{
+      to: '/feed',
+      name: t('feed.title'),
+    }]
+  : [{
+      to: '/library',
+      name: t('library.title'),
+    }])
 </script>
 
 <template>
-  <OrganismPageLayout title="Comic" />
+  <OrganismPageLayout
+    :title="comic?.title ?? ''"
+    :loading="isLoading"
+    :global-loader="isLoading"
+    sticky-header
+    :back-routes
+  >
+    <div
+      v-if="comic"
+      :class="smAndDown ? 'd-flex flex-column ga-8 px-6' : 'comic-infos-grid'"
+    >
+      <div v-if="!smAndDown" class="d-flex flex-column ga-6">
+        <VImg
+          v-if="coverSrc"
+          :src="coverSrc"
+          rounded="lg"
+          :aspect-ratio="2 / 3"
+          cover
+          :lazy-src="defaultCover"
+          class="border-thin rounded-lg flex-grow-0"
+          @error="coverSrc = defaultCover"
+        />
+
+        <ComicsStatusInfos
+          v-if="!smAndDown"
+          :comic
+          @deleted="onDelete"
+        />
+      </div>
+
+      <div class="d-flex flex-column ga-6 w-100">
+        <div class="d-flex ga-4 align-center">
+          <VImg
+            v-if="coverSrc && smAndDown"
+            :src="coverSrc"
+            rounded="lg"
+            :aspect-ratio="2 / 3"
+            cover
+            :width="120"
+            :lazy-src="defaultCover"
+            class="border-thin rounded-lg flex-0-0"
+            @error="coverSrc = defaultCover"
+          />
+
+          <span class="font-title font-weight-bold" :class="{ 'text-display-medium': !smAndDown, 'text-title-large': smAndDown }">{{ comic.title }}</span>
+        </div>
+        <ComicsStatusInfos
+          v-if="smAndDown"
+          :comic
+          @deleted="onDelete"
+        />
+        <ComicsGeneralInfos :comic />
+        <ComicsChapters :id="route.params.id" />
+      </div>
+    </div>
+  </OrganismPageLayout>
 </template>
+
+<style scoped lang="scss">
+.comic-infos-grid {
+  display: grid;
+  align-items: start;
+  gap: 3rem;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
+}
+</style>


### PR DESCRIPTION
## Summary

Closes #60.

- Add `/comic/:id` as the library-owned series page: stored metadata, full chapter list, live download progress, retry, and remove from library
- Load data from `GET /api/comics/{id}` and `GET /api/chapters?comicId=` only (no Asura source API)
- Poll chapters every 2s while any download is in progress (0–99), then stop; show early-access locks and sort chapters by number
- Unknown / not-in-library comic → toast and redirect to `/library`; after delete, navigate to `/library`
- Tighten the chapters list query so `comicId` is the only filter sent to the API

## Test plan

- [x] `/comic/:id` loads stored comic + chapters (cover, metadata, chapter list)
- [x] Live download progress while chapters are downloading; polling stops when none are 0–99
- [x] Retry on error / interrupted chapters works
- [x] Remove from library → `/library`
- [x] Locked chapters stay listed with unlock time
- [x] Unknown id / not in library → leave the page
- [x] No Asura source API calls from this page
- [x] `pnpm test`, `pnpm typecheck`, `pnpm lint`, `pnpm knip` pass