### PR TITLE
feat(comic): refresh action on the library comic page

### DIFF
--- a/api/pkg/core/comics/refresh.go
+++ b/api/pkg/core/comics/refresh.go
@@ -71,7 +71,7 @@ func (s *Service) refreshSource(ctx context.Context, name sources.SourceName) er
 }
 
 func isPollable(status sources.SeriesStatus) bool {
-	return status == sources.SeriesStatusOngoing || status == sources.SeriesStatusHiatus
+	return status == sources.SeriesStatusOngoing || status == sources.SeriesStatusHiatus || status == ""
 }
 
 func (s *Service) RefreshComic(ctx context.Context, opts RefreshComicOpts) (*Comic, error) {

--- a/web/app/features/comics/components/StatusInfos.test.ts
+++ b/web/app/features/comics/components/StatusInfos.test.ts
@@ -3,12 +3,18 @@
 
 import type { VueWrapper } from '@vue/test-utils'
 import type { Comic } from '../types'
-import { mountSuspended } from '@nuxt/test-utils/runtime'
-import { describe, expect, it } from 'vitest'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
 import { VApp, VBtn } from 'vuetify/components'
 import { ASURA_SOURCE_NAME } from '~/constants'
 import StatusInfos from './StatusInfos.vue'
+
+function comicsApiStub(): { refreshById: ReturnType<typeof vi.fn> } {
+  return { refreshById: vi.fn() }
+}
+
+mockNuxtImport('createComicsApi', () => comicsApiStub)
 
 const DeleteStub = defineComponent({
   name: 'ComicsModalDelete',
@@ -40,7 +46,7 @@ function comic(overrides: Partial<Comic> = {}): Comic {
 
 async function mount(value: Comic = comic()): Promise<VueWrapper> {
   return mountSuspended(
-    { render: () => h(VApp, () => [h(StatusInfos, { comic: value })]) },
+    { render: () => h(VApp, () => [h(StatusInfos, { modelValue: value })]) },
     { global: { stubs: { ComicsModalDelete: DeleteStub } } },
   )
 }
@@ -60,6 +66,6 @@ describe('comicsStatusInfos', () => {
     const wrapper = await mount()
 
     expect(wrapper.text()).toContain('Remove from library')
-    expect(wrapper.findComponent(VBtn).props('color')).toBe('error')
+    expect(wrapper.findAllComponents(VBtn).some(btn => btn.props('color') === 'error')).toBe(true)
   })
 })

--- a/web/app/features/comics/components/StatusInfos.vue
+++ b/web/app/features/comics/components/StatusInfos.vue
@@ -2,9 +2,30 @@
 <script setup lang="ts">
 import type { Comic } from '../types'
 
-defineProps<{ comic: Comic }>()
 defineEmits<{ deleted: [] }>()
+const comic = defineModel<Comic>({ required: true })
+const { t } = useI18n()
+const toast = useToast()
+const api = createComicsApi()
+
 const showDeleteModal = ref(false)
+const refreshLoading = ref(false)
+
+async function refreshComic(): Promise<void> {
+  refreshLoading.value = true
+
+  const response = await api.refreshById(comic.value.id)
+  if (response.success) {
+    comic.value = response.data
+  } else {
+    console.error(response.error)
+    toast.error(t('error.unknown'))
+  }
+
+  refreshLoading.value = false
+}
+
+const canRefresh = computed(() => comic.value.status !== 'hiatus' && comic.value.status !== 'completed' && comic.value.status !== 'cancelled')
 </script>
 
 <template>
@@ -24,15 +45,27 @@ const showDeleteModal = ref(false)
       <ComicsChipType :type="comic.type" />
     </div>
 
-    <VBtn
-      variant="tonal"
-      class="w-100 border-thin-error"
-      color="error"
-      prepend-icon="fa6-solid:trash"
-      size="large"
-      :text="$t('comics.remove.title')"
-      @click="showDeleteModal = true"
-    />
+    <div class="d-flex ga-2 ga-4 align-center flex-wrap">
+      <VBtn
+        v-if="canRefresh"
+        v-tooltip="$t('comics.refresh.title')"
+        icon="fa6-solid:repeat"
+        color="secondary"
+        size="small"
+        class="border-thin-secondary"
+        @click="refreshComic"
+      />
+
+      <VBtn
+        variant="tonal"
+        class="border-thin-error"
+        color="error"
+        prepend-icon="fa6-solid:trash"
+        size="large"
+        :text="$t('comics.remove.title')"
+        @click="showDeleteModal = true"
+      />
+    </div>
     <div v-if="comic.author" class="d-flex ga-2 justify-space-between">
       <span class="text-body-large text-medium-emphasis text-uppercase text-truncate">{{ $t('comic.fields.author') }}</span>
       <span class="text-body-large font-weight-bold text-truncate">{{ comic.author }}</span>

--- a/web/app/features/comics/composables/comics.api.ts
+++ b/web/app/features/comics/composables/comics.api.ts
@@ -9,6 +9,7 @@ export interface ComicsApi {
   deleteById: (id: string) => Promise<ApiResponse<void>>
   search: (params: SearchComicParams) => Promise<ApiResponse<SearchComicResponse>>
   getById: (id: string) => Promise<ApiResponse<Comic>>
+  refreshById: (id: string) => Promise<ApiResponse<Comic>>
 }
 
 export interface CreateComicParams {
@@ -70,10 +71,21 @@ export function createComicsApi(): ComicsApi {
     }
   }
 
+  async function refreshById(id: string): Promise<ApiResponse<Comic>> {
+    try {
+      const response = await api<Comic>(`/${id}/refresh`, { method: 'POST' })
+
+      return { success: true, data: response }
+    } catch (error) {
+      return { success: false, error: ApiError.fromFetchError(error) }
+    }
+  }
+
   return {
     create,
     deleteById,
     search,
     getById,
+    refreshById,
   }
 }

--- a/web/app/pages/comic/[id]/index.test.ts
+++ b/web/app/pages/comic/[id]/index.test.ts
@@ -41,9 +41,9 @@ mockNuxtImport('navigateTo', () => navigateTo)
 
 const StatusStub = defineComponent({
   name: 'ComicsStatusInfos',
-  props: { comic: { type: Object, required: true } },
+  props: { modelValue: { type: Object, required: true } },
   emits: ['deleted'],
-  template: '<div data-test="status-infos">{{ comic.title }}</div>',
+  template: '<div data-test="status-infos">{{ modelValue.title }}</div>',
 })
 
 const GeneralStub = defineComponent({

--- a/web/app/pages/comic/[id]/index.vue
+++ b/web/app/pages/comic/[id]/index.vue
@@ -96,7 +96,7 @@ const backRoutes = computed((): PageLayoutBackRoute[] => from.value === FEED_ROU
 
         <ComicsStatusInfos
           v-if="!smAndDown"
-          :comic
+          v-model="comic"
           @deleted="onDelete"
         />
       </div>
@@ -119,7 +119,7 @@ const backRoutes = computed((): PageLayoutBackRoute[] => from.value === FEED_ROU
         </div>
         <ComicsStatusInfos
           v-if="smAndDown"
-          :comic
+          v-model="comic"
           @deleted="onDelete"
         />
         <ComicsGeneralInfos :comic />

--- a/web/i18n/locales/en.json
+++ b/web/i18n/locales/en.json
@@ -295,6 +295,9 @@
       "error": {
         "alreadyExists": "Comic already in library"
       }
+    },
+    "refresh": {
+      "title": "Refresh"
     }
   },
   "comic": {

--- a/web/i18n/locales/fr.json
+++ b/web/i18n/locales/fr.json
@@ -294,6 +294,9 @@
       "error": {
         "alreadyExists": " Série déjà en bibliothèque"
       }
+    },
+    "refresh": {
+      "title": "Rafraîchir"
     }
   },
   "library": {


### PR DESCRIPTION
## Summary

Closes #84.

- Add a Refresh control on `/comic/:id` that calls `POST /api/comics/{id}/refresh` and replaces the stored comic from the response (200 + comic JSON, as in #83)
- Show the control when status is not hiatus / completed / cancelled; disable it while the request is in flight; toast on failure and leave data unchanged
- Treat empty source status as pollable in `RefreshComic` so a missing status does not block an on-demand refresh
- i18n en + fr under `comics.refresh.title`

## Test plan

- [ ] Pollable comic: Refresh posts `/api/comics/{id}/refresh`, then the page status/chapter count update from the returned comic
- [ ] Non-pollable: control not shown (or disabled), no request
- [ ] In-flight: control disabled until the request finishes
- [ ] Source/API error: toast, page data unchanged
- [ ] en + fr strings
- [ ] `pnpm test`, `pnpm typecheck`, `pnpm lint`, `pnpm knip` pass