### PR TITLE
feat(web): reader settings page (#72)

### DIFF
--- a/web/app/features/comics/components/Input/Status.vue
+++ b/web/app/features/comics/components/Input/Status.vue
@@ -30,7 +30,7 @@ const items: { value: ComicStatus, title: string }[] = [
 <template>
   <VSelect
     width="12rem"
-    :model="status"
+    :model-value="status"
     :items="items"
     density="compact"
     class="border-thin"

--- a/web/app/features/comics/components/Input/Type.vue
+++ b/web/app/features/comics/components/Input/Type.vue
@@ -2,8 +2,14 @@
 <script setup lang="ts">
 import type { ComicType } from '~/features/comics/types'
 
-defineProps<{ disabled?: boolean }>()
-const sort = defineModel<ComicType | undefined>({ required: true })
+withDefaults(defineProps<{
+  disabled?: boolean
+  hideLabel?: boolean
+  clearable?: boolean
+}>(), {
+  clearable: true,
+})
+const type = defineModel<ComicType | undefined>({ required: true })
 const { t } = useI18n()
 
 const items: { value: ComicType, title: string }[] = [
@@ -34,10 +40,10 @@ const items: { value: ComicType, title: string }[] = [
     class="border-thin"
     style="border-radius: 12px"
     :disabled
-    :model="sort"
+    :model-value="type"
     :items="items"
-    :label="$t('sources.asura.type.label')"
-    clearable
-    @update:model-value="sort = $event || undefined"
+    :label="hideLabel ? undefined : $t('sources.asura.type.label')"
+    :clearable
+    @update:model-value="type = $event || undefined"
   />
 </template>

--- a/web/app/features/reader/components/Card.test.ts
+++ b/web/app/features/reader/components/Card.test.ts
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { VueWrapper } from '@vue/test-utils'
+import type { ComicType } from '~/features/comics/types'
+import type { ReaderSettings } from '~/features/reader/types'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { h, ref } from 'vue'
+import { VApp } from 'vuetify/components'
+import { useToast } from '~/composables/toast.composable'
+import Card from './Card.vue'
+
+const { updateReaderSettings } = await vi.hoisted(async () => ({
+  updateReaderSettings: vi.fn(),
+}))
+
+function readerSettingsApiStub(): { updateReaderSettings: typeof updateReaderSettings } {
+  return { updateReaderSettings }
+}
+
+mockNuxtImport('createReaderSettingsApi', () => readerSettingsApiStub)
+
+function buttonByText(wrapper: VueWrapper, text: string): ReturnType<VueWrapper['find']> | undefined {
+  return wrapper.findAll('button').find(b => b.text().includes(text))
+}
+
+function manhwaDefaults(): ReaderSettings {
+  return {
+    type: 'manhwa',
+    readingMode: 'webtoon',
+    pageScale: 'fit-width',
+    doublePage: false,
+  }
+}
+
+async function mount(settings: ReaderSettings = manhwaDefaults()): Promise<{
+  wrapper: VueWrapper
+  model: ReturnType<typeof ref<ReaderSettings>>
+  type: ReturnType<typeof ref<ComicType>>
+}> {
+  const model = ref({ ...settings })
+  const type = ref(settings.type)
+  const wrapper = await mountSuspended({
+    setup: () => ({ model, type }),
+    render: () => h(VApp, () => [
+      h(Card, {
+        'modelValue': model.value,
+        'type': type.value,
+        'onUpdate:modelValue': (value: ReaderSettings) => {
+          model.value = value
+        },
+        'onUpdate:type': (value: ComicType) => {
+          type.value = value
+        },
+      }),
+    ]),
+  })
+
+  return { wrapper, model, type }
+}
+
+beforeEach(() => {
+  updateReaderSettings.mockReset()
+  useToast().messages.value.length = 0
+})
+
+describe('readerCard', () => {
+  it('keeps save disabled while nothing changed', async () => {
+    const { wrapper } = await mount()
+
+    expect(buttonByText(wrapper, 'Save')?.attributes('disabled')).toBeDefined()
+  })
+
+  it('hides reset when the saved settings already match the type defaults', async () => {
+    const { wrapper } = await mount()
+
+    expect(buttonByText(wrapper, 'Reset')).toBeUndefined()
+  })
+
+  it('enables save once a field changed', async () => {
+    const { wrapper } = await mount()
+
+    await buttonByText(wrapper, 'Left to right')?.trigger('click')
+
+    await vi.waitFor(() => expect(buttonByText(wrapper, 'Save')?.attributes('disabled')).toBeUndefined())
+  })
+
+  it('saves the edited settings', async () => {
+    updateReaderSettings.mockResolvedValue({
+      success: true,
+      data: { ...manhwaDefaults(), readingMode: 'paged-ltr' },
+    })
+    const { wrapper, model } = await mount()
+
+    await buttonByText(wrapper, 'Left to right')?.trigger('click')
+    await vi.waitFor(() => expect(buttonByText(wrapper, 'Save')?.attributes('disabled')).toBeUndefined())
+    await buttonByText(wrapper, 'Save')?.trigger('click')
+
+    await vi.waitFor(() => expect(updateReaderSettings).toHaveBeenCalledWith({
+      type: 'manhwa',
+      readingMode: 'paged-ltr',
+      pageScale: 'fit-width',
+      doublePage: false,
+    }))
+    expect(model.value.readingMode).toBe('paged-ltr')
+  })
+
+  it('toasts when save fails', async () => {
+    updateReaderSettings.mockResolvedValue({
+      success: false,
+      error: { status: 500, message: 'boom' },
+    })
+    const { wrapper } = await mount()
+
+    await buttonByText(wrapper, 'Left to right')?.trigger('click')
+    await vi.waitFor(() => expect(buttonByText(wrapper, 'Save')?.attributes('disabled')).toBeUndefined())
+    await buttonByText(wrapper, 'Save')?.trigger('click')
+
+    await vi.waitFor(() => expect(useToast().messages.value).toEqual([
+      { text: 'Unknown error', color: 'error' },
+    ]))
+  })
+
+  it('offers reset when the saved settings differ from the type defaults', async () => {
+    const { wrapper } = await mount({
+      type: 'manhwa',
+      readingMode: 'paged-rtl',
+      pageScale: 'fit-screen',
+      doublePage: true,
+    })
+
+    expect(buttonByText(wrapper, 'Reset')?.exists()).toBe(true)
+  })
+
+  it('restores the type defaults', async () => {
+    const restored = manhwaDefaults()
+    updateReaderSettings.mockResolvedValue({ success: true, data: restored })
+    const { wrapper, model } = await mount({
+      type: 'manhwa',
+      readingMode: 'paged-rtl',
+      pageScale: 'fit-screen',
+      doublePage: true,
+    })
+
+    await buttonByText(wrapper, 'Reset')?.trigger('click')
+
+    await vi.waitFor(() => expect(updateReaderSettings).toHaveBeenCalledWith(restored))
+    expect(model.value).toEqual(restored)
+  })
+
+  it('blocks double page and non-width scales in webtoon mode', async () => {
+    const { wrapper } = await mount()
+
+    expect(buttonByText(wrapper, 'Double page')?.attributes('disabled')).toBeDefined()
+    expect(buttonByText(wrapper, 'Fit height')?.attributes('disabled')).toBeDefined()
+    expect(buttonByText(wrapper, 'Fit screen')?.attributes('disabled')).toBeDefined()
+    expect(buttonByText(wrapper, 'Fit width')?.attributes('disabled')).toBeUndefined()
+    expect(buttonByText(wrapper, 'Single page')?.attributes('disabled')).toBeUndefined()
+  })
+})

--- a/web/app/features/reader/components/Card.test.ts
+++ b/web/app/features/reader/components/Card.test.ts
@@ -103,7 +103,7 @@ describe('readerCard', () => {
       pageScale: 'fit-width',
       doublePage: false,
     }))
-    expect(model.value.readingMode).toBe('paged-ltr')
+    expect(model.value?.readingMode).toBe('paged-ltr')
   })
 
   it('toasts when save fails', async () => {

--- a/web/app/features/reader/components/Card.vue
+++ b/web/app/features/reader/components/Card.vue
@@ -1,0 +1,169 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+import type { PageScale, ReaderSettings } from '../types'
+import type { PageMode } from './Input/PageMode.vue'
+import type { ComicType } from '~/features/comics/types'
+
+const settings = defineModel<ReaderSettings>({ required: true })
+const type = defineModel<ComicType>('type', { required: true })
+
+const { t } = useI18n()
+const toast = useToast()
+const { smAndDown } = useDisplay()
+const { updateReaderSettings } = createReaderSettingsApi()
+
+const internalSettings = ref<ReaderSettings>({ ...settings.value })
+watch(settings, () => {
+  internalSettings.value = { ...settings.value }
+}, { immediate: true })
+
+const updateLoading = ref(false)
+async function updateSettings(): Promise<void> {
+  updateLoading.value = true
+
+  const res = await updateReaderSettings(internalSettings.value)
+  if (res.success) {
+    settings.value = res.data
+  } else {
+    console.error('updateReaderSettings', res.error)
+    toast.error(t('error.unknown'))
+  }
+
+  updateLoading.value = false
+}
+
+const canUpdateSettings = computed(() => settings.value.doublePage !== internalSettings.value.doublePage
+  || settings.value.pageScale !== internalSettings.value.pageScale
+  || settings.value.readingMode !== internalSettings.value.readingMode)
+
+const unwantedPageScaleOptions = computed((): PageScale[] => {
+  if (internalSettings.value.readingMode === 'webtoon') {
+    return ['fit-height', 'fit-screen']
+  }
+
+  return []
+})
+
+const pageMode = computed({
+  get(): PageMode {
+    return internalSettings.value.doublePage ? 'double' : 'single'
+  },
+  set(value: PageMode) {
+    internalSettings.value.doublePage = value === 'double'
+  },
+})
+
+const unwantedPageModeOptions = computed((): PageMode[] => {
+  if (internalSettings.value.readingMode === 'webtoon') {
+    return ['double']
+  }
+
+  return []
+})
+
+const DEFAULT_OPTIONS: Record<ComicType, Omit<ReaderSettings, 'type'>> = {
+  manhwa: {
+    readingMode: 'webtoon',
+    pageScale: 'fit-width',
+    doublePage: false,
+  },
+  mangatoon: {
+    readingMode: 'webtoon',
+    pageScale: 'fit-width',
+    doublePage: false,
+  },
+  manhua: {
+    readingMode: 'paged-rtl',
+    pageScale: 'fit-screen',
+    doublePage: false,
+  },
+  manga: {
+    readingMode: 'webtoon',
+    pageScale: 'fit-width',
+    doublePage: false,
+  },
+}
+
+const canRestoreDefault = computed(() => {
+  const defaultOptions = DEFAULT_OPTIONS[type.value]
+
+  return settings.value.doublePage !== defaultOptions.doublePage
+    || settings.value.pageScale !== defaultOptions.pageScale
+    || settings.value.readingMode !== defaultOptions.readingMode
+})
+
+const restoreDefaultLoading = ref(false)
+async function restoreDefault(): Promise<void> {
+  restoreDefaultLoading.value = true
+
+  const res = await updateReaderSettings({ ...DEFAULT_OPTIONS[type.value], type: type.value })
+  if (res.success) {
+    settings.value = res.data
+  } else {
+    console.error('updateReaderSettings', res.error)
+    toast.error(t('error.unknown'))
+  }
+
+  restoreDefaultLoading.value = false
+}
+</script>
+
+<template>
+  <VCard class="pa-4 border-thin d-flex flex-column ga-6" style="border-radius: 12px;">
+    <div class="d-flex ga-2 align-center justify-space-between">
+      <span class="text-title-large">{{ $t('sources.asura.type.label') }}</span>
+      <div class="w-fit">
+        <ComicsInputType
+          v-model="type"
+          hide-label
+          :clearable="false"
+          :disabled="updateLoading || restoreDefaultLoading"
+        />
+      </div>
+    </div>
+    <VDivider />
+
+    <ReaderInputMode v-model="internalSettings.readingMode" :disabled="updateLoading || restoreDefaultLoading" />
+
+    <ReaderInputPageScale
+      v-model="internalSettings.pageScale"
+      :disabled-options="unwantedPageScaleOptions"
+      :disabled="updateLoading || restoreDefaultLoading"
+    />
+
+    <ReaderInputPageMode
+      v-model="pageMode"
+      :disabled-options="unwantedPageModeOptions"
+      :disabled="updateLoading || restoreDefaultLoading"
+    />
+
+    <div class="d-flex justify-end ga-4 w-100 flex-wrap">
+      <VBtn
+        v-if="canRestoreDefault"
+        :text="$t('actions.reset')"
+        color="secondary"
+        size="large"
+        variant="outlined"
+        :class="{
+          'w-100': smAndDown,
+        }"
+        :disabled="updateLoading"
+        :loading="restoreDefaultLoading"
+        @click="restoreDefault"
+      />
+
+      <VBtn
+        :text="$t('actions.save')"
+        color="primary"
+        size="large"
+        :class="{
+          'border-thin-primary': canUpdateSettings,
+          'w-100': smAndDown,
+        }"
+        :disabled="!canUpdateSettings || restoreDefaultLoading"
+        :loading="updateLoading"
+        @click="updateSettings"
+      />
+    </div>
+  </VCard>
+</template>

--- a/web/app/features/reader/components/Input/Mode.test.ts
+++ b/web/app/features/reader/components/Input/Mode.test.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { VueWrapper } from '@vue/test-utils'
+import type { ReadingMode } from '~/features/reader/types'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it } from 'vitest'
+import { h, ref } from 'vue'
+import { VApp } from 'vuetify/components'
+import Mode from './Mode.vue'
+
+function buttonByText(wrapper: VueWrapper, text: string): ReturnType<VueWrapper['find']> {
+  return wrapper.findAll('button').find(b => b.text().includes(text))!
+}
+
+async function mount(mode: ReadingMode = 'webtoon', isDisabled = false): Promise<{
+  wrapper: VueWrapper
+  model: ReturnType<typeof ref<ReadingMode>>
+}> {
+  const model = ref(mode)
+  const wrapper = await mountSuspended({
+    setup: () => ({ model, isDisabled }),
+    render: () => h(VApp, () => [
+      h(Mode, {
+        'modelValue': model.value,
+        'disabled': isDisabled,
+        'onUpdate:modelValue': (value: ReadingMode) => {
+          model.value = value
+        },
+      }),
+    ]),
+  })
+
+  return { wrapper, model }
+}
+
+describe('readerInputMode', () => {
+  it('offers each reading mode', async () => {
+    const { wrapper } = await mount()
+
+    expect(wrapper.text()).toContain('Left to right')
+    expect(wrapper.text()).toContain('Right to left')
+    expect(wrapper.text()).toContain('Continous scroll')
+  })
+
+  it('selects a mode on click', async () => {
+    const { wrapper, model } = await mount('webtoon')
+
+    await buttonByText(wrapper, 'Left to right').trigger('click')
+
+    expect(model.value).toBe('paged-ltr')
+  })
+
+  it('disables every option while loading', async () => {
+    const { wrapper } = await mount('webtoon', true)
+
+    expect(wrapper.findAll('button').every(b => b.attributes('disabled') !== undefined)).toBe(true)
+  })
+})

