### PR TITLE
feat(comics): on-demand chapter list refresh

### DIFF
--- a/api/pkg/core/comics/domain.go
+++ b/api/pkg/core/comics/domain.go
@@ -4,6 +4,7 @@ package comics
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -79,12 +80,20 @@ type GetBySlugsAndSource struct {
 	UserID uuid.UUID
 }
 
+var ErrSourceUnavailable = errors.New("source unavailable")
+
+type RefreshComicOpts struct {
+	UserID uuid.UUID
+	ID     uuid.UUID
+}
+
 type ComicsService interface {
 	Create(context.Context, CreateOpts) (*Comic, error)
 	GetByID(context.Context, GetByIDOpts) (*Comic, error)
 	GetMany(context.Context, GetManyOpts) (Page, error)
 	Delete(context.Context, DeleteOpts) error
 	RefreshChapterLists(context.Context) error
+	RefreshComic(context.Context, RefreshComicOpts) (*Comic, error)
 	ServeCover(ctx context.Context, opts GetByIDOpts) (diskPath, contentType string, err error)
 }
 

--- a/api/pkg/core/comics/gateway/http/controller.go
+++ b/api/pkg/core/comics/gateway/http/controller.go
@@ -90,6 +90,7 @@ func (c *Controller) InitRouter(r chi.Router) {
 
 		r.Post("/", c.create)
 		r.Get("/", c.getMany)
+		r.Post("/{id}/refresh", c.refreshByID)
 		r.Get("/{id}/cover", c.serveCover)
 		r.Get("/{id}", c.getByID)
 		r.Delete("/{id}", c.deleteByID)
@@ -160,6 +161,61 @@ func (c *Controller) getByID(w http.ResponseWriter, r *http.Request) {
 		}
 
 		c.deps.Logger.Error("failed to get comic by id", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, comicResponseFromDomain(comic))
+}
+
+func (c *Controller) refreshByID(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user, ok := httpsession.UserFrom(ctx)
+	if !ok {
+		c.deps.Logger.Error("user not found in context")
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+
+		return
+	}
+
+	id, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "id must be a valid UUID")
+
+		return
+	}
+
+	comic, err := c.deps.ComicsService.RefreshComic(ctx, comics.RefreshComicOpts{
+		UserID: user.ID,
+		ID:     id,
+	})
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusNotFound, "comic not found")
+
+			return
+		}
+
+		if errors.Is(err, domain.ErrForbidden) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusForbidden, "comic not in library")
+
+			return
+		}
+
+		if errors.Is(err, domain.ErrConflict) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusConflict, "comic is not pollable")
+
+			return
+		}
+
+		if errors.Is(err, comics.ErrSourceUnavailable) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusBadGateway, "source unavailable")
+
+			return
+		}
+
+		c.deps.Logger.Error("failed to refresh comic", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 
 		return

--- a/api/pkg/core/comics/gateway/http/controller_test.go
+++ b/api/pkg/core/comics/gateway/http/controller_test.go
@@ -578,3 +578,150 @@ func TestDeleteByIDInternalError(t *testing.T) {
 		t.Errorf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
 	}
 }
