### PR TITLE
feat(readersettings): per-user per-type reader settings API

### DIFF
--- a/api/cmd/uchiyomiserver/setup.go
+++ b/api/cmd/uchiyomiserver/setup.go
@@ -58,6 +58,9 @@ import (
 	httphealth "github.com/kharente-deuh/uchiyomi-server/pkg/core/health/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/library"
 	pglibrary "github.com/kharente-deuh/uchiyomi-server/pkg/core/library/repository/pg"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readersettings"
+	httpreadersettings "github.com/kharente-deuh/uchiyomi-server/pkg/core/readersettings/gateway/http"
+	pgreadersettings "github.com/kharente-deuh/uchiyomi-server/pkg/core/readersettings/repository/pg"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/setup"
 	httpsetup "github.com/kharente-deuh/uchiyomi-server/pkg/core/setup/gateway/http"
 	httpusers "github.com/kharente-deuh/uchiyomi-server/pkg/core/users/gateway/http"
@@ -143,6 +146,11 @@ func setupApp(cfg *cfg) (*core.App, error) {
 		return nil, fmt.Errorf("failed to init feedSvc: %w", err)
 	}
 
+	readerSettingsSvc, err := readersettings.NewService(readersettings.Deps{Repository: dbr.ReaderSettingsRepository})
+	if err != nil {
+		return nil, fmt.Errorf("failed to init readerSettingsSvc: %w", err)
+	}
+
 	asuraApp.BindChaptersService(chaptersSvc)
 
 	comicsSvc, err := comics.NewService(comics.Deps{
@@ -172,17 +180,18 @@ func setupApp(cfg *cfg) (*core.App, error) {
 	registry := core.NewHealthRegistry(dbr.PGDB)
 
 	ctrls, err := setupCtrls(ctrlsDeps{
-		Logger:               logger,
-		ComicsService:        comicsSvc,
-		ChaptersService:      chaptersSvc,
-		FeedService:          feedSvc,
-		SessionsService:      services.Sessions,
-		SetupService:         services.Setup,
-		AuthService:          services.Auth,
-		OIDCProvidersService: services.OIDCProviders,
-		AsuraApp:             asuraApp,
-		CoversService:        coversBundle.Service,
-		Registry:             registry,
+		Logger:                logger,
+		ComicsService:         comicsSvc,
+		ChaptersService:       chaptersSvc,
+		FeedService:           feedSvc,
+		ReaderSettingsService: readerSettingsSvc,
+		SessionsService:       services.Sessions,
+		SetupService:          services.Setup,
+		AuthService:           services.Auth,
+		OIDCProvidersService:  services.OIDCProviders,
+		AsuraApp:              asuraApp,
+		CoversService:         coversBundle.Service,
+		Registry:              registry,
 	})
 	if err != nil {
 		//nolint:wrapcheck
@@ -195,16 +204,17 @@ func setupApp(cfg *cfg) (*core.App, error) {
 			AllowedOrigins: cfg.Http.AllowedOrigins,
 		},
 		core.Deps{
-			SetupCtrl:         ctrls.Setup,
-			AsuraCtrl:         ctrls.Asura,
-			CoversCtrl:        ctrls.Covers,
-			HealthCtrl:        ctrls.Health,
-			AuthCtrl:          ctrls.Auth,
-			UsersCtrl:         ctrls.Users,
-			OIDCProvidersCtrl: ctrls.OIDCProviders,
-			ComicsCtrl:        ctrls.Comics,
-			ChaptersCtrl:      ctrls.Chapters,
-			FeedCtrl:          ctrls.Feed,
+			SetupCtrl:          ctrls.Setup,
+			AsuraCtrl:          ctrls.Asura,
+			CoversCtrl:         ctrls.Covers,
+			HealthCtrl:         ctrls.Health,
+			AuthCtrl:           ctrls.Auth,
+			UsersCtrl:          ctrls.Users,
+			OIDCProvidersCtrl:  ctrls.OIDCProviders,
+			ComicsCtrl:         ctrls.Comics,
+			ChaptersCtrl:       ctrls.Chapters,
+			FeedCtrl:           ctrls.Feed,
+			ReaderSettingsCtrl: ctrls.ReaderSettings,
 
 			Health:             registry,
 			Logger:             logger,
@@ -235,6 +245,7 @@ type dbRelated struct {
 	ChaptersRepository            *pgchapters.PGChaptersRepository
 	LibraryRepository             *pglibrary.PGLibraryRepository
 	FeedRepository                *pgfeed.PGFeedRepository
+	ReaderSettingsRepository      *pgreadersettings.PGReaderSettingsRepository
 }
 
 func setupDBRelated(c *cfg, logger *slog.Logger) (*dbRelated, error) {
@@ -304,6 +315,11 @@ func setupDBRelated(c *cfg, logger *slog.Logger) (*dbRelated, error) {
 		return nil, fmt.Errorf("failed to init feedRepository: %w", err)
 	}
 
+	readerSettingsRepository, err := pgreadersettings.New(pgreadersettings.Deps{DB: pgdb.DB})
+	if err != nil {
+		return nil, fmt.Errorf("failed to init readerSettingsRepository: %w", err)
+	}
+
 	dbr := &dbRelated{
 		PGDB:                          pgdb,
 		Txor:                          txor,
@@ -316,6 +332,7 @@ func setupDBRelated(c *cfg, logger *slog.Logger) (*dbRelated, error) {
 		ChaptersRepository:            chaptersRepository,
 		LibraryRepository:             libraryRepository,
 		FeedRepository:                feedRepository,
+		ReaderSettingsRepository:      readerSettingsRepository,
 	}
 
 	return dbr, nil
@@ -711,30 +728,32 @@ func setupAsura(logger *slog.Logger, comicsRepo comics.ComicsRepository) (*asura
 }
 
 type ctrls struct {
-	Setup         *httpsetup.Controller
-	Asura         *httpasura.Controller
-	Covers        *httpcovers.Controller
-	Health        *httphealth.Controller
-	Auth          *httpauth.Controller
-	Users         *httpusers.Controller
-	OIDCProviders *httpoidcproviders.Controller
-	Comics        *httpcomics.Controller
-	Chapters      *httpchapters.Controller
-	Feed          *httpfeed.Controller
+	Setup          *httpsetup.Controller
+	Asura          *httpasura.Controller
+	Covers         *httpcovers.Controller
+	Health         *httphealth.Controller
+	Auth           *httpauth.Controller
+	Users          *httpusers.Controller
+	OIDCProviders  *httpoidcproviders.Controller
+	Comics         *httpcomics.Controller
+	Chapters       *httpchapters.Controller
+	Feed           *httpfeed.Controller
+	ReaderSettings *httpreadersettings.Controller
 }
 
 type ctrlsDeps struct {
-	FeedService          feed.FeedService
-	AsuraApp             *asura.App
-	CoversService        *covers.Service
-	SetupService         *setup.Service
-	SessionsService      *sessions.Service
-	Logger               *slog.Logger
-	Registry             *health.Registry
-	AuthService          *auth.Service
-	OIDCProvidersService *oidcproviders.Service
-	ComicsService        *comics.Service
-	ChaptersService      *chapters.Service
+	FeedService           feed.FeedService
+	ReaderSettingsService readersettings.ReaderSettingsService
+	AsuraApp              *asura.App
+	CoversService         *covers.Service
+	SetupService          *setup.Service
+	SessionsService       *sessions.Service
+	Logger                *slog.Logger
+	Registry              *health.Registry
+	AuthService           *auth.Service
+	OIDCProvidersService  *oidcproviders.Service
+	ComicsService         *comics.Service
+	ChaptersService       *chapters.Service
 }
 
 func setupCtrls(deps ctrlsDeps) (*ctrls, error) {
@@ -896,17 +915,32 @@ func setupCtrls(deps ctrlsDeps) (*ctrls, error) {
 		return nil, fmt.Errorf("failed to init feed controller: %w", err)
 	}
 
+	readerSettingsCtrl, err := httpreadersettings.New(
+		httpreadersettings.Config{
+			Endpoint:    "/me",
+			Middlewares: chi.Middlewares{authenticator.Middleware},
+		},
+		httpreadersettings.Deps{
+			Logger:  deps.Logger,
+			Service: deps.ReaderSettingsService,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init reader settings controller: %w", err)
+	}
+
 	c := &ctrls{
-		Asura:         asuraCtrl,
-		Covers:        coversCtrl,
-		Setup:         setup,
-		Health:        healthCtrl,
-		Auth:          authCtrl,
-		Users:         usersCtrl,
-		OIDCProviders: oidcProvidersCtrl,
-		Comics:        comicsCtrl,
-		Chapters:      chaptersCtrl,
-		Feed:          feedCtrl,
+		Asura:          asuraCtrl,
+		Covers:         coversCtrl,
+		Setup:          setup,
+		Health:         healthCtrl,
+		Auth:           authCtrl,
+		Users:          usersCtrl,
+		OIDCProviders:  oidcProvidersCtrl,
+		Comics:         comicsCtrl,
+		Chapters:       chaptersCtrl,
+		Feed:           feedCtrl,
+		ReaderSettings: readerSettingsCtrl,
 	}
 
 	return c, nil

--- a/api/cmd/uchiyomiserver/setup_internal_test.go
+++ b/api/cmd/uchiyomiserver/setup_internal_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
 	coredomain "github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/feed"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readersettings"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/users"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/health"
 )
@@ -75,6 +76,16 @@ type stubFeedService struct{}
 
 func (stubFeedService) Get(context.Context, feed.GetOpts) (feed.Page, error) {
 	return feed.Page{Items: []feed.Item{}, Total: 0}, nil
+}
+
+type stubReaderSettingsService struct{}
+
+func (stubReaderSettingsService) ListForUser(context.Context, uuid.UUID) ([]readersettings.Profile, error) {
+	return []readersettings.Profile{}, nil
+}
+
+func (stubReaderSettingsService) Replace(context.Context, readersettings.ReplaceOpts) (readersettings.Profile, error) {
+	return readersettings.Profile{}, nil
 }
 
 type emptyOIDCProvidersRepository struct{}
@@ -242,13 +253,14 @@ func newTestCtrlsForUser(t *testing.T, user *users.User) *ctrls {
 	}
 
 	c, err := setupCtrls(ctrlsDeps{
-		AsuraApp:             asuraApp,
-		CoversService:        coversBundle.Service,
-		SessionsService:      newTestSessionsService(t, user),
-		Logger:               logger,
-		Registry:             health.NewRegistry(),
-		OIDCProvidersService: newTestOIDCProvidersService(t),
-		FeedService:          stubFeedService{},
+		AsuraApp:              asuraApp,
+		CoversService:         coversBundle.Service,
+		SessionsService:       newTestSessionsService(t, user),
+		Logger:                logger,
+		Registry:              health.NewRegistry(),
+		OIDCProvidersService:  newTestOIDCProvidersService(t),
+		FeedService:           stubFeedService{},
+		ReaderSettingsService: stubReaderSettingsService{},
 	})
 	if err != nil {
 		t.Fatalf("setupCtrls: %v", err)

--- a/api/pkg/core/app.go
+++ b/api/pkg/core/app.go
@@ -22,6 +22,7 @@ import (
 	httpcovers "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/gateway/http"
 	httpfeed "github.com/kharente-deuh/uchiyomi-server/pkg/core/feed/gateway/http"
 	httphealth "github.com/kharente-deuh/uchiyomi-server/pkg/core/health/gateway/http"
+	httpreadersettings "github.com/kharente-deuh/uchiyomi-server/pkg/core/readersettings/gateway/http"
 	httpsetup "github.com/kharente-deuh/uchiyomi-server/pkg/core/setup/gateway/http"
 	httpusers "github.com/kharente-deuh/uchiyomi-server/pkg/core/users/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/health"
@@ -67,16 +68,17 @@ type Database interface {
 type Deps struct {
 	DB Database
 
-	SetupCtrl         *httpsetup.Controller
-	AsuraCtrl         *httpasura.Controller
-	CoversCtrl        *httpcovers.Controller
-	HealthCtrl        *httphealth.Controller
-	AuthCtrl          *httpauth.Controller
-	UsersCtrl         *httpusers.Controller
-	ComicsCtrl        *httpcomics.Controller
-	ChaptersCtrl      *httpchapters.Controller
-	FeedCtrl          *httpfeed.Controller
-	OIDCProvidersCtrl *httpoidcproviders.Controller
+	SetupCtrl          *httpsetup.Controller
+	AsuraCtrl          *httpasura.Controller
+	CoversCtrl         *httpcovers.Controller
+	HealthCtrl         *httphealth.Controller
+	AuthCtrl           *httpauth.Controller
+	UsersCtrl          *httpusers.Controller
+	ComicsCtrl         *httpcomics.Controller
+	ChaptersCtrl       *httpchapters.Controller
+	FeedCtrl           *httpfeed.Controller
+	ReaderSettingsCtrl *httpreadersettings.Controller
+	OIDCProvidersCtrl  *httpoidcproviders.Controller
 
 	Logger *slog.Logger
 	Health *health.Registry
@@ -160,6 +162,10 @@ func (deps *Deps) Validate() error {
 
 	if deps.FeedCtrl == nil {
 		return errors.New("feedCtrl is required")
+	}
+
+	if deps.ReaderSettingsCtrl == nil {
+		return errors.New("readerSettingsCtrl is required")
 	}
 
 	if deps.Health == nil {
@@ -300,6 +306,7 @@ func (a *App) newRouter(ui http.Handler) chi.Router {
 			a.deps.ComicsCtrl.InitRouter(r)
 			a.deps.ChaptersCtrl.InitRouter(r)
 			a.deps.FeedCtrl.InitRouter(r)
+			a.deps.ReaderSettingsCtrl.InitRouter(r)
 			r.Route("/sources", func(r chi.Router) {
 				a.deps.CoversCtrl.InitRouter(r)
 				a.deps.AsuraCtrl.InitRouter(r)

--- a/api/pkg/core/app_internal_test.go
+++ b/api/pkg/core/app_internal_test.go
@@ -43,6 +43,21 @@ func TestRouterMountsTheFeedRoute(t *testing.T) {
 	}
 }
 
+func TestRouterMountsTheReaderSettingsRoute(t *testing.T) {
+	t.Parallel()
+
+	app, _ := newTestApp(t, &fakeDB{}, gatePort)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/me/reader-settings", nil)
+	rec := httptest.NewRecorder()
+
+	app.newRouter(nil).ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusNotFound {
+		t.Errorf("GET /api/me/reader-settings = 404, want the route to be mounted")
+	}
+}
+
 func TestRouterMountsTheOIDCCallbackAdvertisedAsRedirectURI(t *testing.T) {
 	t.Parallel()
 

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -34,6 +34,8 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/feed"
 	httpfeed "github.com/kharente-deuh/uchiyomi-server/pkg/core/feed/gateway/http"
 	healthhttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/health/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readersettings"
+	httpreadersettings "github.com/kharente-deuh/uchiyomi-server/pkg/core/readersettings/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/setup"
 	httpsetup "github.com/kharente-deuh/uchiyomi-server/pkg/core/setup/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/users"
@@ -406,6 +408,16 @@ func (fakeFeedService) Get(context.Context, feed.GetOpts) (feed.Page, error) {
 	return feed.Page{Items: []feed.Item{}, Total: 0}, nil
 }
 
+type fakeReaderSettingsService struct{}
+
+func (fakeReaderSettingsService) ListForUser(context.Context, uuid.UUID) ([]readersettings.Profile, error) {
+	return []readersettings.Profile{}, nil
+}
+
+func (fakeReaderSettingsService) Replace(context.Context, readersettings.ReplaceOpts) (readersettings.Profile, error) {
+	return readersettings.Profile{}, nil
+}
+
 func newTestCache[P any, T any](t *testing.T, name string, logger *slog.Logger) *fncache.Cache[P, T] {
 	t.Helper()
 
@@ -577,6 +589,14 @@ func newTestApp(t *testing.T, db Database, port int) (*App, *health.Registry) {
 		t.Fatalf("httpfeed.New: %v", err)
 	}
 
+	readerSettingsCtrl, err := httpreadersettings.New(
+		httpreadersettings.Config{Endpoint: "/me"},
+		httpreadersettings.Deps{Logger: logger, Service: fakeReaderSettingsService{}},
+	)
+	if err != nil {
+		t.Fatalf("httpreadersettings.New: %v", err)
+	}
+
 	app, err := New(
 		Config{ServerPort: port, AllowedOrigins: []string{"*"}},
 		Deps{
@@ -591,6 +611,7 @@ func newTestApp(t *testing.T, db Database, port int) (*App, *health.Registry) {
 			ComicsCtrl:         comicsCtrl,
 			ChaptersCtrl:       chaptersCtrl,
 			FeedCtrl:           feedCtrl,
+			ReaderSettingsCtrl: readerSettingsCtrl,
 			Logger:             logger,
 			Health:             registry,
 			Asura:              asuraApp,

--- a/api/pkg/core/readersettings/domain.go
+++ b/api/pkg/core/readersettings/domain.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package readersettings
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+)
+
+var ErrInvalid = errors.New("invalid reader settings")
+
+type ReadingMode string
+
+const (
+	ReadingModePagedRTL ReadingMode = "paged-rtl"
+	ReadingModePagedLTR ReadingMode = "paged-ltr"
+	ReadingModeWebtoon  ReadingMode = "webtoon"
+)
+
+type PageScale string
+
+const (
+	PageScaleFitWidth  PageScale = "fit-width"
+	PageScaleFitHeight PageScale = "fit-height"
+	PageScaleFitScreen PageScale = "fit-screen"
+)
+
+type Profile struct {
+	Type        sources.SeriesType
+	ReadingMode ReadingMode
+	PageScale   PageScale
+	DoublePage  bool
+}
+
+type ReplaceOpts struct {
+	ReadingMode ReadingMode
+	PageScale   PageScale
+	Type        sources.SeriesType
+	UserID      uuid.UUID
+	DoublePage  bool
+}
+
+type UpsertOpts struct {
+	ReadingMode ReadingMode
+	PageScale   PageScale
+	Type        sources.SeriesType
+	UserID      uuid.UUID
+	DoublePage  bool
+}
+
+type Repository interface {
+	ListByUser(context.Context, uuid.UUID) ([]Profile, error)
+	Upsert(context.Context, UpsertOpts) (Profile, error)
+}
+
+type ReaderSettingsService interface {
+	ListForUser(context.Context, uuid.UUID) ([]Profile, error)
+	Replace(context.Context, ReplaceOpts) (Profile, error)
+}
+
+func AllTypes() []sources.SeriesType {
+	return []sources.SeriesType{
+		sources.SeriesTypeManga,
+		sources.SeriesTypeManhua,
+		sources.SeriesTypeManhwa,
+		sources.SeriesTypeMangatoon,
+	}
+}
+
+func DefaultProfile(t sources.SeriesType) Profile {
+	switch t {
+	case sources.SeriesTypeManga:
+		return Profile{
+			Type:        sources.SeriesTypeManga,
+			ReadingMode: ReadingModePagedRTL,
+			PageScale:   PageScaleFitScreen,
+		}
+	case sources.SeriesTypeManhua:
+		return Profile{
+			Type:        sources.SeriesTypeManhua,
+			ReadingMode: ReadingModePagedLTR,
+			PageScale:   PageScaleFitScreen,
+		}
+	case sources.SeriesTypeManhwa:
+		return Profile{
+			Type:        sources.SeriesTypeManhwa,
+			ReadingMode: ReadingModeWebtoon,
+			PageScale:   PageScaleFitWidth,
+		}
+	case sources.SeriesTypeMangatoon:
+		return Profile{
+			Type:        sources.SeriesTypeMangatoon,
+			ReadingMode: ReadingModeWebtoon,
+			PageScale:   PageScaleFitWidth,
+		}
+	default:
+		return Profile{Type: t}
+	}
+}
+
+func ParseReadingMode(s string) (ReadingMode, error) {
+	switch s {
+	case string(ReadingModePagedRTL):
+		return ReadingModePagedRTL, nil
+	case string(ReadingModePagedLTR):
+		return ReadingModePagedLTR, nil
+	case string(ReadingModeWebtoon):
+		return ReadingModeWebtoon, nil
+	default:
+		return "", fmt.Errorf("%w: reading mode %q", ErrInvalid, s)
+	}
+}
+
+func ParsePageScale(s string) (PageScale, error) {
+	switch s {
+	case string(PageScaleFitWidth):
+		return PageScaleFitWidth, nil
+	case string(PageScaleFitHeight):
+		return PageScaleFitHeight, nil
+	case string(PageScaleFitScreen):
+		return PageScaleFitScreen, nil
+	default:
+		return "", fmt.Errorf("%w: page scale %q", ErrInvalid, s)
+	}
+}

--- a/api/pkg/core/readersettings/domain_test.go
+++ b/api/pkg/core/readersettings/domain_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package readersettings_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readersettings"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+)
+
+func TestAllTypesOrder(t *testing.T) {
+	t.Parallel()
+
+	got := readersettings.AllTypes()
+	want := []sources.SeriesType{
+		sources.SeriesTypeManga,
+		sources.SeriesTypeManhua,
+		sources.SeriesTypeManhwa,
+		sources.SeriesTypeMangatoon,
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("AllTypes() len = %d, want %d", len(got), len(want))
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("AllTypes()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestDefaultProfile(t *testing.T) {
+	t.Parallel()
+
+	tests := map[sources.SeriesType]readersettings.Profile{
+		sources.SeriesTypeManga: {
+			Type:        sources.SeriesTypeManga,
+			ReadingMode: readersettings.ReadingModePagedRTL,
+			PageScale:   readersettings.PageScaleFitScreen,
+			DoublePage:  false,
+		},
+		sources.SeriesTypeManhua: {
+			Type:        sources.SeriesTypeManhua,
+			ReadingMode: readersettings.ReadingModePagedLTR,
+			PageScale:   readersettings.PageScaleFitScreen,
+			DoublePage:  false,
+		},
+		sources.SeriesTypeManhwa: {
+			Type:        sources.SeriesTypeManhwa,
+			ReadingMode: readersettings.ReadingModeWebtoon,
+			PageScale:   readersettings.PageScaleFitWidth,
+			DoublePage:  false,
+		},
+		sources.SeriesTypeMangatoon: {
+			Type:        sources.SeriesTypeMangatoon,
+			ReadingMode: readersettings.ReadingModeWebtoon,
+			PageScale:   readersettings.PageScaleFitWidth,
+			DoublePage:  false,
+		},
+	}
+
+	for typ, want := range tests {
+		t.Run(string(typ), func(t *testing.T) {
+			t.Parallel()
+
+			got := readersettings.DefaultProfile(typ)
+			if got != want {
+				t.Errorf("DefaultProfile(%q) = %+v, want %+v", typ, got, want)
+			}
+		})
+	}
+}
+
+func TestParseReadingMode(t *testing.T) {
+	t.Parallel()
+
+	ok := map[string]readersettings.ReadingMode{
+		"paged-rtl": readersettings.ReadingModePagedRTL,
+		"paged-ltr": readersettings.ReadingModePagedLTR,
+		"webtoon":   readersettings.ReadingModeWebtoon,
+	}
+
+	for in, want := range ok {
+		got, err := readersettings.ParseReadingMode(in)
+		if err != nil {
+			t.Fatalf("ParseReadingMode(%q): %v", in, err)
+		}
+
+		if got != want {
+			t.Errorf("ParseReadingMode(%q) = %q, want %q", in, got, want)
+		}
+	}
+
+	_, err := readersettings.ParseReadingMode("scroll")
+	if !errors.Is(err, readersettings.ErrInvalid) {
+		t.Errorf("ParseReadingMode(scroll) err = %v, want ErrInvalid", err)
+	}
+}
+
+func TestParsePageScale(t *testing.T) {
+	t.Parallel()
+
+	ok := map[string]readersettings.PageScale{
+		"fit-width":  readersettings.PageScaleFitWidth,
+		"fit-height": readersettings.PageScaleFitHeight,
+		"fit-screen": readersettings.PageScaleFitScreen,
+	}
+
+	for in, want := range ok {
+		got, err := readersettings.ParsePageScale(in)
+		if err != nil {
+			t.Fatalf("ParsePageScale(%q): %v", in, err)
+		}
+
+		if got != want {
+			t.Errorf("ParsePageScale(%q) = %q, want %q", in, got, want)
+		}
+	}
+
+	_, err := readersettings.ParsePageScale("original")
+	if !errors.Is(err, readersettings.ErrInvalid) {
+		t.Errorf("ParsePageScale(original) err = %v, want ErrInvalid", err)
+	}
+}

--- a/api/pkg/core/readersettings/gateway/http/controller.go
+++ b/api/pkg/core/readersettings/gateway/http/controller.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package http
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	httpsession "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readersettings"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/httputils"
+)
+
+type Config struct {
+	Endpoint    string
+	Middlewares chi.Middlewares
+}
+
+func (cfg *Config) Validate() error {
+	if cfg.Endpoint == "" {
+		return errors.New("endpoint is required")
+	}
+
+	if !strings.HasPrefix(cfg.Endpoint, "/") {
+		return fmt.Errorf("endpoint must start with '/', got %q", cfg.Endpoint)
+	}
+
+	hasNilMiddlewares := slices.ContainsFunc(cfg.Middlewares, func(m func(http.Handler) http.Handler) bool {
+		return m == nil
+	})
+
+	if hasNilMiddlewares {
+		return errors.New("all middlewares must not be nil")
+	}
+
+	return nil
+}
+
+type Deps struct {
+	Service readersettings.ReaderSettingsService
+	Logger  *slog.Logger
+}
+
+func (deps *Deps) Validate() error {
+	if deps.Service == nil {
+		return errors.New("service is required")
+	}
+
+	if deps.Logger == nil {
+		return errors.New("logger is required")
+	}
+
+	return nil
+}
+
+type Controller struct {
+	deps Deps
+	cfg  Config
+}
+
+func New(cfg Config, deps Deps) (*Controller, error) {
+	var err error
+	if err = cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("cfg.Validate: %w", err)
+	}
+
+	if err = deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	deps.Logger = deps.Logger.With("component", "readersettings.gateway.http")
+
+	return &Controller{deps: deps, cfg: cfg}, nil
+}
+
+func (c *Controller) InitRouter(r chi.Router) {
+	r.Route(c.cfg.Endpoint, func(r chi.Router) {
+		r.Use(c.cfg.Middlewares...)
+		r.Get("/reader-settings", c.list)
+		r.Put("/reader-settings/{type}", c.replace)
+	})
+}
+
+func (c *Controller) list(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user, ok := httpsession.UserFrom(ctx)
+	if !ok {
+		httputils.WriteError(w, c.deps.Logger, http.StatusUnauthorized, "")
+
+		return
+	}
+
+	profiles, err := c.deps.Service.ListForUser(ctx, user.ID)
+	if err != nil {
+		c.deps.Logger.Error("failed to list reader settings", "error", err)
+		httputils.WriteError(w, c.deps.Logger, http.StatusInternalServerError, "")
+
+		return
+	}
+
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, listFromDomain(profiles))
+}
+
+func (c *Controller) replace(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user, ok := httpsession.UserFrom(ctx)
+	if !ok {
+		httputils.WriteError(w, c.deps.Logger, http.StatusUnauthorized, "")
+
+		return
+	}
+
+	comicType, err := sources.ParseSeriesType(chi.URLParam(r, "type"))
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "invalid comic type")
+
+		return
+	}
+
+	req, err := httputils.DecodeJSON[replaceRequest](r)
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "invalid request body")
+
+		return
+	}
+
+	readingMode, err := readersettings.ParseReadingMode(req.ReadingMode)
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "invalid request body")
+
+		return
+	}
+
+	pageScale, err := readersettings.ParsePageScale(req.PageScale)
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "invalid request body")
+
+		return
+	}
+
+	profile, err := c.deps.Service.Replace(ctx, readersettings.ReplaceOpts{
+		UserID:      user.ID,
+		Type:        comicType,
+		ReadingMode: readingMode,
+		PageScale:   pageScale,
+		DoublePage:  *req.DoublePage,
+	})
+	if err != nil {
+		if errors.Is(err, readersettings.ErrInvalid) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "invalid request body")
+
+			return
+		}
+
+		c.deps.Logger.Error("failed to replace reader settings", "error", err)
+		httputils.WriteError(w, c.deps.Logger, http.StatusInternalServerError, "")
+
+		return
+	}
+
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, profileFromDomain(profile))
+}

--- a/api/pkg/core/readersettings/gateway/http/controller_test.go
+++ b/api/pkg/core/readersettings/gateway/http/controller_test.go
@@ -1,0 +1,399 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package http_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
+	sessionshttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readersettings"
+	httpreadersettings "github.com/kharente-deuh/uchiyomi-server/pkg/core/readersettings/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/users"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+)
+
+const (
+	endpoint     = "/me"
+	listPath     = "/me/reader-settings"
+	cookieName   = "uchiyomi_session"
+	testToken    = "letoken"
+	testUsername = "alice"
+)
+
+type stubService struct {
+	listErr     error
+	replaceErr  error
+	list        []readersettings.Profile
+	lastReplace readersettings.ReplaceOpts
+	lastList    uuid.UUID
+}
+
+func (s *stubService) ListForUser(_ context.Context, userID uuid.UUID) ([]readersettings.Profile, error) {
+	s.lastList = userID
+
+	return s.list, s.listErr
+}
+
+func (s *stubService) Replace(_ context.Context, opts readersettings.ReplaceOpts) (readersettings.Profile, error) {
+	s.lastReplace = opts
+
+	return readersettings.Profile{
+		Type:        opts.Type,
+		ReadingMode: opts.ReadingMode,
+		PageScale:   opts.PageScale,
+		DoublePage:  opts.DoublePage,
+	}, s.replaceErr
+}
+
+type stubSessionService struct {
+	result *sessions.AuthenticatedSession
+}
+
+func (s *stubSessionService) Authenticate(_ context.Context, _ string) (*sessions.AuthenticatedSession, error) {
+	if s.result == nil {
+		return nil, sessions.ErrInvalidSession
+	}
+
+	return s.result, nil
+}
+
+type listResponse struct {
+	Items []struct {
+		Type        string `json:"type"`
+		ReadingMode string `json:"readingMode"`
+		PageScale   string `json:"pageScale"`
+		DoublePage  bool   `json:"doublePage"`
+	} `json:"items"`
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewJSONHandler(bytes.NewBuffer(nil), &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func frozenNow() time.Time {
+	return time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
+}
+
+func authenticatorFor(t *testing.T, user *users.User) chi.Middlewares {
+	t.Helper()
+
+	logger := testLogger()
+
+	cookies, err := sessionshttp.NewCookieManager(sessionshttp.CookieConfig{Name: cookieName, Path: "/"})
+	if err != nil {
+		t.Fatalf("NewCookieManager: %v", err)
+	}
+
+	a, err := sessionshttp.NewAuthenticator(sessionshttp.AuthenticatorDeps{
+		SessionService: &stubSessionService{result: &sessions.AuthenticatedSession{
+			User:    user,
+			Session: sessions.Session{ID: uuid.New(), UserID: user.ID, ExpiresAt: frozenNow().Add(time.Hour)},
+		}},
+		Cookies: cookies,
+		Logger:  logger,
+		Now:     frozenNow,
+	})
+	if err != nil {
+		t.Fatalf("NewAuthenticator: %v", err)
+	}
+
+	return chi.Middlewares{a.Middleware}
+}
+
+func newTestRouter(t *testing.T, svc *stubService, mws chi.Middlewares) chi.Router {
+	t.Helper()
+
+	logger := testLogger()
+
+	c, err := httpreadersettings.New(
+		httpreadersettings.Config{Endpoint: endpoint, Middlewares: mws},
+		httpreadersettings.Deps{Logger: logger, Service: svc},
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	r := chi.NewRouter()
+	c.InitRouter(r)
+
+	return r
+}
+
+func defaultProfiles() []readersettings.Profile {
+	types := readersettings.AllTypes()
+	out := make([]readersettings.Profile, 0, len(types))
+	for _, typ := range types {
+		out = append(out, readersettings.DefaultProfile(typ))
+	}
+
+	return out
+}
+
+func testUser() *users.User {
+	return &users.User{ID: uuid.New(), Name: testUsername}
+}
+
+func getList(r chi.Router, withCookie bool) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, listPath, nil)
+	if withCookie {
+		req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	}
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	return rec
+}
+
+func putReplace(r chi.Router, comicType, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPut, listPath+"/"+comicType, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	return rec
+}
+
+func TestNewValidatesConfigAndDeps(t *testing.T) {
+	t.Parallel()
+
+	logger := testLogger()
+	svc := &stubService{}
+	passthrough := func(next http.Handler) http.Handler { return next }
+
+	tests := map[string]struct {
+		deps    httpreadersettings.Deps
+		wantErr string
+		cfg     httpreadersettings.Config
+	}{
+		"empty endpoint": {
+			cfg:     httpreadersettings.Config{},
+			deps:    httpreadersettings.Deps{Logger: logger, Service: svc},
+			wantErr: "cfg.Validate: endpoint is required",
+		},
+		"nil middleware": {
+			cfg: httpreadersettings.Config{
+				Endpoint:    endpoint,
+				Middlewares: chi.Middlewares{passthrough, nil},
+			},
+			deps:    httpreadersettings.Deps{Logger: logger, Service: svc},
+			wantErr: "cfg.Validate: all middlewares must not be nil",
+		},
+		"nil logger": {
+			cfg:     httpreadersettings.Config{Endpoint: endpoint},
+			deps:    httpreadersettings.Deps{Service: svc},
+			wantErr: "deps.Validate: logger is required",
+		},
+		"nil service": {
+			cfg:     httpreadersettings.Config{Endpoint: endpoint},
+			deps:    httpreadersettings.Deps{Logger: logger},
+			wantErr: "deps.Validate: service is required",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := httpreadersettings.New(tc.cfg, tc.deps)
+			if err == nil {
+				t.Fatalf("New() = nil, want %q", tc.wantErr)
+			}
+
+			if c != nil {
+				t.Error("New returned a controller in addition to the error")
+			}
+
+			if err.Error() != tc.wantErr {
+				t.Errorf("New() = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestListUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	r := newTestRouter(t, &stubService{list: defaultProfiles()}, authenticatorFor(t, user))
+
+	rec := getList(r, false)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusUnauthorized, rec.Body.String())
+	}
+}
+
+func TestListOK(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	svc := &stubService{list: defaultProfiles()}
+	r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+	rec := getList(r, true)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var got listResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("body not decodable (%q): %v", rec.Body.String(), err)
+	}
+
+	if len(got.Items) != 4 {
+		t.Fatalf("items len = %d, want 4 (body: %s)", len(got.Items), rec.Body.String())
+	}
+
+	first := got.Items[0]
+	if first.Type != "manga" {
+		t.Errorf("items[0].type = %q, want %q", first.Type, "manga")
+	}
+
+	if first.ReadingMode != "paged-rtl" {
+		t.Errorf("items[0].readingMode = %q, want %q", first.ReadingMode, "paged-rtl")
+	}
+
+	if first.PageScale != "fit-screen" {
+		t.Errorf("items[0].pageScale = %q, want %q", first.PageScale, "fit-screen")
+	}
+
+	if first.DoublePage {
+		t.Errorf("items[0].doublePage = true, want false")
+	}
+
+	if svc.lastList != user.ID {
+		t.Errorf("lastList = %s, want %s", svc.lastList, user.ID)
+	}
+}
+
+func TestReplaceOK(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	svc := &stubService{}
+	r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+	body := `{"readingMode":"paged-rtl","pageScale":"fit-height","doublePage":true}`
+	rec := putReplace(r, "manga", body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var got struct {
+		Type       string `json:"type"`
+		DoublePage bool   `json:"doublePage"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("body not decodable (%q): %v", rec.Body.String(), err)
+	}
+
+	if got.Type != "manga" {
+		t.Errorf("type = %q, want %q", got.Type, "manga")
+	}
+
+	if !got.DoublePage {
+		t.Errorf("doublePage = false, want true")
+	}
+
+	if svc.lastReplace.UserID != user.ID {
+		t.Errorf("lastReplace.UserID = %s, want %s", svc.lastReplace.UserID, user.ID)
+	}
+
+	if svc.lastReplace.Type != sources.SeriesTypeManga {
+		t.Errorf("lastReplace.Type = %q, want %q", svc.lastReplace.Type, sources.SeriesTypeManga)
+	}
+}
+
+func TestReplaceUnknownType(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	svc := &stubService{}
+	r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+	rec := putReplace(r, "webcomic", `{"readingMode":"paged-rtl","pageScale":"fit-height","doublePage":true}`)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+
+	if svc.lastReplace.UserID != uuid.Nil {
+		t.Errorf("Replace was called with UserID %s, want uuid.Nil", svc.lastReplace.UserID)
+	}
+}
+
+func TestReplaceInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	r := newTestRouter(t, &stubService{}, authenticatorFor(t, user))
+
+	rec := putReplace(r, "manga", `{`)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestReplaceMissingField(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	r := newTestRouter(t, &stubService{}, authenticatorFor(t, user))
+
+	rec := putReplace(r, "manga", `{"readingMode":"paged-rtl","pageScale":"fit-height"}`)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestReplaceWebtoonDoublePage(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	svc := &stubService{replaceErr: readersettings.ErrInvalid}
+	r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+	body := `{"readingMode":"webtoon","pageScale":"fit-width","doublePage":true}`
+	rec := putReplace(r, "manhwa", body)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestReplaceUsesSessionUserNotBody(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	svc := &stubService{}
+	r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+	body := `{"readingMode":"paged-rtl","pageScale":"fit-height","doublePage":false}`
+	rec := putReplace(r, "manga", body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	if svc.lastReplace.UserID != user.ID {
+		t.Errorf("lastReplace.UserID = %s, want session user %s", svc.lastReplace.UserID, user.ID)
+	}
+}

--- a/api/pkg/core/readersettings/gateway/http/dto.go
+++ b/api/pkg/core/readersettings/gateway/http/dto.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package http
+
+import (
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readersettings"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+)
+
+type profileResponse struct {
+	Type        sources.SeriesType         `json:"type"`
+	ReadingMode readersettings.ReadingMode `json:"readingMode"`
+	PageScale   readersettings.PageScale   `json:"pageScale"`
+	DoublePage  bool                       `json:"doublePage"`
+}
+
+type listResponse struct {
+	Items []profileResponse `json:"items"`
+}
+
+type replaceRequest struct {
+	DoublePage  *bool  `json:"doublePage" validate:"required"`
+	ReadingMode string `json:"readingMode" validate:"required"`
+	PageScale   string `json:"pageScale" validate:"required"`
+}
+
+func profileFromDomain(p readersettings.Profile) profileResponse {
+	return profileResponse{
+		Type:        p.Type,
+		ReadingMode: p.ReadingMode,
+		PageScale:   p.PageScale,
+		DoublePage:  p.DoublePage,
+	}
+}
+
+func listFromDomain(profiles []readersettings.Profile) listResponse {
+	items := make([]profileResponse, 0, len(profiles))
+	for _, p := range profiles {
+		items = append(items, profileFromDomain(p))
+	}
+
+	return listResponse{Items: items}
+}

--- a/api/pkg/core/readersettings/repository/pg/repository.go
+++ b/api/pkg/core/readersettings/repository/pg/repository.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package pg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readersettings"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/repository/pgmodels"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/transaction/pgtx"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+var _ readersettings.Repository = (*PGReaderSettingsRepository)(nil)
+
+type Deps struct {
+	DB *gorm.DB
+}
+
+func (deps *Deps) Validate() error {
+	if deps.DB == nil {
+		return errors.New("db is required")
+	}
+
+	return nil
+}
+
+type PGReaderSettingsRepository struct {
+	deps Deps
+}
+
+func New(deps Deps) (*PGReaderSettingsRepository, error) {
+	if err := deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	r := &PGReaderSettingsRepository{deps: deps}
+
+	return r, nil
+}
+
+func (r *PGReaderSettingsRepository) db(ctx context.Context) gorm.Interface[pgmodels.ReaderSettings] {
+	return gorm.G[pgmodels.ReaderSettings](pgtx.From(ctx, r.deps.DB))
+}
+
+func (r *PGReaderSettingsRepository) ListByUser(
+	ctx context.Context, userID uuid.UUID,
+) ([]readersettings.Profile, error) {
+	models, err := r.db(ctx).Where("user_id = ?", userID).Find(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
+	}
+
+	ret := make([]readersettings.Profile, 0, len(models))
+	for i := range models {
+		ret = append(ret, models[i].Domain())
+	}
+
+	return ret, nil
+}
+
+func (r *PGReaderSettingsRepository) Upsert(
+	ctx context.Context, opts readersettings.UpsertOpts,
+) (readersettings.Profile, error) {
+	model := &pgmodels.ReaderSettings{
+		ID:          uuid.New(),
+		UserID:      opts.UserID,
+		ComicType:   pgmodels.ComicTypeFromDomain(opts.Type),
+		ReadingMode: string(opts.ReadingMode),
+		PageScale:   string(opts.PageScale),
+		DoublePage:  opts.DoublePage,
+	}
+
+	err := pgtx.From(ctx, r.deps.DB).WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "user_id"}, {Name: "comic_type"}},
+		DoUpdates: clause.AssignmentColumns([]string{"reading_mode", "page_scale", "double_page", "updated_at"}),
+	}).Create(model).Error
+	if err != nil {
+		return readersettings.Profile{}, fmt.Errorf("pgtx.From(ctx, r.deps.DB).Create: %w", err)
+	}
+
+	return model.Domain(), nil
+}

--- a/api/pkg/core/readersettings/repository/pg/repository_test.go
+++ b/api/pkg/core/readersettings/repository/pg/repository_test.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//nolint:goconst
+package pg_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readersettings"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readersettings/repository/pg"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/repository/pgtest"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+)
+
+func newReaderSettingsRepo(t *testing.T) (*pg.PGReaderSettingsRepository, sqlmock.Sqlmock) {
+	t.Helper()
+
+	db, mock := pgtest.New(t)
+
+	r, err := pg.New(pg.Deps{DB: db})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	return r, mock
+}
+
+func TestNewValidatesDeps(t *testing.T) {
+	t.Parallel()
+
+	r, err := pg.New(pg.Deps{})
+	if err == nil {
+		t.Fatal("New without DB must fail")
+	}
+
+	if r != nil {
+		t.Error("New returned a repository in addition to the error")
+	}
+
+	if want := "deps.Validate: db is required"; err.Error() != want {
+		t.Errorf("err = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestListByUserFiltersUserID(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newReaderSettingsRepo(t)
+
+	userID := uuid.New()
+	otherUserID := uuid.New()
+	id := uuid.New()
+
+	mock.ExpectQuery(`FROM "reader_settings".*user_id`).
+		WithArgs(userID).
+		WillReturnRows(
+			sqlmock.NewRows([]string{
+				"id", "user_id", "comic_type", "reading_mode", "page_scale", "double_page",
+			}).AddRow(
+				id, userID, "manga",
+				string(readersettings.ReadingModePagedRTL),
+				string(readersettings.PageScaleFitScreen),
+				true,
+			),
+		)
+
+	got, err := r.ListByUser(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("ListByUser: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("ListByUser() len = %d, want 1", len(got))
+	}
+
+	want := readersettings.Profile{
+		Type:        sources.SeriesTypeManga,
+		ReadingMode: readersettings.ReadingModePagedRTL,
+		PageScale:   readersettings.PageScaleFitScreen,
+		DoublePage:  true,
+	}
+	if got[0] != want {
+		t.Errorf("ListByUser()[0] = %+v, want %+v", got[0], want)
+	}
+
+	if otherUserID == userID {
+		t.Fatal("unlucky uuid collision")
+	}
+}
+
+func TestUpsertInserts(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newReaderSettingsRepo(t)
+
+	userID := uuid.New()
+	opts := mangaUpsertOpts(userID)
+
+	expectUpsertQuery(mock, userID, `INSERT INTO "reader_settings"`)
+
+	got, err := r.Upsert(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	want := readersettings.Profile{
+		Type:        sources.SeriesTypeManga,
+		ReadingMode: opts.ReadingMode,
+		PageScale:   opts.PageScale,
+		DoublePage:  opts.DoublePage,
+	}
+	if got != want {
+		t.Errorf("Upsert() = %+v, want %+v", got, want)
+	}
+}
+
+func TestUpsertConflictUpdates(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newReaderSettingsRepo(t)
+
+	userID := uuid.New()
+	opts := mangaUpsertOpts(userID)
+
+	expectUpsertQuery(mock, userID, `ON CONFLICT`)
+
+	got, err := r.Upsert(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	want := readersettings.Profile{
+		Type:        sources.SeriesTypeManga,
+		ReadingMode: opts.ReadingMode,
+		PageScale:   opts.PageScale,
+		DoublePage:  opts.DoublePage,
+	}
+	if got != want {
+		t.Errorf("Upsert() = %+v, want %+v", got, want)
+	}
+}
+
+func mangaUpsertOpts(userID uuid.UUID) readersettings.UpsertOpts {
+	return readersettings.UpsertOpts{
+		UserID:      userID,
+		Type:        sources.SeriesTypeManga,
+		ReadingMode: readersettings.ReadingModePagedRTL,
+		PageScale:   readersettings.PageScaleFitScreen,
+		DoublePage:  false,
+	}
+}
+
+func expectUpsertQuery(mock sqlmock.Sqlmock, userID uuid.UUID, sqlRegex string) {
+	mock.ExpectBegin()
+	mock.ExpectQuery(sqlRegex).
+		WithArgs(
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+			string(readersettings.ReadingModePagedRTL),
+			string(readersettings.PageScaleFitScreen),
+			"manga",
+			userID,
+			false,
+			sqlmock.AnyArg(),
+		).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+	mock.ExpectCommit()
+}

--- a/api/pkg/core/readersettings/service.go
+++ b/api/pkg/core/readersettings/service.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package readersettings
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+)
+
+var _ ReaderSettingsService = (*Service)(nil)
+
+type Deps struct {
+	Repository Repository
+}
+
+func (deps *Deps) Validate() error {
+	if deps.Repository == nil {
+		return errors.New("repository is required")
+	}
+
+	return nil
+}
+
+type Service struct {
+	deps Deps
+}
+
+func NewService(deps Deps) (*Service, error) {
+	if err := deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	return &Service{deps: deps}, nil
+}
+
+func (s *Service) ListForUser(ctx context.Context, userID uuid.UUID) ([]Profile, error) {
+	stored, err := s.deps.Repository.ListByUser(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.Repository.ListByUser: %w", err)
+	}
+
+	byType := make(map[sources.SeriesType]Profile, len(stored))
+	for _, profile := range stored {
+		if !knownType(profile.Type) {
+			continue
+		}
+
+		byType[profile.Type] = profile
+	}
+
+	types := AllTypes()
+	out := make([]Profile, 0, len(types))
+	for _, typ := range types {
+		if profile, ok := byType[typ]; ok {
+			out = append(out, profile)
+
+			continue
+		}
+
+		out = append(out, DefaultProfile(typ))
+	}
+
+	return out, nil
+}
+
+func (s *Service) Replace(ctx context.Context, opts ReplaceOpts) (Profile, error) {
+	if !knownType(opts.Type) {
+		return Profile{}, ErrInvalid
+	}
+
+	if opts.ReadingMode == ReadingModeWebtoon && opts.DoublePage {
+		return Profile{}, ErrInvalid
+	}
+
+	profile, err := s.deps.Repository.Upsert(ctx, UpsertOpts(opts))
+	if err != nil {
+		return Profile{}, fmt.Errorf("s.deps.Repository.Upsert: %w", err)
+	}
+
+	return profile, nil
+}
+
+func knownType(t sources.SeriesType) bool {
+	for _, typ := range AllTypes() {
+		if typ == t {
+			return true
+		}
+	}
+
+	return false
+}

--- a/api/pkg/core/readersettings/service_test.go
+++ b/api/pkg/core/readersettings/service_test.go
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package readersettings_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readersettings"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+)
+
+//nolint:govet // fieldalignment on a test fake is not worth the unreadable field order
+type fakeRepo struct {
+	listErr     error
+	upsertErr   error
+	listedFor   uuid.UUID
+	stored      []readersettings.Profile
+	lastUpsert  readersettings.UpsertOpts
+	listCalls   int
+	upsertCalls int
+}
+
+func (f *fakeRepo) ListByUser(_ context.Context, userID uuid.UUID) ([]readersettings.Profile, error) {
+	f.listCalls++
+	f.listedFor = userID
+
+	return f.stored, f.listErr
+}
+
+func (f *fakeRepo) Upsert(_ context.Context, opts readersettings.UpsertOpts) (readersettings.Profile, error) {
+	f.upsertCalls++
+	f.lastUpsert = opts
+
+	return readersettings.Profile{
+		Type:        opts.Type,
+		ReadingMode: opts.ReadingMode,
+		PageScale:   opts.PageScale,
+		DoublePage:  opts.DoublePage,
+	}, f.upsertErr
+}
+
+func newService(t *testing.T, repo readersettings.Repository) *readersettings.Service {
+	t.Helper()
+
+	svc, err := readersettings.NewService(readersettings.Deps{Repository: repo})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	return svc
+}
+
+func TestNewServiceValidatesDeps(t *testing.T) {
+	t.Parallel()
+
+	_, err := readersettings.NewService(readersettings.Deps{})
+	if err == nil {
+		t.Fatal("NewService with empty deps must fail")
+	}
+}
+
+func TestListForUserReturnsFactoryDefaultsWithoutUpsert(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{}
+	svc := newService(t, repo)
+	userID := uuid.New()
+
+	got, err := svc.ListForUser(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("ListForUser: %v", err)
+	}
+
+	if repo.listCalls != 1 || repo.listedFor != userID {
+		t.Errorf("ListByUser calls=%d user=%s", repo.listCalls, repo.listedFor)
+	}
+
+	if repo.upsertCalls != 0 {
+		t.Fatalf("Upsert called %d times, want 0", repo.upsertCalls)
+	}
+
+	want := readersettings.AllTypes()
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d", len(got), len(want))
+	}
+
+	for i, typ := range want {
+		if got[i] != readersettings.DefaultProfile(typ) {
+			t.Errorf("items[%d] = %+v, want default %q", i, got[i], typ)
+		}
+	}
+}
+
+func TestListForUserOverlaysStoredMangaOnly(t *testing.T) {
+	t.Parallel()
+
+	saved := readersettings.Profile{
+		Type:        sources.SeriesTypeManga,
+		ReadingMode: readersettings.ReadingModePagedLTR,
+		PageScale:   readersettings.PageScaleFitHeight,
+		DoublePage:  true,
+	}
+	repo := &fakeRepo{stored: []readersettings.Profile{saved}}
+	svc := newService(t, repo)
+
+	got, err := svc.ListForUser(context.Background(), uuid.New())
+	if err != nil {
+		t.Fatalf("ListForUser: %v", err)
+	}
+
+	if got[0] != saved {
+		t.Errorf("manga = %+v, want stored", got[0])
+	}
+
+	if got[1] != readersettings.DefaultProfile(sources.SeriesTypeManhua) {
+		t.Errorf("manhua changed: %+v", got[1])
+	}
+
+	if got[2] != readersettings.DefaultProfile(sources.SeriesTypeManhwa) {
+		t.Errorf("manhwa changed: %+v", got[2])
+	}
+}
+
+func TestListForUserWrapsRepoError(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("list failed")
+	repo := &fakeRepo{listErr: cause}
+	svc := newService(t, repo)
+
+	_, err := svc.ListForUser(context.Background(), uuid.New())
+	if !errors.Is(err, cause) {
+		t.Errorf("ListForUser = %v, original error no longer reachable", err)
+	}
+}
+
+func TestReplaceMangaDoesNotWriteManhwa(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{}
+	svc := newService(t, repo)
+	userID := uuid.New()
+
+	got, err := svc.Replace(context.Background(), readersettings.ReplaceOpts{
+		UserID:      userID,
+		Type:        sources.SeriesTypeManga,
+		ReadingMode: readersettings.ReadingModePagedRTL,
+		PageScale:   readersettings.PageScaleFitHeight,
+		DoublePage:  true,
+	})
+	if err != nil {
+		t.Fatalf("Replace: %v", err)
+	}
+
+	if repo.upsertCalls != 1 {
+		t.Fatalf("Upsert calls = %d, want 1", repo.upsertCalls)
+	}
+
+	if repo.lastUpsert.UserID != userID || repo.lastUpsert.Type != sources.SeriesTypeManga {
+		t.Errorf("upsert = %+v", repo.lastUpsert)
+	}
+
+	if repo.lastUpsert.Type == sources.SeriesTypeManhwa {
+		t.Fatal("upsert wrote manhwa")
+	}
+
+	if got.Type != sources.SeriesTypeManga || !got.DoublePage {
+		t.Errorf("Replace() = %+v", got)
+	}
+}
+
+func TestReplaceRejectsWebtoonDoublePage(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{}
+	svc := newService(t, repo)
+
+	_, err := svc.Replace(context.Background(), readersettings.ReplaceOpts{
+		UserID:      uuid.New(),
+		Type:        sources.SeriesTypeManhwa,
+		ReadingMode: readersettings.ReadingModeWebtoon,
+		PageScale:   readersettings.PageScaleFitWidth,
+		DoublePage:  true,
+	})
+	if !errors.Is(err, readersettings.ErrInvalid) {
+		t.Errorf("err = %v, want ErrInvalid", err)
+	}
+
+	if repo.upsertCalls != 0 {
+		t.Errorf("Upsert called on invalid combo")
+	}
+}
+
+func TestReplaceRejectsUnknownType(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{}
+	svc := newService(t, repo)
+
+	_, err := svc.Replace(context.Background(), readersettings.ReplaceOpts{
+		UserID:      uuid.New(),
+		Type:        sources.SeriesType("webcomic"),
+		ReadingMode: readersettings.ReadingModePagedLTR,
+		PageScale:   readersettings.PageScaleFitScreen,
+	})
+	if !errors.Is(err, readersettings.ErrInvalid) {
+		t.Errorf("err = %v, want ErrInvalid", err)
+	}
+
+	if repo.upsertCalls != 0 {
+		t.Error("Upsert called for unknown type")
+	}
+}
+
+func TestReplacePassesCallerUserID(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{}
+	svc := newService(t, repo)
+	alice := uuid.New()
+
+	_, err := svc.Replace(context.Background(), readersettings.ReplaceOpts{
+		UserID:      alice,
+		Type:        sources.SeriesTypeManhua,
+		ReadingMode: readersettings.ReadingModePagedLTR,
+		PageScale:   readersettings.PageScaleFitScreen,
+	})
+	if err != nil {
+		t.Fatalf("Replace: %v", err)
+	}
+
+	if repo.lastUpsert.UserID != alice {
+		t.Errorf("UserID = %s, want alice", repo.lastUpsert.UserID)
+	}
+}
+
+func TestReplaceWrapsUpsertError(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("upsert failed")
+	repo := &fakeRepo{upsertErr: cause}
+	svc := newService(t, repo)
+
+	_, err := svc.Replace(context.Background(), readersettings.ReplaceOpts{
+		UserID:      uuid.New(),
+		Type:        sources.SeriesTypeManga,
+		ReadingMode: readersettings.ReadingModePagedRTL,
+		PageScale:   readersettings.PageScaleFitScreen,
+	})
+	if !errors.Is(err, cause) {
+		t.Errorf("Replace = %v, original error no longer reachable", err)
+	}
+}

--- a/api/pkg/repository/pgmodels/claims_test.go
+++ b/api/pkg/repository/pgmodels/claims_test.go
@@ -162,6 +162,7 @@ func TestTableNames(t *testing.T) {
 		"comic":              pgmodels.Comic{}.TableName(),
 		"chapter":            pgmodels.Chapter{}.TableName(),
 		"library entry":      pgmodels.LibraryEntry{}.TableName(),
+		"reader settings":    pgmodels.ReaderSettings{}.TableName(),
 	}
 
 	want := map[string]string{
@@ -173,6 +174,7 @@ func TestTableNames(t *testing.T) {
 		"comic":              "comics",
 		"chapter":            "chapters",
 		"library entry":      "library_entries",
+		"reader settings":    "reader_settings",
 	}
 
 	for model, got := range tests {

--- a/api/pkg/repository/pgmodels/readersettings.go
+++ b/api/pkg/repository/pgmodels/readersettings.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package pgmodels
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readersettings"
+)
+
+type ReaderSettings struct {
+	CreatedAt   time.Time `gorm:"autoCreateTime"`
+	UpdatedAt   time.Time `gorm:"autoUpdateTime"`
+	ReadingMode string    `gorm:"type:text;not null"`
+	PageScale   string    `gorm:"type:text;not null"`
+	//nolint:lll
+	ComicType  ComicType `gorm:"column:comic_type;type:text;not null;uniqueIndex:idx_reader_settings_user_type,priority:2"`
+	User       User      `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE"`
+	ID         uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+	UserID     uuid.UUID `gorm:"type:uuid;not null;uniqueIndex:idx_reader_settings_user_type,priority:1"`
+	DoublePage bool      `gorm:"not null"`
+}
+
+func (ReaderSettings) TableName() string {
+	return "reader_settings"
+}
+
+func (m *ReaderSettings) Domain() readersettings.Profile {
+	return readersettings.Profile{
+		Type:        m.ComicType.Domain(),
+		ReadingMode: readersettings.ReadingMode(m.ReadingMode),
+		PageScale:   readersettings.PageScale(m.PageScale),
+		DoublePage:  m.DoublePage,
+	}
+}

--- a/api/pkg/utils/database/pgdb.go
+++ b/api/pkg/utils/database/pgdb.go
@@ -117,6 +117,7 @@ func (pgdb *PGDB) Migrate() error {
 		&pgmodels.Session{},
 		&pgmodels.PasswordCreds{},
 		&pgmodels.LibraryEntry{},
+		&pgmodels.ReaderSettings{},
 	}
 
 	for _, m := range models {


### PR DESCRIPTION
## Summary

Closes #70.

- Add authenticated `GET /api/me/reader-settings` returning four complete profiles (`manga`, `manhua`, `manhwa`, `mangatoon`), filling factory defaults when the user has never saved that type
- Add authenticated `PUT /api/me/reader-settings/{type}` to replace one type only; unknown type or invalid body → **400**
- Persist `(user, comic type)` profiles; `webtoon` + `doublePage: true` is rejected (`ErrInvalid` → 400)
- Isolate users: list/replace always scoped to the session user

## Test plan

- [x] New user GET returns four factory-default profiles (manga paged-rtl / manhua paged-ltr / manhwa+mangatoon webtoon)
- [x] PUT manga does not change manhwa (or any other type)
- [x] User A cannot read or write user B’s settings
- [x] Unknown type / invalid body / `webtoon` + `doublePage: true` → 400
- [x] Unauthenticated GET/PUT → 401
- [x] `go test ./...` and `golangci-lint run ./...` pass