--- a/web/app/features/reader/components/Input/Mode.vue
+++ b/web/app/features/reader/components/Input/Mode.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import type { ReadingMode } from '../../types'
+
+defineProps<{ disabled?: boolean }>()
+const mode = defineModel<ReadingMode>({ required: true })
+
+const { t } = useI18n()
+
+const items: { label: string, value: ReadingMode, icon: string }[] = [
+  {
+    label: t('reader.mode.pagedLtr'),
+    value: 'paged-ltr',
+    icon: 'fa6-regular:circle-right',
+  },
+  {
+    label: t('reader.mode.pagedRtl'),
+    value: 'paged-rtl',
+    icon: 'fa6-regular:circle-left',
+  },
+  {
+    label: t('reader.mode.webtoon'),
+    value: 'webtoon',
+    icon: 'uchi:continuous-vertical',
+  },
+]
+</script>
+
+<template>
+  <div class="d-flex flex-column ga-2">
+    <span class="text-body-large text-medium-emphasis text-uppercase text-truncate">{{ $t('reader.mode.title') }}</span>
+    <div class="d-flex flex-wrap ga-4">
+      <VBtn
+        v-for="(item, i) in items"
+        :key="i"
+        :value="item.value"
+        :prepend-icon="item.icon"
+        :text="item.label"
+        :disabled
+        size="large"
+        class="text-uppercase"
+        density="comfortable"
+        :class="{ 'border-thin-primary': mode !== item.value }"
+        :variant="mode === item.value ? 'flat' : 'outlined'"
+        @click="mode = item.value"
+      />
+    </div>
+  </div>
+</template>