+
+func TestRefreshRequiresAuthentication(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRouter(t, &stubComicsService{}, nil)
+	req := httptest.NewRequest(http.MethodPost, comicsEndpoint+"/"+uuid.New().String()+"/refresh", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestRefreshInvalidID(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	r := newTestRouter(t, &stubComicsService{}, authenticatorFor(t, user))
+	req := httptest.NewRequest(http.MethodPost, comicsEndpoint+"/not-a-uuid/refresh", nil)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestRefreshNotFound(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	comicID := uuid.New()
+	r := newTestRouter(t, &stubComicsService{
+		refreshComicErr: fmt.Errorf("s.deps.ComicsRepository.FindByID: %w", domain.ErrNotFound),
+	}, authenticatorFor(t, user))
+	req := httptest.NewRequest(http.MethodPost, comicsEndpoint+"/"+comicID.String()+"/refresh", nil)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestRefreshForbidden(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	comicID := uuid.New()
+	r := newTestRouter(t, &stubComicsService{refreshComicErr: domain.ErrForbidden}, authenticatorFor(t, user))
+	req := httptest.NewRequest(http.MethodPost, comicsEndpoint+"/"+comicID.String()+"/refresh", nil)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
+func TestRefreshConflict(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	comicID := uuid.New()
+	r := newTestRouter(t, &stubComicsService{refreshComicErr: domain.ErrConflict}, authenticatorFor(t, user))
+	req := httptest.NewRequest(http.MethodPost, comicsEndpoint+"/"+comicID.String()+"/refresh", nil)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusConflict)
+	}
+}
+
+func TestRefreshSourceUnavailable(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	comicID := uuid.New()
+	r := newTestRouter(t, &stubComicsService{
+		refreshComicErr: fmt.Errorf("src.GetInfosBySlug: %w", comics.ErrSourceUnavailable),
+	}, authenticatorFor(t, user))
+	req := httptest.NewRequest(http.MethodPost, comicsEndpoint+"/"+comicID.String()+"/refresh", nil)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadGateway)
+	}
+}
+
+func TestRefreshOK(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	comic := &comics.Comic{
+		ID:           uuid.New(),
+		Title:        testComicTitle,
+		Slug:         testComicSlug,
+		Source:       sources.SourceAsuraScans,
+		Status:       sources.SeriesStatusOngoing,
+		Type:         sources.SeriesTypeManhwa,
+		ChapterCount: 42,
+	}
+
+	r := newTestRouter(t, &stubComicsService{refreshComicResult: comic}, authenticatorFor(t, user))
+	req := httptest.NewRequest(http.MethodPost, comicsEndpoint+"/"+comic.ID.String()+"/refresh", nil)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var got comicshttpDetail
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if got.ID != comic.ID || got.ChapterCount != 42 {
+		t.Errorf("detail = %+v, want id=%s chapterCount=42", got, comic.ID)
+	}
+}
+
+func TestRefreshInternalError(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	comicID := uuid.New()
+	sentinel := errors.New("db down")
+	r := newTestRouter(t, &stubComicsService{refreshComicErr: sentinel}, authenticatorFor(t, user))
+	req := httptest.NewRequest(http.MethodPost, comicsEndpoint+"/"+comicID.String()+"/refresh", nil)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+}

--- a/api/pkg/core/comics/gateway/http/controller_test.go
+++ b/api/pkg/core/comics/gateway/http/controller_test.go
@@ -38,19 +38,21 @@ const (
 )
 
 type stubComicsService struct {
-	createErr        error
-	getByIDErr       error
-	getManyErr       error
-	deleteErr        error
-	serveCoverErr    error
-	createResult     *comics.Comic
-	getByIDResult    *comics.Comic
-	serveCoverPath   string
-	serveCoverType   string
-	getManyResult    comics.Page
-	lastGetMany      comics.GetManyOpts
-	serveCoverCalls  int
-	lastServeCoverID uuid.UUID
+	createErr          error
+	getByIDErr         error
+	getManyErr         error
+	deleteErr          error
+	serveCoverErr      error
+	refreshComicErr    error
+	createResult       *comics.Comic
+	getByIDResult      *comics.Comic
+	refreshComicResult *comics.Comic
+	serveCoverPath     string
+	serveCoverType     string
+	getManyResult      comics.Page
+	lastGetMany        comics.GetManyOpts
+	serveCoverCalls    int
+	lastServeCoverID   uuid.UUID
 }
 
 func (s *stubComicsService) Create(_ context.Context, _ comics.CreateOpts) (*comics.Comic, error) {
@@ -73,6 +75,10 @@ func (s *stubComicsService) Delete(_ context.Context, _ comics.DeleteOpts) error
 
 func (s *stubComicsService) RefreshChapterLists(context.Context) error {
 	return nil
+}
+
+func (s *stubComicsService) RefreshComic(_ context.Context, _ comics.RefreshComicOpts) (*comics.Comic, error) {
+	return s.refreshComicResult, s.refreshComicErr
 }
 
 func (s *stubComicsService) ServeCover(_ context.Context, opts comics.GetByIDOpts) (string, string, error) {

--- a/api/pkg/core/comics/refresh.go
+++ b/api/pkg/core/comics/refresh.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/logging"
 )
@@ -65,6 +66,32 @@ func (s *Service) refreshSource(ctx context.Context, name sources.SourceName) er
 	}
 
 	return nil
+}
+
+func isPollable(status sources.SeriesStatus) bool {
+	return status == sources.SeriesStatusOngoing || status == sources.SeriesStatusHiatus
+}
+
+func (s *Service) RefreshComic(ctx context.Context, opts RefreshComicOpts) (*Comic, error) {
+	comic, err := s.deps.ComicsRepository.FindByID(ctx, opts.ID)
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.ComicsRepository.FindByID: %w", err)
+	}
+
+	inLibrary, err := s.deps.LibraryRepository.ExistsByUserAndComic(ctx, opts.UserID, comic.ID)
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.LibraryRepository.ExistsByUserAndComic: %w", err)
+	}
+
+	if !inLibrary {
+		return nil, domain.ErrForbidden
+	}
+
+	if !isPollable(comic.Status) {
+		return nil, domain.ErrConflict
+	}
+
+	return comic, nil
 }
 
 func (s *Service) refreshComic(ctx context.Context, src sources.Source, comic Comic) error {

--- a/api/pkg/core/comics/refresh.go
+++ b/api/pkg/core/comics/refresh.go
@@ -4,6 +4,7 @@ package comics
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -12,6 +13,7 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/logging"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/transaction"
 )
 
 func (s *Service) logger() *slog.Logger {
@@ -91,7 +93,74 @@ func (s *Service) RefreshComic(ctx context.Context, opts RefreshComicOpts) (*Com
 		return nil, domain.ErrConflict
 	}
 
-	return comic, nil
+	src, ok := s.deps.Sources[comic.Source]
+	if !ok || src == nil {
+		return nil, fmt.Errorf("source %s not found", comic.Source)
+	}
+
+	infos, err := src.GetInfosBySlug(ctx, sources.GetInfosBySlugOpts{
+		Slug:  comic.Slug,
+		Fresh: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("src.GetInfosBySlug: %w", errors.Join(ErrSourceUnavailable, err))
+	}
+
+	srcChapters, err := src.GetChaptersBySlug(ctx, sources.GetChaptersBySlugOpts{
+		Slug:  comic.Slug,
+		Fresh: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("src.GetChaptersBySlug: %w", errors.Join(ErrSourceUnavailable, err))
+	}
+
+	existing, err := s.deps.ChaptersService.ListByComicID(ctx, comic.ID)
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.ChaptersService.ListByComicID: %w", err)
+	}
+
+	missing := missingSourceChapters(existing, srcChapters)
+
+	var created []chapters.Chapter
+
+	err = s.deps.Transactor.WithinTx(ctx, transaction.TxOpts{}, func(ctx context.Context) error {
+		if len(missing) > 0 {
+			inserted, createErr := s.deps.ChaptersService.CreateAll(ctx, comic.ID, missing)
+			if createErr != nil {
+				return fmt.Errorf("s.deps.ChaptersService.CreateAll: %w", createErr)
+			}
+
+			created = inserted
+		}
+
+		updateErr := s.deps.ComicsRepository.UpdateStatusAndChapterCount(ctx, UpdateStatusAndChapterCountOpts{
+			ID:           comic.ID,
+			Status:       infos.Status,
+			ChapterCount: infos.ChapterCount,
+		})
+		if updateErr != nil {
+			return fmt.Errorf("s.deps.ComicsRepository.UpdateStatusAndChapterCount: %w", updateErr)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.Transactor.WithinTx: %w", err)
+	}
+
+	if len(created) > 0 {
+		err = s.deps.ChaptersService.EnqueueDownloadable(ctx, created)
+		if err != nil {
+			return nil, fmt.Errorf("s.deps.ChaptersService.EnqueueDownloadable: %w", err)
+		}
+	}
+
+	updated, err := s.deps.ComicsRepository.FindByID(ctx, comic.ID)
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.ComicsRepository.FindByID: %w", err)
+	}
+
+	return updated, nil
 }
 
 func (s *Service) refreshComic(ctx context.Context, src sources.Source, comic Comic) error {

--- a/api/pkg/core/comics/refresh/app_test.go
+++ b/api/pkg/core/comics/refresh/app_test.go
@@ -38,6 +38,10 @@ func (f *fakeComicsService) Delete(context.Context, comics.DeleteOpts) error {
 	panic("Delete must not be called")
 }
 
+func (f *fakeComicsService) RefreshComic(context.Context, comics.RefreshComicOpts) (*comics.Comic, error) {
+	panic("RefreshComic must not be called")
+}
+
 func (f *fakeComicsService) RefreshChapterLists(ctx context.Context) error {
 	f.mu.Lock()
 	f.refreshCalls++

--- a/api/pkg/core/comics/refresh_test.go
+++ b/api/pkg/core/comics/refresh_test.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//nolint:goconst
 package comics_test
 
 import (
@@ -11,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/comics"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
 )
 
@@ -318,5 +320,113 @@ func TestRefreshChapterListsSkipsCreateWhenNoMissingChapters(t *testing.T) {
 
 	if repo.updateStatusCalls != 1 {
 		t.Errorf("UpdateStatusAndChapterCount called %d times, want 1", repo.updateStatusCalls)
+	}
+}
+
+func TestRefreshComicNotFound(t *testing.T) {
+	t.Parallel()
+
+	deps := validServiceDeps()
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	_, err = svc.RefreshComic(context.Background(), comics.RefreshComicOpts{
+		UserID: uuid.New(),
+		ID:     uuid.New(),
+	})
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("RefreshComic = %v, want domain.ErrNotFound", err)
+	}
+}
+
+func TestRefreshComicForbiddenWhenNotInLibrary(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	repo := &fakeComicsRepository{
+		findByIDResult: &comics.Comic{
+			ID:     comicID,
+			Source: testSource,
+			Slug:   testSlug,
+			Status: sources.SeriesStatusOngoing,
+			Title:  "Solo Leveling",
+		},
+	}
+	libraryRepo := &fakeLibraryRepository{inLibrary: false}
+
+	deps := validServiceDeps()
+	deps.ComicsRepository = repo
+	deps.LibraryRepository = libraryRepo
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	source := deps.Sources[testSource].(*fakeSource)
+
+	_, err = svc.RefreshComic(context.Background(), comics.RefreshComicOpts{
+		UserID: uuid.New(),
+		ID:     comicID,
+	})
+	if !errors.Is(err, domain.ErrForbidden) {
+		t.Fatalf("RefreshComic = %v, want domain.ErrForbidden", err)
+	}
+
+	if source.calls != 0 || source.chaptersCalls != 0 {
+		t.Errorf("source fetches infos=%d chapters=%d, want 0", source.calls, source.chaptersCalls)
+	}
+}
+
+func TestRefreshComicConflictWhenNotPollable(t *testing.T) {
+	t.Parallel()
+
+	statuses := []sources.SeriesStatus{
+		sources.SeriesStatusCompleted,
+		sources.SeriesStatusCancelled,
+		sources.SeriesStatusDropped,
+	}
+
+	for _, status := range statuses {
+		t.Run(string(status), func(t *testing.T) {
+			t.Parallel()
+
+			comicID := uuid.New()
+			repo := &fakeComicsRepository{
+				findByIDResult: &comics.Comic{
+					ID:     comicID,
+					Source: testSource,
+					Slug:   testSlug,
+					Status: status,
+					Title:  "Solo Leveling",
+				},
+			}
+			libraryRepo := &fakeLibraryRepository{inLibrary: true}
+
+			deps := validServiceDeps()
+			deps.ComicsRepository = repo
+			deps.LibraryRepository = libraryRepo
+
+			svc, err := comics.NewService(deps)
+			if err != nil {
+				t.Fatalf("NewService: %v", err)
+			}
+
+			source := deps.Sources[testSource].(*fakeSource)
+
+			_, err = svc.RefreshComic(context.Background(), comics.RefreshComicOpts{
+				UserID: uuid.New(),
+				ID:     comicID,
+			})
+			if !errors.Is(err, domain.ErrConflict) {
+				t.Fatalf("RefreshComic = %v, want domain.ErrConflict", err)
+			}
+
+			if source.calls != 0 || source.chaptersCalls != 0 {
+				t.Errorf("source fetches infos=%d chapters=%d, want 0", source.calls, source.chaptersCalls)
+			}
+		})
 	}
 }

--- a/api/pkg/core/comics/refresh_test.go
+++ b/api/pkg/core/comics/refresh_test.go
@@ -430,3 +430,312 @@ func TestRefreshComicConflictWhenNotPollable(t *testing.T) {
 		})
 	}
 }
+
+func TestRefreshComicCreatesMissingChaptersUpdatesStatusAndReturnsComic(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	existing := chapters.Chapter{
+		ID:                uuid.New(),
+		ComicID:           comicID,
+		SourceChapterSlug: testChapterSlug,
+		Number:            1,
+		Download:          100,
+	}
+	newSrc := sources.SourceChapter{
+		SourceChapterSlug: testChapter2Slug,
+		Number:            2,
+		Title:             "Chapter 2",
+		PageCount:         18,
+		PublishedAt:       time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	created := chapters.Chapter{
+		ID:                uuid.New(),
+		ComicID:           comicID,
+		SourceChapterSlug: newSrc.SourceChapterSlug,
+		Number:            newSrc.Number,
+		Title:             newSrc.Title,
+		PagesNb:           newSrc.PageCount,
+		PublishedAt:       newSrc.PublishedAt,
+	}
+
+	repo := &fakeComicsRepository{
+		findByIDResult: &comics.Comic{
+			ID:           comicID,
+			Source:       testSource,
+			Slug:         testSlug,
+			Status:       sources.SeriesStatusOngoing,
+			Title:        "Solo Leveling",
+			Type:         sources.SeriesTypeManhwa,
+			ChapterCount: 1,
+		},
+	}
+	chaptersSvc := &fakeChaptersService{
+		listByComicIDResult: []chapters.Chapter{existing},
+		createAllResult:     []chapters.Chapter{created},
+	}
+	source := &fakeSource{
+		infos: &sources.GetInfosBySlugResponse{
+			Status:       sources.SeriesStatusHiatus,
+			ChapterCount: 2,
+			Title:        "Must Not Be Written",
+		},
+		chapters: []sources.SourceChapter{
+			{
+				SourceChapterSlug: existing.SourceChapterSlug,
+				Number:            1,
+				Title:             testChapterTitle,
+			},
+			newSrc,
+		},
+	}
+
+	deps := validServiceDeps()
+	deps.ComicsRepository = repo
+	deps.ChaptersService = chaptersSvc
+	deps.LibraryRepository = &fakeLibraryRepository{inLibrary: true}
+	deps.Sources = sources.SourceMap{testSource: source}
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	got, err := svc.RefreshComic(context.Background(), comics.RefreshComicOpts{
+		UserID: uuid.New(),
+		ID:     comicID,
+	})
+	if err != nil {
+		t.Fatalf("RefreshComic: %v", err)
+	}
+
+	if !source.lastInfosFresh || !source.lastChaptersFresh {
+		t.Errorf("fresh infos=%v chapters=%v, want both true", source.lastInfosFresh, source.lastChaptersFresh)
+	}
+
+	if chaptersSvc.createAllCalls != 1 {
+		t.Fatalf("CreateAll called %d times, want 1", chaptersSvc.createAllCalls)
+	}
+
+	if len(chaptersSvc.lastCreateAllChapters) != 1 ||
+		chaptersSvc.lastCreateAllChapters[0].SourceChapterSlug != testChapter2Slug {
+		t.Errorf("CreateAll chapters = %+v, want only %s", chaptersSvc.lastCreateAllChapters, testChapter2Slug)
+	}
+
+	if chaptersSvc.enqueueDownloadableCalls != 1 {
+		t.Fatalf("EnqueueDownloadable called %d times, want 1", chaptersSvc.enqueueDownloadableCalls)
+	}
+
+	if len(chaptersSvc.lastEnqueueChapters) != 1 || chaptersSvc.lastEnqueueChapters[0].ID != created.ID {
+		t.Errorf("enqueued = %+v, want created chapter", chaptersSvc.lastEnqueueChapters)
+	}
+
+	if repo.createCalls != 0 {
+		t.Errorf("ComicsRepository.Create called %d times, want 0", repo.createCalls)
+	}
+
+	if repo.updateStatusCalls != 1 {
+		t.Fatalf("UpdateStatusAndChapterCount called %d times, want 1", repo.updateStatusCalls)
+	}
+
+	if repo.lastUpdateStatus.ID != comicID ||
+		repo.lastUpdateStatus.Status != sources.SeriesStatusHiatus ||
+		repo.lastUpdateStatus.ChapterCount != 2 {
+		t.Errorf("update opts = %+v", repo.lastUpdateStatus)
+	}
+
+	if got == nil || got.ID != comicID || got.Title != "Solo Leveling" ||
+		got.Status != sources.SeriesStatusHiatus || got.ChapterCount != 2 {
+		t.Errorf("returned comic = %+v, want updated status/count and unchanged title", got)
+	}
+}
+
+func TestRefreshComicSkipsCreateWhenNoMissingChapters(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	repo := &fakeComicsRepository{
+		findByIDResult: &comics.Comic{
+			ID:     comicID,
+			Source: testSource,
+			Slug:   testSlug,
+			Status: sources.SeriesStatusHiatus,
+			Title:  "Solo Leveling",
+		},
+	}
+	chaptersSvc := &fakeChaptersService{
+		listByComicIDResult: []chapters.Chapter{{
+			ComicID:           comicID,
+			SourceChapterSlug: testChapterSlug,
+		}},
+	}
+	source := &fakeSource{
+		infos: &sources.GetInfosBySlugResponse{
+			Status:       sources.SeriesStatusHiatus,
+			ChapterCount: 1,
+		},
+		chapters: []sources.SourceChapter{{SourceChapterSlug: testChapterSlug, Number: 1}},
+	}
+
+	deps := validServiceDeps()
+	deps.ComicsRepository = repo
+	deps.ChaptersService = chaptersSvc
+	deps.LibraryRepository = &fakeLibraryRepository{inLibrary: true}
+	deps.Sources = sources.SourceMap{testSource: source}
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	_, err = svc.RefreshComic(context.Background(), comics.RefreshComicOpts{
+		UserID: uuid.New(),
+		ID:     comicID,
+	})
+	if err != nil {
+		t.Fatalf("RefreshComic: %v", err)
+	}
+
+	if chaptersSvc.createAllCalls != 0 {
+		t.Errorf("CreateAll called %d times, want 0", chaptersSvc.createAllCalls)
+	}
+
+	if chaptersSvc.enqueueDownloadableCalls != 0 {
+		t.Errorf("EnqueueDownloadable called %d times, want 0", chaptersSvc.enqueueDownloadableCalls)
+	}
+
+	if repo.updateStatusCalls != 1 {
+		t.Errorf("UpdateStatusAndChapterCount called %d times, want 1", repo.updateStatusCalls)
+	}
+}
+
+func TestRefreshComicSourceInfosErrorDoesNotWrite(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	repo := &fakeComicsRepository{
+		findByIDResult: &comics.Comic{
+			ID:     comicID,
+			Source: testSource,
+			Slug:   testSlug,
+			Status: sources.SeriesStatusOngoing,
+		},
+	}
+	chaptersSvc := &fakeChaptersService{}
+	source := &fakeSource{err: errors.New("asura down")}
+
+	deps := validServiceDeps()
+	deps.ComicsRepository = repo
+	deps.ChaptersService = chaptersSvc
+	deps.LibraryRepository = &fakeLibraryRepository{inLibrary: true}
+	deps.Sources = sources.SourceMap{testSource: source}
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	_, err = svc.RefreshComic(context.Background(), comics.RefreshComicOpts{
+		UserID: uuid.New(),
+		ID:     comicID,
+	})
+	if !errors.Is(err, comics.ErrSourceUnavailable) {
+		t.Fatalf("RefreshComic = %v, want comics.ErrSourceUnavailable", err)
+	}
+
+	if chaptersSvc.createAllCalls != 0 || repo.updateStatusCalls != 0 {
+		t.Errorf("writes CreateAll=%d UpdateStatus=%d, want 0", chaptersSvc.createAllCalls, repo.updateStatusCalls)
+	}
+}
+
+func TestRefreshComicSourceChaptersErrorDoesNotWrite(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	repo := &fakeComicsRepository{
+		findByIDResult: &comics.Comic{
+			ID:     comicID,
+			Source: testSource,
+			Slug:   testSlug,
+			Status: sources.SeriesStatusOngoing,
+		},
+	}
+	chaptersSvc := &fakeChaptersService{}
+	source := &fakeSource{
+		infos:       &sources.GetInfosBySlugResponse{Status: sources.SeriesStatusOngoing, ChapterCount: 1},
+		chaptersErr: errors.New("asura chapters down"),
+	}
+
+	deps := validServiceDeps()
+	deps.ComicsRepository = repo
+	deps.ChaptersService = chaptersSvc
+	deps.LibraryRepository = &fakeLibraryRepository{inLibrary: true}
+	deps.Sources = sources.SourceMap{testSource: source}
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	_, err = svc.RefreshComic(context.Background(), comics.RefreshComicOpts{
+		UserID: uuid.New(),
+		ID:     comicID,
+	})
+	if !errors.Is(err, comics.ErrSourceUnavailable) {
+		t.Fatalf("RefreshComic = %v, want comics.ErrSourceUnavailable", err)
+	}
+
+	if chaptersSvc.createAllCalls != 0 || repo.updateStatusCalls != 0 {
+		t.Errorf("writes CreateAll=%d UpdateStatus=%d, want 0", chaptersSvc.createAllCalls, repo.updateStatusCalls)
+	}
+}
+
+func TestRefreshComicCreateAllFailureDoesNotUpdateStatus(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	repo := &fakeComicsRepository{
+		findByIDResult: &comics.Comic{
+			ID:     comicID,
+			Source: testSource,
+			Slug:   testSlug,
+			Status: sources.SeriesStatusOngoing,
+		},
+	}
+	chaptersSvc := &fakeChaptersService{
+		createAllErr: errors.New("insert failed"),
+	}
+	source := &fakeSource{
+		infos: &sources.GetInfosBySlugResponse{Status: sources.SeriesStatusOngoing, ChapterCount: 2},
+		chapters: []sources.SourceChapter{
+			{SourceChapterSlug: testChapter2Slug, Number: 2},
+		},
+	}
+
+	deps := validServiceDeps()
+	deps.ComicsRepository = repo
+	deps.ChaptersService = chaptersSvc
+	deps.LibraryRepository = &fakeLibraryRepository{inLibrary: true}
+	deps.Sources = sources.SourceMap{testSource: source}
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	_, err = svc.RefreshComic(context.Background(), comics.RefreshComicOpts{
+		UserID: uuid.New(),
+		ID:     comicID,
+	})
+	if err == nil {
+		t.Fatal("RefreshComic = nil, want CreateAll error")
+	}
+
+	if repo.updateStatusCalls != 0 {
+		t.Errorf("UpdateStatusAndChapterCount called %d times, want 0", repo.updateStatusCalls)
+	}
+
+	if chaptersSvc.enqueueDownloadableCalls != 0 {
+		t.Errorf("EnqueueDownloadable called %d times, want 0", chaptersSvc.enqueueDownloadableCalls)
+	}
+}

--- a/api/pkg/core/comics/service_test.go
+++ b/api/pkg/core/comics/service_test.go
@@ -82,6 +82,7 @@ func (f *fakeLocalCoverStore) RemoveLocal(comicID uuid.UUID) error {
 
 type fakeComicsRepository struct {
 	getByIDErr             error
+	findByIDErr            error
 	findBySourceSlugErr    error
 	deleteErr              error
 	createErr              error
@@ -89,6 +90,7 @@ type fakeComicsRepository struct {
 	listByStatusesErr      error
 	updateStatusErr        error
 	getByIDResult          *comics.Comic
+	findByIDResult         *comics.Comic
 	findBySourceSlugResult *comics.Comic
 	findBySourceSlugSecond *comics.Comic
 	createResult           *comics.Comic
@@ -100,6 +102,7 @@ type fakeComicsRepository struct {
 	findBySourceSlugCalls  int
 	createCalls            int
 	getByIDCalls           int
+	findByIDCalls          int
 	getManyCalls           int
 	deleteCalls            int
 	listByStatusesCalls    int
@@ -113,8 +116,20 @@ func (f *fakeComicsRepository) GetByID(_ context.Context, _ comics.GetByIDOpts) 
 	return f.getByIDResult, f.getByIDErr
 }
 
-func (f *fakeComicsRepository) FindByID(context.Context, uuid.UUID) (*comics.Comic, error) {
-	panic("FindByID must not be called by the comics service")
+func (f *fakeComicsRepository) FindByID(_ context.Context, id uuid.UUID) (*comics.Comic, error) {
+	f.findByIDCalls++
+
+	if f.findByIDErr != nil {
+		return nil, f.findByIDErr
+	}
+
+	if f.findByIDResult == nil || f.findByIDResult.ID != id {
+		return nil, domain.ErrNotFound
+	}
+
+	copied := *f.findByIDResult
+
+	return &copied, nil
 }
 
 func (f *fakeComicsRepository) GetBySourceSlug(context.Context, comics.GetBySourceSlugOpts) (*comics.Comic, error) {
@@ -191,20 +206,28 @@ func (f *fakeComicsRepository) UpdateStatusAndChapterCount(
 	f.updateStatusCalls++
 	f.lastUpdateStatus = opts
 
+	if f.findByIDResult != nil && f.findByIDResult.ID == opts.ID {
+		f.findByIDResult.Status = opts.Status
+		f.findByIDResult.ChapterCount = opts.ChapterCount
+	}
+
 	return f.updateStatusErr
 }
 
 type fakeLibraryRepository struct {
-	createErr            error
-	deleteErr            error
-	existsByComicIDErr   error
-	existsByComicID      bool
-	createCalls          int
-	deleteCalls          int
-	existsByComicIDCalls int
-	lastCreate           library.CreateOpts
-	lastDelete           library.DeleteOpts
-	lastExistsComicID    uuid.UUID
+	createErr                 error
+	deleteErr                 error
+	existsByComicIDErr        error
+	existsByUserAndComicErr   error
+	existsByComicID           bool
+	inLibrary                 bool
+	createCalls               int
+	deleteCalls               int
+	existsByComicIDCalls      int
+	existsByUserAndComicCalls int
+	lastCreate                library.CreateOpts
+	lastDelete                library.DeleteOpts
+	lastExistsComicID         uuid.UUID
 }
 
 func (f *fakeLibraryRepository) Create(_ context.Context, opts library.CreateOpts) (*library.Entry, error) {
@@ -237,7 +260,13 @@ func (f *fakeLibraryRepository) ExistsByComicID(_ context.Context, comicID uuid.
 }
 
 func (f *fakeLibraryRepository) ExistsByUserAndComic(_ context.Context, _, _ uuid.UUID) (bool, error) {
-	return true, nil
+	f.existsByUserAndComicCalls++
+
+	if f.existsByUserAndComicErr != nil {
+		return false, f.existsByUserAndComicErr
+	}
+
+	return f.inLibrary, nil
 }
 
 type fakeChaptersService struct {

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -352,6 +352,10 @@ func (fakeComicsService) RefreshChapterLists(context.Context) error {
 	return errors.New(notImplemented)
 }
 
+func (fakeComicsService) RefreshComic(context.Context, comics.RefreshComicOpts) (*comics.Comic, error) {
+	return nil, errors.New(notImplemented)
+}
+
 func (fakeComicsService) ServeCover(context.Context, comics.GetByIDOpts) (string, string, error) {
 	return "", "", errors.New(notImplemented)
 }


### PR DESCRIPTION
## Summary

Closes #83.

- Add authenticated `POST /api/comics/{id}/refresh` (no body) that refreshes one pollable library comic from its source
- Insert only missing chapters, update status + chapter count in a transaction, then enqueue downloadable chapters after commit
- Return **200** with the updated `comicResponse` (design spec; not the issue’s 204 + re-GET)
- Map 401 / 400 / 404 / 403 / 409 / 502 / 500; leave the periodic `refreshComic` job unchanged
- Do not overwrite title, type, or other add-to-library metadata

## Test plan

- [ ] Pollable comic in the library: missing chapters created, downloadable ones queued, status + chapter count updated
- [ ] Existing chapter rows and download progress unchanged; title/type/other metadata unchanged
- [ ] Unknown id → 404; not in library → 403; completed/cancelled/dropped → 409 with no source calls
- [ ] Source failure → 502 and no DB writes
- [ ] Unauthenticated → 401; invalid UUID → 400
- [ ] Success body is 200 + comic JSON
- [x] `go test ./...` and `golangci-lint run ./...` pass