--- a/web/app/features/reader/components/Input/PageMode.test.ts
+++ b/web/app/features/reader/components/Input/PageMode.test.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { VueWrapper } from '@vue/test-utils'
+import type { PageMode } from './PageMode.vue'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it, vi } from 'vitest'
+import { h, ref } from 'vue'
+import { VApp } from 'vuetify/components'
+import PageModeInput from './PageMode.vue'
+
+function buttonByText(wrapper: VueWrapper, text: string): ReturnType<VueWrapper['find']> {
+  return wrapper.findAll('button').find(b => b.text().includes(text))!
+}
+
+async function mount(
+  mode: PageMode = 'single',
+  disabledOptions: PageMode[] = [],
+): Promise<{
+  wrapper: VueWrapper
+  model: ReturnType<typeof ref<PageMode>>
+  disabledOptions: ReturnType<typeof ref<PageMode[]>>
+}> {
+  const model = ref(mode)
+  const disabledOptionsRef = ref(disabledOptions)
+  const wrapper = await mountSuspended({
+    setup: () => ({ model, disabledOptionsRef }),
+    render: () => h(VApp, () => [
+      h(PageModeInput, {
+        'modelValue': model.value,
+        'disabledOptions': disabledOptionsRef.value,
+        'onUpdate:modelValue': (value: PageMode) => {
+          model.value = value
+        },
+      }),
+    ]),
+  })
+
+  return { wrapper, model, disabledOptions: disabledOptionsRef }
+}
+
+describe('readerInputPageMode', () => {
+  it('offers single and double page', async () => {
+    const { wrapper } = await mount()
+
+    expect(wrapper.text()).toContain('Single page')
+    expect(wrapper.text()).toContain('Double page')
+  })
+
+  it('selects a mode on click', async () => {
+    const { wrapper, model } = await mount('single')
+
+    await buttonByText(wrapper, 'Double page').trigger('click')
+
+    expect(model.value).toBe('double')
+  })
+
+  it('disables listed options', async () => {
+    const { wrapper } = await mount('single', ['double'])
+
+    expect(buttonByText(wrapper, 'Double page').attributes('disabled')).toBeDefined()
+    expect(buttonByText(wrapper, 'Single page').attributes('disabled')).toBeUndefined()
+  })
+
+  it('moves off a newly disabled current option', async () => {
+    const { wrapper, model, disabledOptions } = await mount('double')
+
+    disabledOptions.value = ['double']
+    await wrapper.vm.$forceUpdate()
+    await wrapper.vm.$nextTick()
+
+    await vi.waitFor(() => expect(model.value).toBe('single'))
+  })
+})

--- a/web/app/features/reader/components/Input/PageMode.vue
+++ b/web/app/features/reader/components/Input/PageMode.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+export type PageMode = 'single' | 'double'
+
+const props = defineProps<{
+  disabledOptions?: PageMode[]
+  disabled?: boolean
+}>()
+const scale = defineModel<PageMode>({ required: true })
+
+const { t } = useI18n()
+
+const items: { label: string, value: PageMode, icon: string }[] = [
+  {
+    label: t('reader.pageMode.singlePage'),
+    value: 'single',
+    icon: 'fa6-regular:file',
+  },
+  {
+    label: t('reader.pageMode.doublePage'),
+    value: 'double',
+    icon: 'fa6-solid:book-open',
+  },
+]
+
+watch(() => props.disabledOptions, (value) => {
+  if (!value?.length) {
+    return
+  }
+
+  if (value.includes(scale.value)) {
+    scale.value = items.find(item => !value.includes(item.value))?.value as PageMode
+  }
+})
+
+function isItemDisabled(item: PageMode): boolean {
+  return props.disabledOptions?.includes(item) || props.disabled
+}
+</script>
+
+<template>
+  <div class="d-flex flex-column ga-2">
+    <span class="text-body-large text-medium-emphasis text-uppercase text-truncate">{{ $t('reader.pageMode.title') }}</span>
+    <div class="d-flex flex-wrap ga-4">
+      <VBtn
+        v-for="(item, i) in items"
+        :key="i"
+        :value="item.value"
+        :prepend-icon="item.icon"
+        :text="item.label"
+        :color="isItemDisabled(item.value) ? 'grey' : 'primary'"
+        size="large"
+        :disabled="isItemDisabled(item.value)"
+        class="text-uppercase"
+        density="comfortable"
+        :variant="scale === item.value ? 'flat' : 'outlined'"
+        @click="scale = item.value"
+      />
+    </div>
+  </div>
+</template>

--- a/web/app/features/reader/components/Input/PageScale.test.ts
+++ b/web/app/features/reader/components/Input/PageScale.test.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { VueWrapper } from '@vue/test-utils'
+import type { PageScale } from '~/features/reader/types'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it, vi } from 'vitest'
+import { h, ref } from 'vue'
+import { VApp } from 'vuetify/components'
+import PageScaleInput from './PageScale.vue'
+
+function buttonByText(wrapper: VueWrapper, text: string): ReturnType<VueWrapper['find']> {
+  return wrapper.findAll('button').find(b => b.text().includes(text))!
+}
+
+async function mount(
+  scale: PageScale = 'fit-width',
+  disabledOptions: PageScale[] = [],
+): Promise<{
+  wrapper: VueWrapper
+  model: ReturnType<typeof ref<PageScale>>
+  disabledOptions: ReturnType<typeof ref<PageScale[]>>
+}> {
+  const model = ref(scale)
+  const disabledOptionsRef = ref(disabledOptions)
+  const wrapper = await mountSuspended({
+    setup: () => ({ model, disabledOptionsRef }),
+    render: () => h(VApp, () => [
+      h(PageScaleInput, {
+        'modelValue': model.value,
+        'disabledOptions': disabledOptionsRef.value,
+        'onUpdate:modelValue': (value: PageScale) => {
+          model.value = value
+        },
+      }),
+    ]),
+  })
+
+  return { wrapper, model, disabledOptions: disabledOptionsRef }
+}
+
+describe('readerInputPageScale', () => {
+  it('offers each scale', async () => {
+    const { wrapper } = await mount()
+
+    expect(wrapper.text()).toContain('Fit width')
+    expect(wrapper.text()).toContain('Fit height')
+    expect(wrapper.text()).toContain('Fit screen')
+  })
+
+  it('selects a scale on click', async () => {
+    const { wrapper, model } = await mount('fit-width')
+
+    await buttonByText(wrapper, 'Fit height').trigger('click')
+
+    expect(model.value).toBe('fit-height')
+  })
+
+  it('disables listed options', async () => {
+    const { wrapper } = await mount('fit-width', ['fit-height', 'fit-screen'])
+
+    expect(buttonByText(wrapper, 'Fit height').attributes('disabled')).toBeDefined()
+    expect(buttonByText(wrapper, 'Fit screen').attributes('disabled')).toBeDefined()
+    expect(buttonByText(wrapper, 'Fit width').attributes('disabled')).toBeUndefined()
+  })
+
+  it('moves off a newly disabled current option', async () => {
+    const { wrapper, model, disabledOptions } = await mount('fit-height')
+
+    disabledOptions.value = ['fit-height', 'fit-screen']
+    await wrapper.vm.$forceUpdate()
+    await wrapper.vm.$nextTick()
+
+    await vi.waitFor(() => expect(model.value).toBe('fit-width'))
+  })
+})

--- a/web/app/features/reader/components/Input/PageScale.vue
+++ b/web/app/features/reader/components/Input/PageScale.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import type { PageScale } from '../../types'
+
+const props = defineProps<{
+  disabledOptions?: PageScale[]
+  disabled?: boolean
+}>()
+const scale = defineModel<PageScale>({ required: true })
+
+const { t } = useI18n()
+
+const items: { label: string, value: PageScale, icon: string }[] = [
+  {
+    label: t('reader.pageScale.fitWidth'),
+    value: 'fit-width',
+    icon: 'fa6-solid:arrows-left-right-to-line',
+  },
+  {
+    label: t('reader.pageScale.fitHeight'),
+    value: 'fit-height',
+    icon: 'uchi:screen-height',
+  },
+  {
+    label: t('reader.pageScale.fitScreen'),
+    value: 'fit-screen',
+    icon: 'uchi:screen-fit',
+  },
+]
+
+watch(() => props.disabledOptions, (value) => {
+  if (!value?.length) {
+    return
+  }
+
+  if (value.includes(scale.value)) {
+    scale.value = items.find(item => !value.includes(item.value))?.value as PageScale
+  }
+})
+
+function isItemDisabled(item: PageScale): boolean {
+  return props.disabledOptions?.includes(item) || props.disabled
+}
+</script>
+
+<template>
+  <div class="d-flex flex-column ga-2">
+    <span class="text-body-large text-medium-emphasis text-uppercase text-truncate">{{ $t('reader.pageScale.title') }}</span>
+    <div class="d-flex flex-wrap ga-4">
+      <VBtn
+        v-for="(item, i) in items"
+        :key="i"
+        :value="item.value"
+        :prepend-icon="item.icon"
+        :text="item.label"
+        :color="isItemDisabled(item.value) ? 'grey' : 'primary'"
+        size="large"
+        :disabled="isItemDisabled(item.value)"
+        class="text-uppercase"
+        density="comfortable"
+        :variant="scale === item.value ? 'flat' : 'outlined'"
+        @click="scale = item.value"
+      />
+    </div>
+  </div>
+</template>

--- a/web/app/features/reader/composables/reader-settings.api.test.ts
+++ b/web/app/features/reader/composables/reader-settings.api.test.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createReaderSettingsApi } from './reader-settings.api'
+
+const call = vi.fn()
+
+vi.mock('~/utils/api', async importOriginal => ({
+  ...(await importOriginal<typeof import('~/utils/api')>()),
+  initApi: () => call,
+}))
+
+const settings = {
+  type: 'manhwa',
+  readingMode: 'webtoon',
+  pageScale: 'fit-width',
+  doublePage: false,
+} as const
+
+beforeEach(() => {
+  call.mockReset()
+})
+
+describe('createReaderSettingsApi().getReaderSettings', () => {
+  it('unwraps the items list', async () => {
+    call.mockResolvedValue({ items: [settings] })
+
+    const res = await createReaderSettingsApi().getReaderSettings()
+
+    expect(call).toHaveBeenCalledWith('/')
+    expect(res).toEqual({ success: true, data: [settings] })
+  })
+
+  it('returns an empty list untouched', async () => {
+    call.mockResolvedValue({ items: [] })
+
+    await expect(createReaderSettingsApi().getReaderSettings()).resolves.toEqual({
+      success: true,
+      data: [],
+    })
+  })
+
+  it('surfaces a failure with its status', async () => {
+    call.mockRejectedValue({ statusCode: 500, data: {} })
+
+    const res = await createReaderSettingsApi().getReaderSettings()
+
+    expect(res.success === false && res.error.status).toBe(500)
+  })
+})
+
+describe('createReaderSettingsApi().updateReaderSettings', () => {
+  it('puts the body on the type route', async () => {
+    call.mockResolvedValue(settings)
+
+    const res = await createReaderSettingsApi().updateReaderSettings({ ...settings })
+
+    expect(call).toHaveBeenCalledWith('/manhwa', {
+      method: 'PUT',
+      body: { readingMode: 'webtoon', pageScale: 'fit-width', doublePage: false },
+    })
+    expect(res).toEqual({ success: true, data: settings })
+  })
+
+  it('surfaces a 404 with its status', async () => {
+    call.mockRejectedValue({ statusCode: 404, data: {} })
+
+    const res = await createReaderSettingsApi().updateReaderSettings({ ...settings })
+
+    expect(res.success === false && res.error.status).toBe(404)
+  })
+})

--- a/web/app/features/reader/composables/reader-settings.api.ts
+++ b/web/app/features/reader/composables/reader-settings.api.ts
@@ -1,0 +1,49 @@
+import type { GetReaderSettingsResponse, ReaderSettings } from '../types'
+import type { ApiResponse } from '~/utils/api'
+import { ApiError, initApi } from '~/utils/api'
+
+interface ReaderSettingsApi {
+  getReaderSettings: () => Promise<ApiResponse<ReaderSettings[]>>
+  updateReaderSettings: (settings: ReaderSettings) => Promise<ApiResponse<ReaderSettings>>
+}
+
+export function createReaderSettingsApi(): ReaderSettingsApi {
+  const api = initApi('/me/reader-settings')
+
+  async function getReaderSettings(): Promise<ApiResponse<ReaderSettings[]>> {
+    try {
+      const res = await api<GetReaderSettingsResponse>('/')
+
+      return {
+        success: true,
+        data: res.items,
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error: ApiError.fromFetchError(error),
+      }
+    }
+  }
+
+  async function updateReaderSettings({ type, ...body }: ReaderSettings): Promise<ApiResponse<ReaderSettings>> {
+    try {
+      const res = await api<ReaderSettings>(`/${type}`, { method: 'PUT', body })
+
+      return {
+        success: true,
+        data: res,
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error: ApiError.fromFetchError(error),
+      }
+    }
+  }
+
+  return {
+    getReaderSettings,
+    updateReaderSettings,
+  }
+}

--- a/web/app/features/reader/types.ts
+++ b/web/app/features/reader/types.ts
@@ -1,0 +1,15 @@
+import type { ComicType } from '../comics/types'
+
+export type ReadingMode = 'paged-rtl' | 'paged-ltr' | 'webtoon'
+export type PageScale = 'fit-width' | 'fit-height' | 'fit-screen'
+
+export interface ReaderSettings {
+  type: ComicType
+  readingMode: ReadingMode
+  pageScale: PageScale
+  doublePage: boolean
+}
+
+export interface GetReaderSettingsResponse {
+  items: ReaderSettings[]
+}

--- a/web/app/iconsets/iconify.ts
+++ b/web/app/iconsets/iconify.ts
@@ -11,6 +11,33 @@ addCollection(fa6Solid)
 // eslint-disable-next-line unicorn/no-top-level-side-effects
 addCollection(fa6Regular)
 
+// eslint-disable-next-line unicorn/no-top-level-side-effects
+addCollection({
+  prefix: 'uchi',
+  icons: {
+    'continuous-vertical': {
+      body: '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 2v6a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V2m0 20v-6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v6"></path>',
+      width: 24,
+      height: 24,
+    },
+    'screen-width': {
+      body: '<path fill="currentColor" d="M4 20h16v2H4zM4 2h16v2H4zm9 7h3l-4-4-4 4h3v6H8l4 4 4-4h-3z"></path>',
+      width: 24,
+      height: 24,
+    },
+    'screen-height': {
+      body: '<g transform="matrix(0 1 -1 0 512 0)"><path fill="currentColor" d="M32 64c17.7 0 32 14.3 32 32v320c0 17.7-14.3 32-32 32S0 433.7 0 416V96c0-17.7 14.3-32 32-32m214.6 73.4c12.5 12.5 12.5 32.8 0 45.3L205.3 224h229.5l-41.4-41.4c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l96 96c12.5 12.5 12.5 32.8 0 45.3l-96 96c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3l41.3-41.3H205.2l41.4 41.4c12.5 12.5 12.5 32.8 0 45.3s-32.8 12.5-45.3 0l-96-96c-12.5-12.5-12.5-32.8 0-45.3l96-96c12.5-12.5 32.8-12.5 45.3 0M640 96v320c0 17.7-14.3 32-32 32s-32-14.3-32-32V96c0-17.7 14.3-32 32-32s32 14.3 32 32"/></g>',
+      width: 512,
+      height: 640,
+    },
+    'screen-fit': {
+      body: '<path fill="currentColor" d="m15 3 2.3 2.3-2.89 2.87 1.42 1.42L18.7 6.7 21 9V3zM3 9l2.3-2.3 2.87 2.89 1.42-1.42L6.7 5.3 9 3H3zm6 12-2.3-2.3 2.89-2.87-1.42-1.42L5.3 17.3 3 15v6zm12-6-2.3 2.3-2.87-2.89-1.42 1.42 2.89 2.87L15 21h6z"></path>',
+      width: 24,
+      height: 24,
+    },
+  },
+})
+
 export const aliases: IconAliases = {
   collapse: 'fa6-solid:chevron-up',
   complete: 'fa6-solid:check',

--- a/web/app/iconsets/iconify.ts
+++ b/web/app/iconsets/iconify.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+/* eslint-disable unicorn/no-top-level-side-effects */
 
 import type { IconAliases, IconProps, IconSet } from 'vuetify'
 import fa6Regular from '@iconify-json/fa6-regular/icons.json'
@@ -6,12 +7,10 @@ import fa6Solid from '@iconify-json/fa6-solid/icons.json'
 import { addCollection, getIcon } from '@iconify/vue'
 import { h } from 'vue'
 
-// eslint-disable-next-line unicorn/no-top-level-side-effects
 addCollection(fa6Solid)
-// eslint-disable-next-line unicorn/no-top-level-side-effects
+
 addCollection(fa6Regular)
 
-// eslint-disable-next-line unicorn/no-top-level-side-effects
 addCollection({
   prefix: 'uchi',
   icons: {

--- a/web/app/layouts/default.vue
+++ b/web/app/layouts/default.vue
@@ -73,7 +73,6 @@ const navigationDrawerItems = computed((): NavigationDrawerListProps[] => [
   {
     title: t('nav.settings.title'),
     items: [
-      ...settingsNavItems.value,
       {
         title: t('settings.reader.title'),
         to: '/settings/reader',
@@ -81,6 +80,7 @@ const navigationDrawerItems = computed((): NavigationDrawerListProps[] => [
         isActiveFn: (route: RouteLocationNormalized) => route.path.startsWith('/settings/reader'),
         baseRoute: '/settings/reader',
       },
+      ...settingsNavItems.value,
     ],
   },
 ])

--- a/web/app/layouts/default.vue
+++ b/web/app/layouts/default.vue
@@ -72,7 +72,16 @@ const navigationDrawerItems = computed((): NavigationDrawerListProps[] => [
   },
   {
     title: t('nav.settings.title'),
-    items: settingsNavItems.value,
+    items: [
+      ...settingsNavItems.value,
+      {
+        title: t('settings.reader.title'),
+        to: '/settings/reader',
+        icon: 'fa6-solid:book-open-reader',
+        isActiveFn: (route: RouteLocationNormalized) => route.path.startsWith('/settings/reader'),
+        baseRoute: '/settings/reader',
+      },
+    ],
   },
 ])
 

--- a/web/app/pages/settings/index.test.ts
+++ b/web/app/pages/settings/index.test.ts
@@ -27,17 +27,28 @@ beforeEach(() => {
 })
 
 describe('settings', () => {
+  it('links a regular user to the reader module', async () => {
+    const wrapper = await mount()
+
+    expect(wrapper.findAll('a').map(a => a.attributes('href'))).toEqual(['/settings/reader'])
+    expect(wrapper.text()).toContain('Reader')
+  })
+
   it('hides the OIDC module from a regular user', async () => {
     const wrapper = await mount()
 
-    expect(wrapper.findAll('a')).toHaveLength(0)
+    expect(wrapper.text()).not.toContain('OIDC')
+    expect(wrapper.findAll('a').map(a => a.attributes('href'))).not.toContain('/settings/oidc')
   })
 
-  it('links an admin to the OIDC module', async () => {
+  it('links an admin to the reader and OIDC modules', async () => {
     isAdmin.value = true
     const wrapper = await mount()
 
-    expect(wrapper.findAll('a').map(a => a.attributes('href'))).toEqual(['/settings/oidc'])
+    expect(wrapper.findAll('a').map(a => a.attributes('href'))).toEqual([
+      '/settings/reader',
+      '/settings/oidc',
+    ])
   })
 
   it('describes the OIDC module', async () => {
@@ -53,6 +64,6 @@ describe('settings', () => {
 
     isAdmin.value = true
 
-    await vi.waitFor(() => expect(wrapper.findAll('a')).toHaveLength(1))
+    await vi.waitFor(() => expect(wrapper.findAll('a')).toHaveLength(2))
   })
 })

--- a/web/app/pages/settings/index.vue
+++ b/web/app/pages/settings/index.vue
@@ -20,6 +20,12 @@ interface SettingsModule {
 }
 
 const settingsModules = computed((): SettingsModule[] => [
+  {
+    title: t('settings.reader.title'),
+    description: t('settings.reader.description'),
+    icon: 'fa6-solid:book-open-reader',
+    to: '/settings/reader',
+  },
   ...(isAdmin.value
     ? [
       {
@@ -30,12 +36,6 @@ const settingsModules = computed((): SettingsModule[] => [
       } satisfies SettingsModule,
       ]
     : []),
-  {
-    title: t('settings.reader.title'),
-    description: t('settings.reader.description'),
-    icon: 'fa6-solid:book-open-reader',
-    to: '/settings/reader',
-  },
 ])
 </script>
 
@@ -47,7 +47,7 @@ const settingsModules = computed((): SettingsModule[] => [
         :key="i"
         :to="m.to"
       >
-        <VCard class="pa-4 border-thin" style="border-radius: 12px;">
+        <VCard class="pa-4 border-thin transition-smooth settings-card" style="border-radius: 12px;">
           <div class="d-flex ga-6 text-wrap align-center">
             <VIcon :icon="m.icon" size="large" />
             <div class="d-flex flex-column">
@@ -63,6 +63,19 @@ const settingsModules = computed((): SettingsModule[] => [
 </template>
 
 <style lang="scss" scoped>
+.settings-card {
+  &:hover {
+    border-color: rgb(var(--v-theme-primary));
+
+    .v-icon {
+      color: rgb(var(--v-theme-primary));
+    }
+
+    .text-title-large {
+      color: rgb(var(--v-theme-primary));
+    }
+  }
+}
 .settings-modules-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);

--- a/web/app/pages/settings/index.vue
+++ b/web/app/pages/settings/index.vue
@@ -30,6 +30,12 @@ const settingsModules = computed((): SettingsModule[] => [
       } satisfies SettingsModule,
       ]
     : []),
+  {
+    title: t('settings.reader.title'),
+    description: t('settings.reader.description'),
+    icon: 'fa6-solid:book-open-reader',
+    to: '/settings/reader',
+  },
 ])
 </script>
 

--- a/web/app/pages/settings/reader.test.ts
+++ b/web/app/pages/settings/reader.test.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { VueWrapper } from '@vue/test-utils'
+import type { ReaderSettings } from '~/features/reader/types'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { VApp } from 'vuetify/components'
+import { useToast } from '~/composables/toast.composable'
+import ReaderPage from './reader.vue'
+
+const { getReaderSettings } = await vi.hoisted(async () => ({
+  getReaderSettings: vi.fn(),
+}))
+
+function readerSettingsApiStub(): { getReaderSettings: typeof getReaderSettings } {
+  return { getReaderSettings }
+}
+
+mockNuxtImport('createReaderSettingsApi', () => readerSettingsApiStub)
+
+const CardStub = defineComponent({
+  name: 'ReaderCard',
+  props: {
+    modelValue: { type: Object, required: true },
+    type: { type: String, required: true },
+  },
+  template: '<div data-test="reader-card">{{ type }} {{ modelValue.readingMode }}</div>',
+})
+
+const manhwa: ReaderSettings = {
+  type: 'manhwa',
+  readingMode: 'webtoon',
+  pageScale: 'fit-width',
+  doublePage: false,
+}
+
+const manga: ReaderSettings = {
+  type: 'manga',
+  readingMode: 'paged-rtl',
+  pageScale: 'fit-screen',
+  doublePage: false,
+}
+
+async function mount(): Promise<VueWrapper> {
+  return mountSuspended(
+    { render: () => h(VApp, () => [h(ReaderPage)]) },
+    { global: { stubs: { ReaderCard: CardStub } } },
+  )
+}
+
+beforeEach(() => {
+  getReaderSettings.mockReset()
+  getReaderSettings.mockResolvedValue({ success: true, data: [manhwa, manga] })
+  useToast().messages.value.length = 0
+})
+
+describe('settings/reader', () => {
+  it('loads the settings on mount', async () => {
+    await mount()
+
+    await vi.waitFor(() => expect(getReaderSettings).toHaveBeenCalledTimes(1))
+  })
+
+  it('renders the card for the current comic type', async () => {
+    const wrapper = await mount()
+
+    await vi.waitFor(() => expect(wrapper.find('[data-test="reader-card"]').text()).toBe('manhwa webtoon'))
+  })
+
+  it('keeps the card hidden until settings for the type are in', async () => {
+    getReaderSettings.mockResolvedValue({ success: true, data: [manga] })
+    const wrapper = await mount()
+
+    await vi.waitFor(() => expect(getReaderSettings).toHaveBeenCalled())
+    expect(wrapper.find('[data-test="reader-card"]').exists()).toBe(false)
+  })
+
+  it('toasts when the settings cannot be loaded', async () => {
+    getReaderSettings.mockResolvedValue({
+      success: false,
+      error: { status: 500, message: 'boom' },
+    })
+
+    await mount()
+
+    await vi.waitFor(() => expect(useToast().messages.value).toEqual([
+      { text: 'Unknown error', color: 'error' },
+    ]))
+  })
+})

--- a/web/app/pages/settings/reader.vue
+++ b/web/app/pages/settings/reader.vue
@@ -1,0 +1,38 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+import type { ReaderSettings } from '~/features/reader/types'
+import { AUTHENTICATED_ROUTE_GROUP } from '~/constants/auth'
+
+definePageMeta({
+  layout: 'default',
+  authGroups: [AUTHENTICATED_ROUTE_GROUP],
+})
+
+const { t } = useI18n()
+const toast = useToast()
+const { getReaderSettings, updateReaderSettings } = createReaderSettingsApi()
+
+const isLoading = ref(false)
+const readerSettings = ref<ReaderSettings[]>([])
+
+onMounted(() => {
+  fetchReaderSettings()
+})
+
+async function fetchReaderSettings(): Promise<void> {
+  isLoading.value = true
+  const res = await getReaderSettings()
+  if (res.success) {
+    readerSettings.value = res.data
+  } else {
+    console.error('getReaderSettings', res.error)
+    toast.error(t('error.unknown'))
+  }
+
+  isLoading.value = false
+}
+</script>
+
+<template>
+  <OrganismPageLayout :title="$t('settings.reader.title')" :loading="isLoading" />
+</template>

--- a/web/app/pages/settings/reader.vue
+++ b/web/app/pages/settings/reader.vue
@@ -1,5 +1,6 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script setup lang="ts">
+import type { ComicType } from '~/features/comics/types'
 import type { ReaderSettings } from '~/features/reader/types'
 import { AUTHENTICATED_ROUTE_GROUP } from '~/constants/auth'
 
@@ -10,10 +11,21 @@ definePageMeta({
 
 const { t } = useI18n()
 const toast = useToast()
-const { getReaderSettings, updateReaderSettings } = createReaderSettingsApi()
+const { smAndDown } = useDisplay()
+const { getReaderSettings } = createReaderSettingsApi()
 
 const isLoading = ref(false)
 const readerSettings = ref<ReaderSettings[]>([])
+
+const comicType = ref<ComicType>('manhwa')
+const currentSettings = computed({
+  get: () => readerSettings.value.find(settings => settings.type === comicType.value),
+  set: (value: ReaderSettings) => {
+    if (value) {
+      updateSettings(value)
+    }
+  },
+})
 
 onMounted(() => {
   fetchReaderSettings()
@@ -31,8 +43,29 @@ async function fetchReaderSettings(): Promise<void> {
 
   isLoading.value = false
 }
+
+async function updateSettings(settings: ReaderSettings): Promise<void> {
+  const i = readerSettings.value.findIndex(settings => settings.type === comicType.value)
+  if (i === -1) {
+    return
+  }
+
+  readerSettings.value[i] = settings
+}
 </script>
 
 <template>
-  <OrganismPageLayout :title="$t('settings.reader.title')" :loading="isLoading" />
+  <OrganismPageLayout
+    :title="$t('settings.reader.title')"
+    :loading="isLoading"
+    :global-loader="isLoading"
+  >
+    <div class="d-flex flex-column ga-6" :class="{ 'px-8': smAndDown }">
+      <ReaderCard
+        v-if="currentSettings"
+        v-model="currentSettings"
+        v-model:type="comicType"
+      />
+    </div>
+  </OrganismPageLayout>
 </template>

--- a/web/i18n/locales/en.json
+++ b/web/i18n/locales/en.json
@@ -200,7 +200,8 @@
     "save": "Save",
     "create": "Create",
     "delete": "Delete",
-    "continue": "Continue"
+    "continue": "Continue",
+    "reset": "Reset"
   },
   "common": {
     "loading": "Loading...",
@@ -333,5 +334,24 @@
   },
   "reading": {
     "title": "Reading"
+  },
+  "reader": {
+    "mode": {
+      "pagedRtl": "Right to left",
+      "pagedLtr": "Left to right",
+      "webtoon": "Continous scroll",
+      "title": "Reading direction"
+    },
+    "pageScale": {
+      "fitWidth": "Fit width",
+      "fitHeight": "Fit height",
+      "fitScreen": "Fit screen",
+      "title": "Page scaling"
+    },
+    "pageMode": {
+      "singlePage": "Single page",
+      "doublePage": "Double page",
+      "title": "Page mode"
+    }
   }
 }

--- a/web/i18n/locales/en.json
+++ b/web/i18n/locales/en.json
@@ -186,6 +186,10 @@
         "success": "Provider updated !"
       },
       "description": "Manage OIDC providers"
+    },
+    "reader": {
+      "title": "Reader",
+      "description": "Setup your reader as you like"
     }
   },
   "error": {

--- a/web/i18n/locales/fr.json
+++ b/web/i18n/locales/fr.json
@@ -186,6 +186,10 @@
         "notFound": "Fournisseur introuvable"
       },
       "description": "Gérer les fournisseurs OIDC"
+    },
+    "reader": {
+      "title": "Lecteur",
+      "description": "Configurez votre lecteur comme vous le souhaitez"
     }
   },
   "error": {

--- a/web/i18n/locales/fr.json
+++ b/web/i18n/locales/fr.json
@@ -200,7 +200,8 @@
     "save": "Sauvegarder",
     "create": "Créer",
     "delete": "Supprimer",
-    "continue": "Continuer"
+    "continue": "Continuer",
+    "reset": "Réinitialiser"
   },
   "common": {
     "loading": "Chargement...",
@@ -323,5 +324,23 @@
   },
   "reading": {
     "title": "Lire"
+  },
+  "reader": {
+    "mode": {
+      "pagedRtl": "De droite à gauche",
+      "pagedLtr": "De gauche à droite",
+      "webtoon": "Défilement continu"
+    },
+    "pageScale": {
+      "fitWidth": "Ajuster la largeur",
+      "fitHeight": "Hauteur d'ajustement",
+      "fitScreen": "Ajuster l'écran",
+      "title": "Mise à l'échelle des pages"
+    },
+    "pageMode": {
+      "doublePage": "Double-page",
+      "singlePage": "Page unique",
+      "title": "Mode page"
+    }
   }
 }

--- a/web/nuxt.config.ts
+++ b/web/nuxt.config.ts
@@ -24,6 +24,7 @@ export default defineNuxtConfig({
     { path: '~/features/asura/components', prefix: 'Asura' },
     { path: '~/features/library/components', prefix: 'Library' },
     { path: '~/features/feed/components', prefix: 'Feed' },
+    { path: '~/features/reader/components', prefix: 'Reader' },
   ],
 
   imports: {


### PR DESCRIPTION
## Summary

Closes #72

- Add `/settings/reader` page for editing per-comic-type reader settings (reading mode, page scale, single/double page) via the existing `GET/PUT /api/me/reader-settings` API (#70).
- Introduce `ReaderCard` with type selector, input components (`ReaderInputMode`, `ReaderInputPageScale`, `ReaderInputPageMode`), explicit Save and Reset-to-defaults actions.
- Webtoon mode disables double-page and fit-height/fit-screen scale options in the UI.
- Link the page from Settings for all signed-in users (not admin-only); OIDC settings remain admin-only.
- i18n en + fr, reader icons in iconify set, and tests for the page, card, inputs, and API composable.

## Screenshots

### Desktop
<img width="1563" height="1353" alt="image" src="https://github.com/user-attachments/assets/45d36456-9bb7-40ab-923b-7122e50187a4" />

### Mobile
<img width="322" height="679" alt="image" src="https://github.com/user-attachments/assets/9dad0853-755b-4374-930e-53f23a21c69b" />

## Test plan

- [x] `pnpm test` — 666 tests pass
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm knip`
- [x] Manual: open `/settings/reader`, switch comic type, edit fields, Save persists after reload
- [x] Manual: Reset restores factory defaults for the selected type