### PR TITLE
feat(readingprogress): reading progress API

### DIFF
--- a/api/cmd/uchiyomiserver/setup.go
+++ b/api/cmd/uchiyomiserver/setup.go
@@ -61,6 +61,9 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readersettings"
 	httpreadersettings "github.com/kharente-deuh/uchiyomi-server/pkg/core/readersettings/gateway/http"
 	pgreadersettings "github.com/kharente-deuh/uchiyomi-server/pkg/core/readersettings/repository/pg"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readingprogress"
+	httpreadingprogress "github.com/kharente-deuh/uchiyomi-server/pkg/core/readingprogress/gateway/http"
+	pgreadingprogress "github.com/kharente-deuh/uchiyomi-server/pkg/core/readingprogress/repository/pg"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/setup"
 	httpsetup "github.com/kharente-deuh/uchiyomi-server/pkg/core/setup/gateway/http"
 	httpusers "github.com/kharente-deuh/uchiyomi-server/pkg/core/users/gateway/http"
@@ -151,6 +154,16 @@ func setupApp(cfg *cfg) (*core.App, error) {
 		return nil, fmt.Errorf("failed to init readerSettingsSvc: %w", err)
 	}
 
+	readingProgressSvc, err := readingprogress.NewService(readingprogress.Deps{
+		Repository: dbr.ReadingProgressRepository,
+		Library:    dbr.LibraryRepository,
+		Comics:     comicsExistsLookup{repo: dbr.ComicsRepository},
+		Chapters:   dbr.ChaptersRepository,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to init readingProgressSvc: %w", err)
+	}
+
 	asuraApp.BindChaptersService(chaptersSvc)
 
 	comicsSvc, err := comics.NewService(comics.Deps{
@@ -180,18 +193,19 @@ func setupApp(cfg *cfg) (*core.App, error) {
 	registry := core.NewHealthRegistry(dbr.PGDB)
 
 	ctrls, err := setupCtrls(ctrlsDeps{
-		Logger:                logger,
-		ComicsService:         comicsSvc,
-		ChaptersService:       chaptersSvc,
-		FeedService:           feedSvc,
-		ReaderSettingsService: readerSettingsSvc,
-		SessionsService:       services.Sessions,
-		SetupService:          services.Setup,
-		AuthService:           services.Auth,
-		OIDCProvidersService:  services.OIDCProviders,
-		AsuraApp:              asuraApp,
-		CoversService:         coversBundle.Service,
-		Registry:              registry,
+		Logger:                 logger,
+		ComicsService:          comicsSvc,
+		ChaptersService:        chaptersSvc,
+		FeedService:            feedSvc,
+		ReaderSettingsService:  readerSettingsSvc,
+		ReadingProgressService: readingProgressSvc,
+		SessionsService:        services.Sessions,
+		SetupService:           services.Setup,
+		AuthService:            services.Auth,
+		OIDCProvidersService:   services.OIDCProviders,
+		AsuraApp:               asuraApp,
+		CoversService:          coversBundle.Service,
+		Registry:               registry,
 	})
 	if err != nil {
 		//nolint:wrapcheck
@@ -204,17 +218,18 @@ func setupApp(cfg *cfg) (*core.App, error) {
 			AllowedOrigins: cfg.Http.AllowedOrigins,
 		},
 		core.Deps{
-			SetupCtrl:          ctrls.Setup,
-			AsuraCtrl:          ctrls.Asura,
-			CoversCtrl:         ctrls.Covers,
-			HealthCtrl:         ctrls.Health,
-			AuthCtrl:           ctrls.Auth,
-			UsersCtrl:          ctrls.Users,
-			OIDCProvidersCtrl:  ctrls.OIDCProviders,
-			ComicsCtrl:         ctrls.Comics,
-			ChaptersCtrl:       ctrls.Chapters,
-			FeedCtrl:           ctrls.Feed,
-			ReaderSettingsCtrl: ctrls.ReaderSettings,
+			SetupCtrl:           ctrls.Setup,
+			AsuraCtrl:           ctrls.Asura,
+			CoversCtrl:          ctrls.Covers,
+			HealthCtrl:          ctrls.Health,
+			AuthCtrl:            ctrls.Auth,
+			UsersCtrl:           ctrls.Users,
+			OIDCProvidersCtrl:   ctrls.OIDCProviders,
+			ComicsCtrl:          ctrls.Comics,
+			ChaptersCtrl:        ctrls.Chapters,
+			FeedCtrl:            ctrls.Feed,
+			ReaderSettingsCtrl:  ctrls.ReaderSettings,
+			ReadingProgressCtrl: ctrls.ReadingProgress,
 
 			Health:             registry,
 			Logger:             logger,
@@ -246,6 +261,7 @@ type dbRelated struct {
 	LibraryRepository             *pglibrary.PGLibraryRepository
 	FeedRepository                *pgfeed.PGFeedRepository
 	ReaderSettingsRepository      *pgreadersettings.PGReaderSettingsRepository
+	ReadingProgressRepository     *pgreadingprogress.PGReadingProgressRepository
 }
 
 func setupDBRelated(c *cfg, logger *slog.Logger) (*dbRelated, error) {
@@ -320,6 +336,11 @@ func setupDBRelated(c *cfg, logger *slog.Logger) (*dbRelated, error) {
 		return nil, fmt.Errorf("failed to init readerSettingsRepository: %w", err)
 	}
 
+	readingProgressRepository, err := pgreadingprogress.New(pgreadingprogress.Deps{DB: pgdb.DB})
+	if err != nil {
+		return nil, fmt.Errorf("failed to init readingProgressRepository: %w", err)
+	}
+
 	dbr := &dbRelated{
 		PGDB:                          pgdb,
 		Txor:                          txor,
@@ -333,6 +354,7 @@ func setupDBRelated(c *cfg, logger *slog.Logger) (*dbRelated, error) {
 		LibraryRepository:             libraryRepository,
 		FeedRepository:                feedRepository,
 		ReaderSettingsRepository:      readerSettingsRepository,
+		ReadingProgressRepository:     readingProgressRepository,
 	}
 
 	return dbr, nil
@@ -728,32 +750,34 @@ func setupAsura(logger *slog.Logger, comicsRepo comics.ComicsRepository) (*asura
 }
 
 type ctrls struct {
-	Setup          *httpsetup.Controller
-	Asura          *httpasura.Controller
-	Covers         *httpcovers.Controller
-	Health         *httphealth.Controller
-	Auth           *httpauth.Controller
-	Users          *httpusers.Controller
-	OIDCProviders  *httpoidcproviders.Controller
-	Comics         *httpcomics.Controller
-	Chapters       *httpchapters.Controller
-	Feed           *httpfeed.Controller
-	ReaderSettings *httpreadersettings.Controller
+	Setup           *httpsetup.Controller
+	Asura           *httpasura.Controller
+	Covers          *httpcovers.Controller
+	Health          *httphealth.Controller
+	Auth            *httpauth.Controller
+	Users           *httpusers.Controller
+	OIDCProviders   *httpoidcproviders.Controller
+	Comics          *httpcomics.Controller
+	Chapters        *httpchapters.Controller
+	Feed            *httpfeed.Controller
+	ReaderSettings  *httpreadersettings.Controller
+	ReadingProgress *httpreadingprogress.Controller
 }
 
 type ctrlsDeps struct {
-	FeedService           feed.FeedService
-	ReaderSettingsService readersettings.ReaderSettingsService
-	AsuraApp              *asura.App
-	CoversService         *covers.Service
-	SetupService          *setup.Service
-	SessionsService       *sessions.Service
-	Logger                *slog.Logger
-	Registry              *health.Registry
-	AuthService           *auth.Service
-	OIDCProvidersService  *oidcproviders.Service
-	ComicsService         *comics.Service
-	ChaptersService       *chapters.Service
+	FeedService            feed.FeedService
+	ReaderSettingsService  readersettings.ReaderSettingsService
+	ReadingProgressService readingprogress.ReadingProgressService
+	AsuraApp               *asura.App
+	CoversService          *covers.Service
+	SetupService           *setup.Service
+	SessionsService        *sessions.Service
+	Logger                 *slog.Logger
+	Registry               *health.Registry
+	AuthService            *auth.Service
+	OIDCProvidersService   *oidcproviders.Service
+	ComicsService          *comics.Service
+	ChaptersService        *chapters.Service
 }
 
 func setupCtrls(deps ctrlsDeps) (*ctrls, error) {
@@ -929,18 +953,30 @@ func setupCtrls(deps ctrlsDeps) (*ctrls, error) {
 		return nil, fmt.Errorf("failed to init reader settings controller: %w", err)
 	}
 
+	readingProgressCtrl, err := httpreadingprogress.New(
+		httpreadingprogress.Config{
+			Endpoint:    "/comics",
+			Middlewares: chi.Middlewares{authenticator.Middleware},
+		},
+		httpreadingprogress.Deps{Logger: deps.Logger, Service: deps.ReadingProgressService},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init reading progress controller: %w", err)
+	}
+
 	c := &ctrls{
-		Asura:          asuraCtrl,
-		Covers:         coversCtrl,
-		Setup:          setup,
-		Health:         healthCtrl,
-		Auth:           authCtrl,
-		Users:          usersCtrl,
-		OIDCProviders:  oidcProvidersCtrl,
-		Comics:         comicsCtrl,
-		Chapters:       chaptersCtrl,
-		Feed:           feedCtrl,
-		ReaderSettings: readerSettingsCtrl,
+		Asura:           asuraCtrl,
+		Covers:          coversCtrl,
+		Setup:           setup,
+		Health:          healthCtrl,
+		Auth:            authCtrl,
+		Users:           usersCtrl,
+		OIDCProviders:   oidcProvidersCtrl,
+		Comics:          comicsCtrl,
+		Chapters:        chaptersCtrl,
+		Feed:            feedCtrl,
+		ReaderSettings:  readerSettingsCtrl,
+		ReadingProgress: readingProgressCtrl,
 	}
 
 	return c, nil

--- a/api/cmd/uchiyomiserver/setup_internal_test.go
+++ b/api/cmd/uchiyomiserver/setup_internal_test.go
@@ -20,6 +20,7 @@ import (
 	coredomain "github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/feed"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readersettings"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readingprogress"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/users"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/health"
 )
@@ -86,6 +87,16 @@ func (stubReaderSettingsService) ListForUser(context.Context, uuid.UUID) ([]read
 
 func (stubReaderSettingsService) Replace(context.Context, readersettings.ReplaceOpts) (readersettings.Profile, error) {
 	return readersettings.Profile{}, nil
+}
+
+type stubReadingProgressService struct{}
+
+func (stubReadingProgressService) List(context.Context, readingprogress.ListOpts) (readingprogress.ListResult, error) {
+	return readingprogress.ListResult{Chapters: []readingprogress.Progress{}}, nil
+}
+
+func (stubReadingProgressService) Save(context.Context, readingprogress.SaveOpts) (readingprogress.Progress, error) {
+	return readingprogress.Progress{}, nil
 }
 
 type emptyOIDCProvidersRepository struct{}
@@ -253,14 +264,15 @@ func newTestCtrlsForUser(t *testing.T, user *users.User) *ctrls {
 	}
 
 	c, err := setupCtrls(ctrlsDeps{
-		AsuraApp:              asuraApp,
-		CoversService:         coversBundle.Service,
-		SessionsService:       newTestSessionsService(t, user),
-		Logger:                logger,
-		Registry:              health.NewRegistry(),
-		OIDCProvidersService:  newTestOIDCProvidersService(t),
-		FeedService:           stubFeedService{},
-		ReaderSettingsService: stubReaderSettingsService{},
+		AsuraApp:               asuraApp,
+		CoversService:          coversBundle.Service,
+		SessionsService:        newTestSessionsService(t, user),
+		Logger:                 logger,
+		Registry:               health.NewRegistry(),
+		OIDCProvidersService:   newTestOIDCProvidersService(t),
+		FeedService:            stubFeedService{},
+		ReaderSettingsService:  stubReaderSettingsService{},
+		ReadingProgressService: stubReadingProgressService{},
 	})
 	if err != nil {
 		t.Fatalf("setupCtrls: %v", err)

--- a/api/pkg/core/app.go
+++ b/api/pkg/core/app.go
@@ -23,6 +23,7 @@ import (
 	httpfeed "github.com/kharente-deuh/uchiyomi-server/pkg/core/feed/gateway/http"
 	httphealth "github.com/kharente-deuh/uchiyomi-server/pkg/core/health/gateway/http"
 	httpreadersettings "github.com/kharente-deuh/uchiyomi-server/pkg/core/readersettings/gateway/http"
+	httpreadingprogress "github.com/kharente-deuh/uchiyomi-server/pkg/core/readingprogress/gateway/http"
 	httpsetup "github.com/kharente-deuh/uchiyomi-server/pkg/core/setup/gateway/http"
 	httpusers "github.com/kharente-deuh/uchiyomi-server/pkg/core/users/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/health"
@@ -68,17 +69,18 @@ type Database interface {
 type Deps struct {
 	DB Database
 
-	SetupCtrl          *httpsetup.Controller
-	AsuraCtrl          *httpasura.Controller
-	CoversCtrl         *httpcovers.Controller
-	HealthCtrl         *httphealth.Controller
-	AuthCtrl           *httpauth.Controller
-	UsersCtrl          *httpusers.Controller
-	ComicsCtrl         *httpcomics.Controller
-	ChaptersCtrl       *httpchapters.Controller
-	FeedCtrl           *httpfeed.Controller
-	ReaderSettingsCtrl *httpreadersettings.Controller
-	OIDCProvidersCtrl  *httpoidcproviders.Controller
+	SetupCtrl           *httpsetup.Controller
+	AsuraCtrl           *httpasura.Controller
+	CoversCtrl          *httpcovers.Controller
+	HealthCtrl          *httphealth.Controller
+	AuthCtrl            *httpauth.Controller
+	UsersCtrl           *httpusers.Controller
+	ComicsCtrl          *httpcomics.Controller
+	ChaptersCtrl        *httpchapters.Controller
+	FeedCtrl            *httpfeed.Controller
+	ReaderSettingsCtrl  *httpreadersettings.Controller
+	ReadingProgressCtrl *httpreadingprogress.Controller
+	OIDCProvidersCtrl   *httpoidcproviders.Controller
 
 	Logger *slog.Logger
 	Health *health.Registry
@@ -166,6 +168,10 @@ func (deps *Deps) Validate() error {
 
 	if deps.ReaderSettingsCtrl == nil {
 		return errors.New("readerSettingsCtrl is required")
+	}
+
+	if deps.ReadingProgressCtrl == nil {
+		return errors.New("readingProgressCtrl is required")
 	}
 
 	if deps.Health == nil {
@@ -304,6 +310,7 @@ func (a *App) newRouter(ui http.Handler) chi.Router {
 			a.deps.UsersCtrl.InitRouter(r)
 			a.deps.OIDCProvidersCtrl.InitRouter(r)
 			a.deps.ComicsCtrl.InitRouter(r)
+			a.deps.ReadingProgressCtrl.InitRouter(r)
 			a.deps.ChaptersCtrl.InitRouter(r)
 			a.deps.FeedCtrl.InitRouter(r)
 			a.deps.ReaderSettingsCtrl.InitRouter(r)

--- a/api/pkg/core/app_internal_test.go
+++ b/api/pkg/core/app_internal_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/health"
 )
 
@@ -55,6 +56,21 @@ func TestRouterMountsTheReaderSettingsRoute(t *testing.T) {
 
 	if rec.Code == http.StatusNotFound {
 		t.Errorf("GET /api/me/reader-settings = 404, want the route to be mounted")
+	}
+}
+
+func TestRouterMountsTheReadingProgressRoute(t *testing.T) {
+	t.Parallel()
+
+	app, _ := newTestApp(t, &fakeDB{}, gatePort)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/comics/"+uuid.Nil.String()+"/progress", nil)
+	rec := httptest.NewRecorder()
+
+	app.newRouter(nil).ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusNotFound {
+		t.Errorf("GET /api/comics/{id}/progress = 404, want the route to be mounted")
 	}
 }
 

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -36,6 +36,8 @@ import (
 	healthhttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/health/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readersettings"
 	httpreadersettings "github.com/kharente-deuh/uchiyomi-server/pkg/core/readersettings/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readingprogress"
+	httpreadingprogress "github.com/kharente-deuh/uchiyomi-server/pkg/core/readingprogress/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/setup"
 	httpsetup "github.com/kharente-deuh/uchiyomi-server/pkg/core/setup/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/users"
@@ -418,6 +420,16 @@ func (fakeReaderSettingsService) Replace(context.Context, readersettings.Replace
 	return readersettings.Profile{}, nil
 }
 
+type fakeReadingProgressService struct{}
+
+func (fakeReadingProgressService) List(context.Context, readingprogress.ListOpts) (readingprogress.ListResult, error) {
+	return readingprogress.ListResult{Chapters: []readingprogress.Progress{}}, nil
+}
+
+func (fakeReadingProgressService) Save(context.Context, readingprogress.SaveOpts) (readingprogress.Progress, error) {
+	return readingprogress.Progress{}, nil
+}
+
 func newTestCache[P any, T any](t *testing.T, name string, logger *slog.Logger) *fncache.Cache[P, T] {
 	t.Helper()
 
@@ -597,29 +609,38 @@ func newTestApp(t *testing.T, db Database, port int) (*App, *health.Registry) {
 		t.Fatalf("httpreadersettings.New: %v", err)
 	}
 
+	readingProgressCtrl, err := httpreadingprogress.New(
+		httpreadingprogress.Config{Endpoint: "/comics"},
+		httpreadingprogress.Deps{Logger: logger, Service: fakeReadingProgressService{}},
+	)
+	if err != nil {
+		t.Fatalf("httpreadingprogress.New: %v", err)
+	}
+
 	app, err := New(
 		Config{ServerPort: port, AllowedOrigins: []string{"*"}},
 		Deps{
-			DB:                 db,
-			SetupCtrl:          setupCtrl,
-			AuthCtrl:           authCtrl,
-			UsersCtrl:          usersCtrl,
-			AsuraCtrl:          asuraCtrl,
-			CoversCtrl:         coversCtrl,
-			HealthCtrl:         healthCtrl,
-			OIDCProvidersCtrl:  oidcProvidersCtrl,
-			ComicsCtrl:         comicsCtrl,
-			ChaptersCtrl:       chaptersCtrl,
-			FeedCtrl:           feedCtrl,
-			ReaderSettingsCtrl: readerSettingsCtrl,
-			Logger:             logger,
-			Health:             registry,
-			Asura:              asuraApp,
-			Covers:             coversApp,
-			Downloads:          fakeDownloadsApp{},
-			ChapterListRefresh: fakeChapterListRefreshApp{},
-			Sessions:           sessionsApp,
-			OIDCRevalidation:   fakeOIDCRevalidationApp{},
+			DB:                  db,
+			SetupCtrl:           setupCtrl,
+			AuthCtrl:            authCtrl,
+			UsersCtrl:           usersCtrl,
+			AsuraCtrl:           asuraCtrl,
+			CoversCtrl:          coversCtrl,
+			HealthCtrl:          healthCtrl,
+			OIDCProvidersCtrl:   oidcProvidersCtrl,
+			ComicsCtrl:          comicsCtrl,
+			ChaptersCtrl:        chaptersCtrl,
+			FeedCtrl:            feedCtrl,
+			ReaderSettingsCtrl:  readerSettingsCtrl,
+			ReadingProgressCtrl: readingProgressCtrl,
+			Logger:              logger,
+			Health:              registry,
+			Asura:               asuraApp,
+			Covers:              coversApp,
+			Downloads:           fakeDownloadsApp{},
+			ChapterListRefresh:  fakeChapterListRefreshApp{},
+			Sessions:            sessionsApp,
+			OIDCRevalidation:    fakeOIDCRevalidationApp{},
 		})
 	if err != nil {
 		t.Fatalf("New: %v", err)

--- a/api/pkg/core/readingprogress/domain.go
+++ b/api/pkg/core/readingprogress/domain.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package readingprogress
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
+)
+
+var ErrInvalid = errors.New("invalid reading progress")
+
+type Progress struct {
+	UpdatedAt time.Time
+	ChapterID uuid.UUID
+	Page      int
+}
+
+type Continue struct {
+	ChapterID uuid.UUID
+	Page      int
+}
+
+type ListResult struct {
+	Continue *Continue
+	Chapters []Progress
+}
+
+type ListOpts struct {
+	UserID  uuid.UUID
+	ComicID uuid.UUID
+}
+
+type SaveOpts struct {
+	UserID    uuid.UUID
+	ComicID   uuid.UUID
+	ChapterID uuid.UUID
+	Page      int
+}
+
+type GetOpts struct {
+	UserID    uuid.UUID
+	ComicID   uuid.UUID
+	ChapterID uuid.UUID
+}
+
+type UpsertOpts struct {
+	UpdatedAt time.Time
+	UserID    uuid.UUID
+	ComicID   uuid.UUID
+	ChapterID uuid.UUID
+	Page      int
+}
+
+type Repository interface {
+	ListByUserAndComic(context.Context, ListOpts) ([]Progress, error)
+	Get(context.Context, GetOpts) (*Progress, error)
+	Upsert(context.Context, UpsertOpts) (Progress, error)
+}
+
+type ReadingProgressService interface {
+	List(context.Context, ListOpts) (ListResult, error)
+	Save(context.Context, SaveOpts) (Progress, error)
+}
+
+type LibraryMembership interface {
+	ExistsByUserAndComic(context.Context, uuid.UUID, uuid.UUID) (bool, error)
+}
+
+type ComicLookup interface {
+	Exists(context.Context, uuid.UUID) (bool, error)
+}
+
+type ChapterLookup interface {
+	GetByID(context.Context, uuid.UUID) (*chapters.Chapter, error)
+	GetByIds(context.Context, []uuid.UUID) ([]chapters.Chapter, error)
+}
+
+func ClampPage(page, pagesNb int) int {
+	if pagesNb > 0 && page > pagesNb {
+		return pagesNb
+	}
+
+	return page
+}
+
+func MergePage(stored *int, incoming, pagesNb int) (int, error) {
+	if incoming < 1 {
+		return 0, fmt.Errorf("%w: page must be at least 1", ErrInvalid)
+	}
+
+	if pagesNb > 0 && incoming > pagesNb {
+		return 0, fmt.Errorf("%w: page exceeds chapter length", ErrInvalid)
+	}
+
+	page := incoming
+	if stored != nil && *stored > page {
+		page = *stored
+	}
+
+	return ClampPage(page, pagesNb), nil
+}

--- a/api/pkg/core/readingprogress/domain_test.go
+++ b/api/pkg/core/readingprogress/domain_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package readingprogress_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readingprogress"
+)
+
+func TestClampPage(t *testing.T) {
+	t.Parallel()
+
+	if got := readingprogress.ClampPage(18, 12); got != 12 {
+		t.Errorf("ClampPage(18, 12) = %d, want 12", got)
+	}
+
+	if got := readingprogress.ClampPage(5, 12); got != 5 {
+		t.Errorf("ClampPage(5, 12) = %d, want 5", got)
+	}
+
+	if got := readingprogress.ClampPage(3, 0); got != 3 {
+		t.Errorf("ClampPage(3, 0) = %d, want 3", got)
+	}
+}
+
+func TestMergePageFurthest(t *testing.T) {
+	t.Parallel()
+
+	stored := 20
+	got, err := readingprogress.MergePage(&stored, 8, 20)
+	if err != nil {
+		t.Fatalf("MergePage: %v", err)
+	}
+
+	if got != 20 {
+		t.Errorf("MergePage stored 20 incoming 8 = %d, want 20", got)
+	}
+}
+
+func TestMergePageFirstSave(t *testing.T) {
+	t.Parallel()
+
+	got, err := readingprogress.MergePage(nil, 5, 10)
+	if err != nil {
+		t.Fatalf("MergePage: %v", err)
+	}
+
+	if got != 5 {
+		t.Errorf("MergePage first save = %d, want 5", got)
+	}
+}
+
+func TestMergePageRejectsAbovePagesNb(t *testing.T) {
+	t.Parallel()
+
+	_, err := readingprogress.MergePage(nil, 16, 15)
+	if !errors.Is(err, readingprogress.ErrInvalid) {
+		t.Errorf("err = %v, want ErrInvalid", err)
+	}
+}
+
+func TestMergePageAllowsWhenPagesNbZero(t *testing.T) {
+	t.Parallel()
+
+	got, err := readingprogress.MergePage(nil, 3, 0)
+	if err != nil {
+		t.Fatalf("MergePage: %v", err)
+	}
+
+	if got != 3 {
+		t.Errorf("got %d, want 3", got)
+	}
+}
+
+func TestMergePageRejectsPageBelowOne(t *testing.T) {
+	t.Parallel()
+
+	_, err := readingprogress.MergePage(nil, 0, 10)
+	if !errors.Is(err, readingprogress.ErrInvalid) {
+		t.Errorf("err = %v, want ErrInvalid", err)
+	}
+}
+
+func TestMergePagePersistsClampWhenStoredAbovePagesNb(t *testing.T) {
+	t.Parallel()
+
+	stored := 18
+	got, err := readingprogress.MergePage(&stored, 10, 12)
+	if err != nil {
+		t.Fatalf("MergePage: %v", err)
+	}
+
+	if got != 12 {
+		t.Errorf("furthest 18 then clamp to 12 = %d, want 12", got)
+	}
+}

--- a/api/pkg/core/readingprogress/gateway/http/controller.go
+++ b/api/pkg/core/readingprogress/gateway/http/controller.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package http
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	httpsession "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readingprogress"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/httputils"
+)
+
+type Config struct {
+	Endpoint    string
+	Middlewares chi.Middlewares
+}
+
+func (cfg *Config) Validate() error {
+	if cfg.Endpoint == "" {
+		return errors.New("endpoint is required")
+	}
+
+	if !strings.HasPrefix(cfg.Endpoint, "/") {
+		return fmt.Errorf("endpoint must start with '/', got %q", cfg.Endpoint)
+	}
+
+	hasNilMiddlewares := slices.ContainsFunc(cfg.Middlewares, func(m func(http.Handler) http.Handler) bool {
+		return m == nil
+	})
+
+	if hasNilMiddlewares {
+		return errors.New("all middlewares must not be nil")
+	}
+
+	return nil
+}
+
+type Deps struct {
+	Service readingprogress.ReadingProgressService
+	Logger  *slog.Logger
+}
+
+func (deps *Deps) Validate() error {
+	if deps.Service == nil {
+		return errors.New("service is required")
+	}
+
+	if deps.Logger == nil {
+		return errors.New("logger is required")
+	}
+
+	return nil
+}
+
+type Controller struct {
+	deps Deps
+	cfg  Config
+}
+
+func New(cfg Config, deps Deps) (*Controller, error) {
+	var err error
+	if err = cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("cfg.Validate: %w", err)
+	}
+
+	if err = deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	deps.Logger = deps.Logger.With("component", "readingprogress.gateway.http")
+
+	return &Controller{deps: deps, cfg: cfg}, nil
+}
+
+func (c *Controller) InitRouter(r chi.Router) {
+	r.Route(c.cfg.Endpoint, func(r chi.Router) {
+		r.Use(c.cfg.Middlewares...)
+		r.Get("/{id}/progress", c.get)
+		r.Put("/{id}/progress", c.put)
+	})
+}
+
+func (c *Controller) get(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user, ok := httpsession.UserFrom(ctx)
+	if !ok {
+		httputils.WriteError(w, c.deps.Logger, http.StatusUnauthorized, "")
+
+		return
+	}
+
+	comicID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "id must be a valid UUID")
+
+		return
+	}
+
+	result, err := c.deps.Service.List(ctx, readingprogress.ListOpts{
+		UserID:  user.ID,
+		ComicID: comicID,
+	})
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusNotFound, "")
+
+			return
+		}
+
+		if errors.Is(err, domain.ErrForbidden) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusForbidden, "comic not in library")
+
+			return
+		}
+
+		c.deps.Logger.Error("failed to list reading progress", "error", err)
+		httputils.WriteError(w, c.deps.Logger, http.StatusInternalServerError, "")
+
+		return
+	}
+
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, listFromDomain(result))
+}
+
+func (c *Controller) put(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user, ok := httpsession.UserFrom(ctx)
+	if !ok {
+		httputils.WriteError(w, c.deps.Logger, http.StatusUnauthorized, "")
+
+		return
+	}
+
+	comicID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "id must be a valid UUID")
+
+		return
+	}
+
+	req, err := httputils.DecodeJSON[saveRequest](r)
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "invalid request body")
+
+		return
+	}
+
+	if *req.Page < 1 {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "invalid request body")
+
+		return
+	}
+
+	saved, err := c.deps.Service.Save(ctx, readingprogress.SaveOpts{
+		UserID:    user.ID,
+		ComicID:   comicID,
+		ChapterID: req.ChapterID,
+		Page:      *req.Page,
+	})
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusNotFound, "")
+
+			return
+		}
+
+		if errors.Is(err, domain.ErrForbidden) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusForbidden, "comic not in library")
+
+			return
+		}
+
+		if errors.Is(err, readingprogress.ErrInvalid) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "invalid request body")
+
+			return
+		}
+
+		c.deps.Logger.Error("failed to save reading progress", "error", err)
+		httputils.WriteError(w, c.deps.Logger, http.StatusInternalServerError, "")
+
+		return
+	}
+
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, progressFromDomain(saved))
+}

--- a/api/pkg/core/readingprogress/gateway/http/controller.go
+++ b/api/pkg/core/readingprogress/gateway/http/controller.go
@@ -81,10 +81,10 @@ func New(cfg Config, deps Deps) (*Controller, error) {
 }
 
 func (c *Controller) InitRouter(r chi.Router) {
-	r.Route(c.cfg.Endpoint, func(r chi.Router) {
+	r.Group(func(r chi.Router) {
 		r.Use(c.cfg.Middlewares...)
-		r.Get("/{id}/progress", c.get)
-		r.Put("/{id}/progress", c.put)
+		r.Get(c.cfg.Endpoint+"/{id}/progress", c.get)
+		r.Put(c.cfg.Endpoint+"/{id}/progress", c.put)
 	})
 }
 

--- a/api/pkg/core/readingprogress/gateway/http/controller_test.go
+++ b/api/pkg/core/readingprogress/gateway/http/controller_test.go
@@ -1,0 +1,509 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package http_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
+	sessionshttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readingprogress"
+	httpreadingprogress "github.com/kharente-deuh/uchiyomi-server/pkg/core/readingprogress/gateway/http"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/users"
+)
+
+const (
+	endpoint     = "/comics"
+	cookieName   = "uchiyomi_session"
+	testToken    = "letoken"
+	testUsername = "alice"
+)
+
+type stubService struct {
+	listErr    error
+	saveErr    error
+	listResult readingprogress.ListResult
+	saveResult readingprogress.Progress
+	lastList   readingprogress.ListOpts
+	lastSave   readingprogress.SaveOpts
+}
+
+func (s *stubService) List(_ context.Context, opts readingprogress.ListOpts) (readingprogress.ListResult, error) {
+	s.lastList = opts
+
+	return s.listResult, s.listErr
+}
+
+func (s *stubService) Save(_ context.Context, opts readingprogress.SaveOpts) (readingprogress.Progress, error) {
+	s.lastSave = opts
+
+	return s.saveResult, s.saveErr
+}
+
+type stubSessionService struct {
+	result *sessions.AuthenticatedSession
+}
+
+func (s *stubSessionService) Authenticate(_ context.Context, _ string) (*sessions.AuthenticatedSession, error) {
+	if s.result == nil {
+		return nil, sessions.ErrInvalidSession
+	}
+
+	return s.result, nil
+}
+
+type progressJSON struct {
+	ChapterID string `json:"chapterId"`
+	Page      int    `json:"page"`
+	UpdatedAt string `json:"updatedAt"`
+}
+
+type listJSON struct {
+	Chapters []progressJSON `json:"chapters"`
+	Continue *struct {
+		ChapterID string `json:"chapterId"`
+		Page      int    `json:"page"`
+	} `json:"continue"`
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
+
+func frozenNow() time.Time {
+	return time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
+}
+
+func authenticatorFor(t *testing.T, user *users.User) chi.Middlewares {
+	t.Helper()
+
+	logger := testLogger()
+
+	cookies, err := sessionshttp.NewCookieManager(sessionshttp.CookieConfig{Name: cookieName, Path: "/"})
+	if err != nil {
+		t.Fatalf("NewCookieManager: %v", err)
+	}
+
+	a, err := sessionshttp.NewAuthenticator(sessionshttp.AuthenticatorDeps{
+		SessionService: &stubSessionService{result: &sessions.AuthenticatedSession{
+			User:    user,
+			Session: sessions.Session{ID: uuid.New(), UserID: user.ID, ExpiresAt: frozenNow().Add(time.Hour)},
+		}},
+		Cookies: cookies,
+		Logger:  logger,
+		Now:     frozenNow,
+	})
+	if err != nil {
+		t.Fatalf("NewAuthenticator: %v", err)
+	}
+
+	return chi.Middlewares{a.Middleware}
+}
+
+func newTestRouter(t *testing.T, svc *stubService, mws chi.Middlewares) chi.Router {
+	t.Helper()
+
+	c, err := httpreadingprogress.New(
+		httpreadingprogress.Config{Endpoint: endpoint, Middlewares: mws},
+		httpreadingprogress.Deps{Logger: testLogger(), Service: svc},
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	r := chi.NewRouter()
+	c.InitRouter(r)
+
+	return r
+}
+
+func testUser() *users.User {
+	return &users.User{ID: uuid.New(), Name: testUsername}
+}
+
+func getProgress(t *testing.T, r chi.Router, comicID string, withCookie bool) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, endpoint+"/"+comicID+"/progress", nil)
+	if withCookie {
+		req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	}
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	return rec
+}
+
+func putProgress(t *testing.T, r chi.Router, comicID, body string, withCookie bool) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPut, endpoint+"/"+comicID+"/progress", strings.NewReader(body))
+	if withCookie {
+		req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	}
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	return rec
+}
+
+func TestNewValidatesConfigAndDeps(t *testing.T) {
+	t.Parallel()
+
+	logger := testLogger()
+	svc := &stubService{}
+	passthrough := func(next http.Handler) http.Handler { return next }
+
+	tests := map[string]struct {
+		deps    httpreadingprogress.Deps
+		wantErr string
+		cfg     httpreadingprogress.Config
+	}{
+		"empty endpoint": {
+			cfg:     httpreadingprogress.Config{},
+			deps:    httpreadingprogress.Deps{Logger: logger, Service: svc},
+			wantErr: "cfg.Validate: endpoint is required",
+		},
+		"nil middleware": {
+			cfg: httpreadingprogress.Config{
+				Endpoint:    endpoint,
+				Middlewares: chi.Middlewares{passthrough, nil},
+			},
+			deps:    httpreadingprogress.Deps{Logger: logger, Service: svc},
+			wantErr: "cfg.Validate: all middlewares must not be nil",
+		},
+		"nil logger": {
+			cfg:     httpreadingprogress.Config{Endpoint: endpoint},
+			deps:    httpreadingprogress.Deps{Service: svc},
+			wantErr: "deps.Validate: logger is required",
+		},
+		"nil service": {
+			cfg:     httpreadingprogress.Config{Endpoint: endpoint},
+			deps:    httpreadingprogress.Deps{Logger: logger},
+			wantErr: "deps.Validate: service is required",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := httpreadingprogress.New(tc.cfg, tc.deps)
+			if err == nil {
+				t.Fatalf("New() = nil, want %q", tc.wantErr)
+			}
+
+			if c != nil {
+				t.Error("New returned a controller in addition to the error")
+			}
+
+			if err.Error() != tc.wantErr {
+				t.Errorf("New() = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestGetUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	r := newTestRouter(t, &stubService{}, authenticatorFor(t, user))
+
+	rec := getProgress(t, r, uuid.New().String(), false)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusUnauthorized, rec.Body.String())
+	}
+}
+
+func TestPutUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	r := newTestRouter(t, &stubService{}, authenticatorFor(t, user))
+
+	rec := putProgress(t, r, uuid.New().String(), `{"chapterId":"`+uuid.New().String()+`","page":1}`, false)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusUnauthorized, rec.Body.String())
+	}
+}
+
+func TestGetOK(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	comicID := uuid.New()
+	chapterNewer := uuid.New()
+	chapterOlder := uuid.New()
+	updatedNewer := time.Date(2026, 2, 2, 10, 0, 0, 0, time.UTC)
+	updatedOlder := time.Date(2026, 2, 1, 10, 0, 0, 0, time.UTC)
+
+	svc := &stubService{
+		listResult: readingprogress.ListResult{
+			Continue: &readingprogress.Continue{ChapterID: chapterNewer, Page: 5},
+			Chapters: []readingprogress.Progress{
+				{UpdatedAt: updatedNewer, ChapterID: chapterNewer, Page: 5},
+				{UpdatedAt: updatedOlder, ChapterID: chapterOlder, Page: 12},
+			},
+		},
+	}
+	r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+	rec := getProgress(t, r, comicID.String(), true)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	if svc.lastList.UserID != user.ID {
+		t.Errorf("lastList.UserID = %s, want %s", svc.lastList.UserID, user.ID)
+	}
+
+	if svc.lastList.ComicID != comicID {
+		t.Errorf("lastList.ComicID = %s, want %s", svc.lastList.ComicID, comicID)
+	}
+
+	var got listJSON
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("body not decodable (%q): %v", rec.Body.String(), err)
+	}
+
+	if len(got.Chapters) != 2 {
+		t.Fatalf("chapters len = %d, want 2", len(got.Chapters))
+	}
+
+	if got.Chapters[0].ChapterID != chapterNewer.String() || got.Chapters[0].Page != 5 {
+		t.Errorf("chapters[0] = %+v", got.Chapters[0])
+	}
+
+	if got.Chapters[0].UpdatedAt == "" {
+		t.Error("chapters[0].updatedAt is empty, want RFC3339 timestamp")
+	}
+
+	if got.Chapters[1].ChapterID != chapterOlder.String() || got.Chapters[1].Page != 12 {
+		t.Errorf("chapters[1] = %+v", got.Chapters[1])
+	}
+
+	if got.Continue == nil {
+		t.Fatal("continue is nil, want object")
+	}
+
+	if got.Continue.ChapterID != chapterNewer.String() || got.Continue.Page != 5 {
+		t.Errorf("continue = %+v", got.Continue)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw body: %v", err)
+	}
+
+	var continueRaw map[string]json.RawMessage
+	if err := json.Unmarshal(raw["continue"], &continueRaw); err != nil {
+		t.Fatalf("decode continue: %v", err)
+	}
+
+	if _, ok := continueRaw["updatedAt"]; ok {
+		t.Error("continue must not include updatedAt")
+	}
+}
+
+func TestGetEmptyContinueNull(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	comicID := uuid.New()
+	svc := &stubService{
+		listResult: readingprogress.ListResult{Chapters: []readingprogress.Progress{}},
+	}
+	r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+	rec := getProgress(t, r, comicID.String(), true)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var got listJSON
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("body not decodable (%q): %v", rec.Body.String(), err)
+	}
+
+	if got.Continue != nil {
+		t.Errorf("continue = %+v, want null", got.Continue)
+	}
+
+	if len(got.Chapters) != 0 {
+		t.Errorf("chapters len = %d, want 0", len(got.Chapters))
+	}
+
+	if !bytes.Contains(rec.Body.Bytes(), []byte(`"chapters":[]`)) {
+		t.Errorf("body = %s, want chapters:[]", rec.Body.String())
+	}
+}
+
+func TestPutOK(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	comicID := uuid.New()
+	chapterID := uuid.New()
+	savedAt := time.Date(2026, 3, 1, 8, 0, 0, 0, time.UTC)
+
+	svc := &stubService{
+		saveResult: readingprogress.Progress{UpdatedAt: savedAt, ChapterID: chapterID, Page: 20},
+	}
+	r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+	body := `{"chapterId":"` + chapterID.String() + `","page":8}`
+	rec := putProgress(t, r, comicID.String(), body, true)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	if svc.lastSave.UserID != user.ID {
+		t.Errorf("lastSave.UserID = %s, want %s", svc.lastSave.UserID, user.ID)
+	}
+
+	if svc.lastSave.ComicID != comicID {
+		t.Errorf("lastSave.ComicID = %s, want %s", svc.lastSave.ComicID, comicID)
+	}
+
+	if svc.lastSave.ChapterID != chapterID {
+		t.Errorf("lastSave.ChapterID = %s, want %s", svc.lastSave.ChapterID, chapterID)
+	}
+
+	if svc.lastSave.Page != 8 {
+		t.Errorf("lastSave.Page = %d, want 8", svc.lastSave.Page)
+	}
+
+	var got progressJSON
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("body not decodable (%q): %v", rec.Body.String(), err)
+	}
+
+	if got.ChapterID != chapterID.String() {
+		t.Errorf("chapterId = %q, want %q", got.ChapterID, chapterID.String())
+	}
+
+	if got.Page != 20 {
+		t.Errorf("page = %d, want 20", got.Page)
+	}
+}
+
+func TestPutInvalidComicID(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	r := newTestRouter(t, &stubService{}, authenticatorFor(t, user))
+
+	rec := putProgress(t, r, "not-a-uuid", `{"chapterId":"`+uuid.New().String()+`","page":1}`, true)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestPutInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	r := newTestRouter(t, &stubService{}, authenticatorFor(t, user))
+
+	rec := putProgress(t, r, uuid.New().String(), `{`, true)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestPutPageZero(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	r := newTestRouter(t, &stubService{}, authenticatorFor(t, user))
+
+	rec := putProgress(t, r, uuid.New().String(), `{"chapterId":"`+uuid.New().String()+`","page":0}`, true)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestPutForbidden(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	svc := &stubService{saveErr: domain.ErrForbidden}
+	r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+	rec := putProgress(t, r, uuid.New().String(), `{"chapterId":"`+uuid.New().String()+`","page":1}`, true)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusForbidden, rec.Body.String())
+	}
+
+	var got struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+
+	if got.Message != "comic not in library" {
+		t.Errorf("message = %q, want %q", got.Message, "comic not in library")
+	}
+}
+
+func TestGetNotFound(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	svc := &stubService{listErr: domain.ErrNotFound}
+	r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+	rec := getProgress(t, r, uuid.New().String(), true)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+}
+
+func TestPutUsesSessionUser(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	comicID := uuid.New()
+	chapterID := uuid.New()
+
+	svc := &stubService{
+		saveResult: readingprogress.Progress{UpdatedAt: time.Now().UTC(), ChapterID: chapterID, Page: 3},
+	}
+	r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+	body := `{"chapterId":"` + chapterID.String() + `","page":3}`
+	rec := putProgress(t, r, comicID.String(), body, true)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	if svc.lastSave.UserID != user.ID {
+		t.Errorf("lastSave.UserID = %s, want session user %s", svc.lastSave.UserID, user.ID)
+	}
+}

--- a/api/pkg/core/readingprogress/gateway/http/controller_test.go
+++ b/api/pkg/core/readingprogress/gateway/http/controller_test.go
@@ -65,16 +65,16 @@ func (s *stubSessionService) Authenticate(_ context.Context, _ string) (*session
 
 type progressJSON struct {
 	ChapterID string `json:"chapterId"`
-	Page      int    `json:"page"`
 	UpdatedAt string `json:"updatedAt"`
+	Page      int    `json:"page"`
 }
 
 type listJSON struct {
-	Chapters []progressJSON `json:"chapters"`
 	Continue *struct {
 		ChapterID string `json:"chapterId"`
 		Page      int    `json:"page"`
 	} `json:"continue"`
+	Chapters []progressJSON `json:"chapters"`
 }
 
 func testLogger() *slog.Logger {

--- a/api/pkg/core/readingprogress/gateway/http/dto.go
+++ b/api/pkg/core/readingprogress/gateway/http/dto.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package http
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readingprogress"
+)
+
+type progressResponse struct {
+	UpdatedAt time.Time `json:"updatedAt"`
+	ChapterID uuid.UUID `json:"chapterId"`
+	Page      int       `json:"page"`
+}
+
+type continueResponse struct {
+	ChapterID uuid.UUID `json:"chapterId"`
+	Page      int       `json:"page"`
+}
+
+type listResponse struct {
+	Continue *continueResponse  `json:"continue"`
+	Chapters []progressResponse `json:"chapters"`
+}
+
+type saveRequest struct {
+	ChapterID uuid.UUID `json:"chapterId" validate:"required"`
+	Page      *int      `json:"page" validate:"required"`
+}
+
+func progressFromDomain(p readingprogress.Progress) progressResponse {
+	return progressResponse{
+		UpdatedAt: p.UpdatedAt,
+		ChapterID: p.ChapterID,
+		Page:      p.Page,
+	}
+}
+
+func listFromDomain(result readingprogress.ListResult) listResponse {
+	chapters := make([]progressResponse, 0, len(result.Chapters))
+	for _, p := range result.Chapters {
+		chapters = append(chapters, progressFromDomain(p))
+	}
+
+	var cont *continueResponse
+	if result.Continue != nil {
+		cont = &continueResponse{
+			ChapterID: result.Continue.ChapterID,
+			Page:      result.Continue.Page,
+		}
+	}
+
+	return listResponse{
+		Continue: cont,
+		Chapters: chapters,
+	}
+}

--- a/api/pkg/core/readingprogress/gateway/http/dto.go
+++ b/api/pkg/core/readingprogress/gateway/http/dto.go
@@ -26,8 +26,8 @@ type listResponse struct {
 }
 
 type saveRequest struct {
-	ChapterID uuid.UUID `json:"chapterId" validate:"required"`
 	Page      *int      `json:"page" validate:"required"`
+	ChapterID uuid.UUID `json:"chapterId" validate:"required"`
 }
 
 func progressFromDomain(p readingprogress.Progress) progressResponse {

--- a/api/pkg/core/readingprogress/repository/pg/repository.go
+++ b/api/pkg/core/readingprogress/repository/pg/repository.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package pg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readingprogress"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/repository/pgmodels"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/transaction/pgtx"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+var _ readingprogress.Repository = (*PGReadingProgressRepository)(nil)
+
+type Deps struct {
+	DB *gorm.DB
+}
+
+func (deps *Deps) Validate() error {
+	if deps.DB == nil {
+		return errors.New("db is required")
+	}
+
+	return nil
+}
+
+type PGReadingProgressRepository struct {
+	deps Deps
+}
+
+func New(deps Deps) (*PGReadingProgressRepository, error) {
+	if err := deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	r := &PGReadingProgressRepository{deps: deps}
+
+	return r, nil
+}
+
+func (r *PGReadingProgressRepository) db(ctx context.Context) gorm.Interface[pgmodels.ReadingProgress] {
+	return gorm.G[pgmodels.ReadingProgress](pgtx.From(ctx, r.deps.DB))
+}
+
+func (r *PGReadingProgressRepository) ListByUserAndComic(
+	ctx context.Context, opts readingprogress.ListOpts,
+) ([]readingprogress.Progress, error) {
+	models, err := r.db(ctx).
+		Joins(clause.JoinTarget{Association: "LibraryEntry"}, nil).
+		Where("library_entries.user_id = ? AND library_entries.comic_id = ?", opts.UserID, opts.ComicID).
+		Order("reading_progress.updated_at DESC").
+		Find(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("r.db(ctx).Find: %w", err)
+	}
+
+	ret := make([]readingprogress.Progress, 0, len(models))
+	for i := range models {
+		ret = append(ret, models[i].Domain())
+	}
+
+	return ret, nil
+}
+
+func (r *PGReadingProgressRepository) Get(
+	ctx context.Context, opts readingprogress.GetOpts,
+) (*readingprogress.Progress, error) {
+	model, err := r.db(ctx).
+		Joins(clause.JoinTarget{Association: "LibraryEntry"}, nil).
+		Where(
+			"library_entries.user_id = ? AND library_entries.comic_id = ? AND reading_progress.chapter_id = ?",
+			opts.UserID, opts.ComicID, opts.ChapterID,
+		).
+		First(ctx)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrNotFound
+		}
+
+		return nil, fmt.Errorf("r.db(ctx).First: %w", err)
+	}
+
+	ret := model.Domain()
+
+	return &ret, nil
+}
+
+func (r *PGReadingProgressRepository) Upsert(
+	ctx context.Context, opts readingprogress.UpsertOpts,
+) (readingprogress.Progress, error) {
+	entry, err := gorm.G[pgmodels.LibraryEntry](pgtx.From(ctx, r.deps.DB)).
+		Where("user_id = ? AND comic_id = ?", opts.UserID, opts.ComicID).
+		First(ctx)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return readingprogress.Progress{}, domain.ErrNotFound
+		}
+
+		return readingprogress.Progress{}, fmt.Errorf("gorm.G[pgmodels.LibraryEntry].First: %w", err)
+	}
+
+	model := &pgmodels.ReadingProgress{
+		ID:             uuid.New(),
+		LibraryEntryID: entry.ID,
+		ChapterID:      opts.ChapterID,
+		Page:           opts.Page,
+		UpdatedAt:      opts.UpdatedAt,
+	}
+
+	err = pgtx.From(ctx, r.deps.DB).WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "library_entry_id"}, {Name: "chapter_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"page", "updated_at"}),
+	}).Create(model).Error
+	if err != nil {
+		return readingprogress.Progress{}, fmt.Errorf("pgtx.From(ctx, r.deps.DB).Create: %w", err)
+	}
+
+	return model.Domain(), nil
+}

--- a/api/pkg/core/readingprogress/repository/pg/repository_test.go
+++ b/api/pkg/core/readingprogress/repository/pg/repository_test.go
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//nolint:goconst
+package pg_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readingprogress"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readingprogress/repository/pg"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/repository/pgtest"
+)
+
+func newReadingProgressRepo(t *testing.T) (*pg.PGReadingProgressRepository, sqlmock.Sqlmock) {
+	t.Helper()
+
+	db, mock := pgtest.New(t)
+
+	r, err := pg.New(pg.Deps{DB: db})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	return r, mock
+}
+
+func TestNewValidatesDeps(t *testing.T) {
+	t.Parallel()
+
+	r, err := pg.New(pg.Deps{})
+	if err == nil {
+		t.Fatal("New without DB must fail")
+	}
+
+	if r != nil {
+		t.Error("New returned a repository in addition to the error")
+	}
+
+	if want := "deps.Validate: db is required"; err.Error() != want {
+		t.Errorf("err = %q, want %q", err.Error(), want)
+	}
+}
+
+func readingProgressSelectColumns() []string {
+	return []string{"id", "library_entry_id", "chapter_id", "page", "updated_at"}
+}
+
+func TestListByUserAndComicJoinsLibraryEntry(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newReadingProgressRepo(t)
+
+	userID := uuid.New()
+	otherUserID := uuid.New()
+	comicID := uuid.New()
+	chapterID := uuid.New()
+	updatedAt := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(`reading_progress.*library_entries`).
+		WithArgs(userID, comicID).
+		WillReturnRows(
+			sqlmock.NewRows(readingProgressSelectColumns()).AddRow(
+				uuid.New(), uuid.New(), chapterID, 5, updatedAt,
+			),
+		)
+
+	got, err := r.ListByUserAndComic(context.Background(), readingprogress.ListOpts{
+		UserID:  userID,
+		ComicID: comicID,
+	})
+	if err != nil {
+		t.Fatalf("ListByUserAndComic: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("ListByUserAndComic() len = %d, want 1", len(got))
+	}
+
+	want := readingprogress.Progress{
+		ChapterID: chapterID,
+		Page:      5,
+		UpdatedAt: updatedAt,
+	}
+	if got[0] != want {
+		t.Errorf("ListByUserAndComic()[0] = %+v, want %+v", got[0], want)
+	}
+
+	if otherUserID == userID {
+		t.Fatal("unlucky uuid collision")
+	}
+}
+
+func TestListOrdersByUpdatedAtDesc(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newReadingProgressRepo(t)
+
+	userID := uuid.New()
+	comicID := uuid.New()
+
+	mock.ExpectQuery(`ORDER BY.*updated_at`).
+		WithArgs(userID, comicID).
+		WillReturnRows(sqlmock.NewRows(readingProgressSelectColumns()))
+
+	_, err := r.ListByUserAndComic(context.Background(), readingprogress.ListOpts{
+		UserID:  userID,
+		ComicID: comicID,
+	})
+	if err != nil {
+		t.Fatalf("ListByUserAndComic: %v", err)
+	}
+}
+
+func TestGetNotFound(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newReadingProgressRepo(t)
+
+	userID := uuid.New()
+	comicID := uuid.New()
+	chapterID := uuid.New()
+
+	mock.ExpectQuery(`reading_progress.*library_entries`).
+		WithArgs(userID, comicID, chapterID, 1).
+		WillReturnRows(sqlmock.NewRows(readingProgressSelectColumns()))
+
+	got, err := r.Get(context.Background(), readingprogress.GetOpts{
+		UserID:    userID,
+		ComicID:   comicID,
+		ChapterID: chapterID,
+	})
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("Get = %v, want domain.ErrNotFound", err)
+	}
+
+	if got != nil {
+		t.Errorf("Get returned %+v in addition to the error", got)
+	}
+}
+
+func TestUpsertInserts(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newReadingProgressRepo(t)
+
+	userID := uuid.New()
+	comicID := uuid.New()
+	chapterID := uuid.New()
+	entryID := uuid.New()
+	updatedAt := time.Date(2024, 6, 2, 8, 30, 0, 0, time.UTC)
+	page := 12
+
+	mock.ExpectQuery(`FROM "library_entries".*user_id`).
+		WithArgs(userID, comicID, 1).
+		WillReturnRows(
+			sqlmock.NewRows([]string{"id", "user_id", "comic_id", "added_at"}).
+				AddRow(entryID, userID, comicID, time.Now()),
+		)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`INSERT INTO "reading_progress"`).
+		WithArgs(
+			updatedAt,
+			entryID,
+			chapterID,
+			page,
+			sqlmock.AnyArg(),
+		).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+	mock.ExpectCommit()
+
+	got, err := r.Upsert(context.Background(), readingprogress.UpsertOpts{
+		UserID:    userID,
+		ComicID:   comicID,
+		ChapterID: chapterID,
+		Page:      page,
+		UpdatedAt: updatedAt,
+	})
+	if err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	want := readingprogress.Progress{
+		ChapterID: chapterID,
+		Page:      page,
+		UpdatedAt: updatedAt,
+	}
+	if got != want {
+		t.Errorf("Upsert() = %+v, want %+v", got, want)
+	}
+}
+
+func TestUpsertConflictUpdates(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newReadingProgressRepo(t)
+
+	userID := uuid.New()
+	comicID := uuid.New()
+	chapterID := uuid.New()
+	entryID := uuid.New()
+	updatedAt := time.Date(2024, 6, 3, 9, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(`FROM "library_entries".*user_id`).
+		WithArgs(userID, comicID, 1).
+		WillReturnRows(
+			sqlmock.NewRows([]string{"id", "user_id", "comic_id", "added_at"}).
+				AddRow(entryID, userID, comicID, time.Now()),
+		)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`ON CONFLICT`).
+		WithArgs(
+			updatedAt,
+			entryID,
+			chapterID,
+			7,
+			sqlmock.AnyArg(),
+		).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+	mock.ExpectCommit()
+
+	got, err := r.Upsert(context.Background(), readingprogress.UpsertOpts{
+		UserID:    userID,
+		ComicID:   comicID,
+		ChapterID: chapterID,
+		Page:      7,
+		UpdatedAt: updatedAt,
+	})
+	if err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	want := readingprogress.Progress{
+		ChapterID: chapterID,
+		Page:      7,
+		UpdatedAt: updatedAt,
+	}
+	if got != want {
+		t.Errorf("Upsert() = %+v, want %+v", got, want)
+	}
+}

--- a/api/pkg/core/readingprogress/service.go
+++ b/api/pkg/core/readingprogress/service.go
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package readingprogress
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+)
+
+var _ ReadingProgressService = (*Service)(nil)
+
+type Deps struct {
+	Repository Repository
+	Library    LibraryMembership
+	Comics     ComicLookup
+	Chapters   ChapterLookup
+}
+
+func (deps *Deps) Validate() error {
+	if deps.Repository == nil {
+		return errors.New("repository is required")
+	}
+
+	if deps.Library == nil {
+		return errors.New("library is required")
+	}
+
+	if deps.Comics == nil {
+		return errors.New("comics is required")
+	}
+
+	if deps.Chapters == nil {
+		return errors.New("chapters is required")
+	}
+
+	return nil
+}
+
+type Service struct {
+	deps Deps
+}
+
+func NewService(deps Deps) (*Service, error) {
+	if err := deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	return &Service{deps: deps}, nil
+}
+
+func (s *Service) List(ctx context.Context, opts ListOpts) (ListResult, error) {
+	if err := s.requireLibrary(ctx, opts.UserID, opts.ComicID); err != nil {
+		return ListResult{}, err
+	}
+
+	rows, err := s.deps.Repository.ListByUserAndComic(ctx, opts)
+	if err != nil {
+		return ListResult{}, fmt.Errorf("s.deps.Repository.ListByUserAndComic: %w", err)
+	}
+
+	if len(rows) == 0 {
+		return ListResult{Chapters: []Progress{}}, nil
+	}
+
+	ids := make([]uuid.UUID, len(rows))
+	for i, row := range rows {
+		ids[i] = row.ChapterID
+	}
+
+	chapterList, err := s.deps.Chapters.GetByIds(ctx, ids)
+	if err != nil {
+		return ListResult{}, fmt.Errorf("s.deps.Chapters.GetByIds: %w", err)
+	}
+
+	pagesNb := make(map[uuid.UUID]int, len(chapterList))
+	for _, chapter := range chapterList {
+		pagesNb[chapter.ID] = chapter.PagesNb
+	}
+
+	chapters := make([]Progress, len(rows))
+	for i, row := range rows {
+		chapters[i] = Progress{
+			UpdatedAt: row.UpdatedAt,
+			ChapterID: row.ChapterID,
+			Page:      ClampPage(row.Page, pagesNb[row.ChapterID]),
+		}
+	}
+
+	result := ListResult{Chapters: chapters}
+	first := chapters[0]
+	result.Continue = &Continue{
+		ChapterID: first.ChapterID,
+		Page:      first.Page,
+	}
+
+	return result, nil
+}
+
+func (s *Service) Save(ctx context.Context, opts SaveOpts) (Progress, error) {
+	if err := s.requireLibrary(ctx, opts.UserID, opts.ComicID); err != nil {
+		return Progress{}, err
+	}
+
+	chapter, err := s.deps.Chapters.GetByID(ctx, opts.ChapterID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return Progress{}, domain.ErrNotFound
+		}
+
+		return Progress{}, fmt.Errorf("s.deps.Chapters.GetByID: %w", err)
+	}
+
+	if chapter.ComicID != opts.ComicID {
+		return Progress{}, domain.ErrNotFound
+	}
+
+	stored, err := s.deps.Repository.Get(ctx, GetOpts{
+		UserID:    opts.UserID,
+		ComicID:   opts.ComicID,
+		ChapterID: opts.ChapterID,
+	})
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			stored = nil
+		} else {
+			return Progress{}, fmt.Errorf("s.deps.Repository.Get: %w", err)
+		}
+	}
+
+	var storedPage *int
+	if stored != nil {
+		page := stored.Page
+		storedPage = &page
+	}
+
+	page, err := MergePage(storedPage, opts.Page, chapter.PagesNb)
+	if err != nil {
+		return Progress{}, err
+	}
+
+	saved, err := s.deps.Repository.Upsert(ctx, UpsertOpts{
+		UpdatedAt: time.Now().UTC(),
+		UserID:    opts.UserID,
+		ComicID:   opts.ComicID,
+		ChapterID: opts.ChapterID,
+		Page:      page,
+	})
+	if err != nil {
+		return Progress{}, fmt.Errorf("s.deps.Repository.Upsert: %w", err)
+	}
+
+	return saved, nil
+}
+
+func (s *Service) requireLibrary(ctx context.Context, userID, comicID uuid.UUID) error {
+	inLibrary, err := s.deps.Library.ExistsByUserAndComic(ctx, userID, comicID)
+	if err != nil {
+		return fmt.Errorf("s.deps.Library.ExistsByUserAndComic: %w", err)
+	}
+
+	if !inLibrary {
+		exists, lookupErr := s.deps.Comics.Exists(ctx, comicID)
+		if lookupErr != nil {
+			return fmt.Errorf("s.deps.Comics.Exists: %w", lookupErr)
+		}
+
+		if !exists {
+			return domain.ErrNotFound
+		}
+
+		return domain.ErrForbidden
+	}
+
+	return nil
+}

--- a/api/pkg/core/readingprogress/service_test.go
+++ b/api/pkg/core/readingprogress/service_test.go
@@ -1,0 +1,459 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package readingprogress_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readingprogress"
+)
+
+type fakeRepo struct {
+	listErr     error
+	getErr      error
+	upsertErr   error
+	existing    *readingprogress.Progress
+	rows        []readingprogress.Progress
+	lastUpsert  readingprogress.UpsertOpts
+	listCalls   int
+	getCalls    int
+	upsertCalls int
+	lastGet     readingprogress.GetOpts
+	listed      readingprogress.ListOpts
+}
+
+func (f *fakeRepo) ListByUserAndComic(
+	_ context.Context,
+	opts readingprogress.ListOpts,
+) ([]readingprogress.Progress, error) {
+	f.listCalls++
+	f.listed = opts
+
+	return f.rows, f.listErr
+}
+
+func (f *fakeRepo) Get(_ context.Context, opts readingprogress.GetOpts) (*readingprogress.Progress, error) {
+	f.getCalls++
+	f.lastGet = opts
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+
+	return f.existing, nil
+}
+
+func (f *fakeRepo) Upsert(_ context.Context, opts readingprogress.UpsertOpts) (readingprogress.Progress, error) {
+	f.upsertCalls++
+	f.lastUpsert = opts
+
+	return readingprogress.Progress{
+		ChapterID: opts.ChapterID,
+		Page:      opts.Page,
+		UpdatedAt: opts.UpdatedAt,
+	}, f.upsertErr
+}
+
+type fakeLibrary struct {
+	err     error
+	inLib   bool
+	userID  uuid.UUID
+	comicID uuid.UUID
+	calls   int
+}
+
+func (f *fakeLibrary) ExistsByUserAndComic(_ context.Context, userID, comicID uuid.UUID) (bool, error) {
+	f.calls++
+	f.userID = userID
+	f.comicID = comicID
+
+	return f.inLib, f.err
+}
+
+type fakeComics struct {
+	err    error
+	exists bool
+	id     uuid.UUID
+	calls  int
+}
+
+func (f *fakeComics) Exists(_ context.Context, id uuid.UUID) (bool, error) {
+	f.calls++
+	f.id = id
+
+	return f.exists, f.err
+}
+
+type fakeChapters struct {
+	getErr   error
+	idsErr   error
+	chapter  *chapters.Chapter
+	byID     map[uuid.UUID]chapters.Chapter
+	lastID   uuid.UUID
+	getCalls int
+	idsCalls int
+}
+
+func (f *fakeChapters) GetByID(_ context.Context, id uuid.UUID) (*chapters.Chapter, error) {
+	f.getCalls++
+	f.lastID = id
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+
+	return f.chapter, nil
+}
+
+func (f *fakeChapters) GetByIds(_ context.Context, ids []uuid.UUID) ([]chapters.Chapter, error) {
+	f.idsCalls++
+	if f.idsErr != nil {
+		return nil, f.idsErr
+	}
+
+	out := make([]chapters.Chapter, 0, len(ids))
+	for _, id := range ids {
+		if ch, ok := f.byID[id]; ok {
+			out = append(out, ch)
+		}
+	}
+
+	return out, nil
+}
+
+func newService(
+	t *testing.T,
+	repo readingprogress.Repository,
+	lib readingprogress.LibraryMembership,
+	comics readingprogress.ComicLookup,
+	ch readingprogress.ChapterLookup,
+) *readingprogress.Service {
+	t.Helper()
+
+	svc, err := readingprogress.NewService(readingprogress.Deps{
+		Repository: repo,
+		Library:    lib,
+		Comics:     comics,
+		Chapters:   ch,
+	})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	return svc
+}
+
+func TestNewServiceValidatesDeps(t *testing.T) {
+	t.Parallel()
+
+	_, err := readingprogress.NewService(readingprogress.Deps{})
+	if err == nil {
+		t.Fatal("NewService with empty deps must fail")
+	}
+}
+
+func TestSaveTwoChaptersContinueIsLastOpened(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	comicID := uuid.New()
+	ch10 := uuid.New()
+	ch3 := uuid.New()
+	repo := &fakeRepo{getErr: domain.ErrNotFound}
+	chap := &fakeChapters{chapter: &chapters.Chapter{ID: ch10, ComicID: comicID, PagesNb: 30, Download: 40}}
+	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, chap)
+
+	if _, err := svc.Save(context.Background(), readingprogress.SaveOpts{
+		UserID: userID, ComicID: comicID, ChapterID: ch10, Page: 5,
+	}); err != nil {
+		t.Fatalf("Save ch10: %v", err)
+	}
+
+	chap.chapter = &chapters.Chapter{ID: ch3, ComicID: comicID, PagesNb: 20, Download: 100}
+	got, err := svc.Save(context.Background(), readingprogress.SaveOpts{
+		UserID: userID, ComicID: comicID, ChapterID: ch3, Page: 12,
+	})
+	if err != nil {
+		t.Fatalf("Save ch3: %v", err)
+	}
+
+	if got.ChapterID != ch3 || got.Page != 12 {
+		t.Errorf("Save ch3 = %+v", got)
+	}
+
+	if repo.lastUpsert.ChapterID != ch3 || repo.lastUpsert.UserID != userID {
+		t.Errorf("last upsert = %+v", repo.lastUpsert)
+	}
+
+	if chap.chapter.Download != 100 {
+		t.Fatal("test setup")
+	}
+}
+
+func TestSaveDoesNotReadDownload(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chID := uuid.New()
+	repo := &fakeRepo{getErr: domain.ErrNotFound}
+	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{}, &fakeChapters{
+		chapter: &chapters.Chapter{ID: chID, ComicID: comicID, PagesNb: 10, Download: 40},
+	})
+
+	if _, err := svc.Save(context.Background(), readingprogress.SaveOpts{
+		UserID: uuid.New(), ComicID: comicID, ChapterID: chID, Page: 2,
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if repo.upsertCalls != 1 {
+		t.Fatalf("upsert calls = %d", repo.upsertCalls)
+	}
+}
+
+func TestSaveLowerPageKeepsFurthestAndWrites(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chID := uuid.New()
+	repo := &fakeRepo{
+		existing: &readingprogress.Progress{ChapterID: chID, Page: 20, UpdatedAt: time.Unix(1, 0).UTC()},
+	}
+	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{}, &fakeChapters{
+		chapter: &chapters.Chapter{ID: chID, ComicID: comicID, PagesNb: 30},
+	})
+
+	got, err := svc.Save(context.Background(), readingprogress.SaveOpts{
+		UserID: uuid.New(), ComicID: comicID, ChapterID: chID, Page: 8,
+	})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if got.Page != 20 {
+		t.Errorf("page = %d, want 20", got.Page)
+	}
+
+	if repo.upsertCalls != 1 || repo.lastUpsert.Page != 20 {
+		t.Errorf("upsert page = %d, calls = %d", repo.lastUpsert.Page, repo.upsertCalls)
+	}
+}
+
+func TestSaveGetNotFoundTreatsAsNoStoredRow(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chID := uuid.New()
+	repo := &fakeRepo{getErr: domain.ErrNotFound}
+	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{}, &fakeChapters{
+		chapter: &chapters.Chapter{ID: chID, ComicID: comicID, PagesNb: 10},
+	})
+
+	got, err := svc.Save(context.Background(), readingprogress.SaveOpts{
+		UserID: uuid.New(), ComicID: comicID, ChapterID: chID, Page: 3,
+	})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if got.Page != 3 {
+		t.Errorf("page = %d, want 3", got.Page)
+	}
+
+	if repo.upsertCalls != 1 {
+		t.Fatalf("upsert calls = %d", repo.upsertCalls)
+	}
+}
+
+func TestSaveGetErrorWraps(t *testing.T) {
+	t.Parallel()
+
+	getErr := errors.New("db down")
+	comicID := uuid.New()
+	chID := uuid.New()
+	repo := &fakeRepo{getErr: getErr}
+	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{}, &fakeChapters{
+		chapter: &chapters.Chapter{ID: chID, ComicID: comicID, PagesNb: 10},
+	})
+
+	_, err := svc.Save(context.Background(), readingprogress.SaveOpts{
+		UserID: uuid.New(), ComicID: comicID, ChapterID: chID, Page: 1,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !errors.Is(err, getErr) {
+		t.Errorf("err = %v, want wrapped %v", err, getErr)
+	}
+}
+
+func TestSaveForbiddenWhenNotInLibrary(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	repo := &fakeRepo{}
+	svc := newService(t, repo, &fakeLibrary{inLib: false}, &fakeComics{exists: true}, &fakeChapters{})
+
+	_, err := svc.Save(context.Background(), readingprogress.SaveOpts{
+		UserID: uuid.New(), ComicID: comicID, ChapterID: uuid.New(), Page: 1,
+	})
+	if !errors.Is(err, domain.ErrForbidden) {
+		t.Errorf("err = %v, want ErrForbidden", err)
+	}
+
+	if repo.upsertCalls != 0 {
+		t.Error("upsert on forbidden")
+	}
+}
+
+func TestSaveNotFoundWhenComicMissing(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{}
+	svc := newService(t, repo, &fakeLibrary{inLib: false}, &fakeComics{exists: false}, &fakeChapters{})
+
+	_, err := svc.Save(context.Background(), readingprogress.SaveOpts{
+		UserID: uuid.New(), ComicID: uuid.New(), ChapterID: uuid.New(), Page: 1,
+	})
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSaveUnknownChapter(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{}
+	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{
+		getErr: domain.ErrNotFound,
+	})
+
+	_, err := svc.Save(context.Background(), readingprogress.SaveOpts{
+		UserID: uuid.New(), ComicID: uuid.New(), ChapterID: uuid.New(), Page: 1,
+	})
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+
+	if repo.upsertCalls != 0 {
+		t.Error("upsert for unknown chapter")
+	}
+}
+
+func TestSaveChapterOfAnotherComic(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{}
+	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{}, &fakeChapters{
+		chapter: &chapters.Chapter{ID: uuid.New(), ComicID: uuid.New(), PagesNb: 10},
+	})
+
+	_, err := svc.Save(context.Background(), readingprogress.SaveOpts{
+		UserID: uuid.New(), ComicID: uuid.New(), ChapterID: uuid.New(), Page: 1,
+	})
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSaveRejectsPageAbovePagesNb(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chID := uuid.New()
+	repo := &fakeRepo{}
+	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{}, &fakeChapters{
+		chapter: &chapters.Chapter{ID: chID, ComicID: comicID, PagesNb: 15},
+	})
+
+	_, err := svc.Save(context.Background(), readingprogress.SaveOpts{
+		UserID: uuid.New(), ComicID: comicID, ChapterID: chID, Page: 16,
+	})
+	if !errors.Is(err, readingprogress.ErrInvalid) {
+		t.Errorf("err = %v, want ErrInvalid", err)
+	}
+
+	if repo.upsertCalls != 0 {
+		t.Error("upsert on invalid page")
+	}
+}
+
+func TestListEmptyContinueNull(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	comicID := uuid.New()
+	repo := &fakeRepo{rows: nil}
+	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{}, &fakeChapters{})
+
+	got, err := svc.List(context.Background(), readingprogress.ListOpts{UserID: userID, ComicID: comicID})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if got.Continue != nil {
+		t.Errorf("continue = %+v, want nil", got.Continue)
+	}
+
+	if got.Chapters == nil || len(got.Chapters) != 0 {
+		t.Errorf("chapters = %#v, want empty non-nil", got.Chapters)
+	}
+
+	if repo.listed.UserID != userID || repo.listed.ComicID != comicID {
+		t.Errorf("list opts = %+v", repo.listed)
+	}
+}
+
+func TestListClampsWithoutWrite(t *testing.T) {
+	t.Parallel()
+
+	chID := uuid.New()
+	repo := &fakeRepo{rows: []readingprogress.Progress{{
+		ChapterID: chID,
+		Page:      18,
+		UpdatedAt: time.Unix(2, 0).UTC(),
+	}}}
+	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{}, &fakeChapters{
+		byID: map[uuid.UUID]chapters.Chapter{
+			chID: {ID: chID, PagesNb: 12, Download: 50},
+		},
+	})
+
+	got, err := svc.List(context.Background(), readingprogress.ListOpts{UserID: uuid.New(), ComicID: uuid.New()})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if len(got.Chapters) != 1 || got.Chapters[0].Page != 12 {
+		t.Errorf("chapters = %+v, want page 12", got.Chapters)
+	}
+
+	if got.Continue == nil || got.Continue.Page != 12 || got.Continue.ChapterID != chID {
+		t.Errorf("continue = %+v", got.Continue)
+	}
+
+	if repo.upsertCalls != 0 {
+		t.Error("List must not upsert")
+	}
+}
+
+func TestListForbidden(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{}
+	svc := newService(t, repo, &fakeLibrary{inLib: false}, &fakeComics{exists: true}, &fakeChapters{})
+
+	_, err := svc.List(context.Background(), readingprogress.ListOpts{UserID: uuid.New(), ComicID: uuid.New()})
+	if !errors.Is(err, domain.ErrForbidden) {
+		t.Errorf("err = %v, want ErrForbidden", err)
+	}
+
+	if repo.listCalls != 0 {
+		t.Error("listed without membership")
+	}
+}

--- a/api/pkg/repository/pgmodels/claims_test.go
+++ b/api/pkg/repository/pgmodels/claims_test.go
@@ -4,6 +4,7 @@ package pgmodels_test
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -163,6 +164,7 @@ func TestTableNames(t *testing.T) {
 		"chapter":            pgmodels.Chapter{}.TableName(),
 		"library entry":      pgmodels.LibraryEntry{}.TableName(),
 		"reader settings":    pgmodels.ReaderSettings{}.TableName(),
+		"reading progress":   pgmodels.ReadingProgress{}.TableName(),
 	}
 
 	want := map[string]string{
@@ -175,11 +177,30 @@ func TestTableNames(t *testing.T) {
 		"chapter":            "chapters",
 		"library entry":      "library_entries",
 		"reader settings":    "reader_settings",
+		"reading progress":   "reading_progress",
 	}
 
 	for model, got := range tests {
 		if got != want[model] {
 			t.Errorf("%s: TableName() = %q, want %q", model, got, want[model])
+		}
+	}
+}
+
+func TestReadingProgressConstraints(t *testing.T) {
+	t.Parallel()
+
+	typ := reflect.TypeOf(pgmodels.ReadingProgress{})
+
+	for _, name := range []string{"LibraryEntry", "Chapter"} {
+		field, ok := typ.FieldByName(name)
+		if !ok {
+			t.Fatalf("%s field not found", name)
+		}
+
+		tag := field.Tag.Get("gorm")
+		if !strings.Contains(tag, "constraint:OnDelete:CASCADE") {
+			t.Errorf("%s gorm tag = %q, want constraint:OnDelete:CASCADE", name, tag)
 		}
 	}
 }

--- a/api/pkg/repository/pgmodels/readingprogress.go
+++ b/api/pkg/repository/pgmodels/readingprogress.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package pgmodels
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readingprogress"
+)
+
+type ReadingProgress struct {
+	UpdatedAt      time.Time    `gorm:"not null"`
+	LibraryEntry   LibraryEntry `gorm:"foreignKey:LibraryEntryID;constraint:OnDelete:CASCADE"`
+	Chapter        Chapter      `gorm:"foreignKey:ChapterID;constraint:OnDelete:CASCADE"`
+	ID             uuid.UUID    `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+	LibraryEntryID uuid.UUID    `gorm:"type:uuid;not null;uniqueIndex:idx_reading_progress_entry_chapter,priority:1"`
+	ChapterID      uuid.UUID    `gorm:"type:uuid;not null;uniqueIndex:idx_reading_progress_entry_chapter,priority:2"`
+	Page           int          `gorm:"not null"`
+}
+
+func (ReadingProgress) TableName() string {
+	return "reading_progress"
+}
+
+func (m *ReadingProgress) Domain() readingprogress.Progress {
+	return readingprogress.Progress{
+		ChapterID: m.ChapterID,
+		Page:      m.Page,
+		UpdatedAt: m.UpdatedAt,
+	}
+}

--- a/api/pkg/utils/database/pgdb.go
+++ b/api/pkg/utils/database/pgdb.go
@@ -118,6 +118,7 @@ func (pgdb *PGDB) Migrate() error {
 		&pgmodels.PasswordCreds{},
 		&pgmodels.LibraryEntry{},
 		&pgmodels.ReaderSettings{},
+		&pgmodels.ReadingProgress{},
 	}
 
 	for _, m := range models {

--- a/web/app/features/comics/components/StatusInfos.test.ts
+++ b/web/app/features/comics/components/StatusInfos.test.ts
@@ -3,27 +3,12 @@
 
 import type { VueWrapper } from '@vue/test-utils'
 import type { Comic } from '../types'
-import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
-import { describe, expect, it, vi } from 'vitest'
-import { defineComponent, h } from 'vue'
-import { VApp, VBtn } from 'vuetify/components'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it } from 'vitest'
+import { h } from 'vue'
+import { VApp } from 'vuetify/components'
 import { ASURA_SOURCE_NAME } from '~/constants'
 import StatusInfos from './StatusInfos.vue'
-
-function comicsApiStub(): { refreshById: ReturnType<typeof vi.fn> } {
-  return { refreshById: vi.fn() }
-}
-
-mockNuxtImport('createComicsApi', () => comicsApiStub)
-
-const DeleteStub = defineComponent({
-  name: 'ComicsModalDelete',
-  props: {
-    modelValue: { type: Boolean, default: false },
-    comic: { type: Object, required: true },
-  },
-  template: '<div data-test="delete-modal" />',
-})
 
 function comic(overrides: Partial<Comic> = {}): Comic {
   return {
@@ -45,10 +30,9 @@ function comic(overrides: Partial<Comic> = {}): Comic {
 }
 
 async function mount(value: Comic = comic()): Promise<VueWrapper> {
-  return mountSuspended(
-    { render: () => h(VApp, () => [h(StatusInfos, { modelValue: value })]) },
-    { global: { stubs: { ComicsModalDelete: DeleteStub } } },
-  )
+  return mountSuspended({
+    render: () => h(VApp, () => [h(StatusInfos, { comic: value })]),
+  })
 }
 
 describe('comicsStatusInfos', () => {
@@ -59,13 +43,5 @@ describe('comicsStatusInfos', () => {
     expect(wrapper.text()).toContain('Manhwa')
     expect(wrapper.text()).toContain('Chugong')
     expect(wrapper.text()).toContain('Jang')
-    expect(wrapper.find('[data-test="delete-modal"]').exists()).toBe(true)
-  })
-
-  it('shows the remove-from-library action', async () => {
-    const wrapper = await mount()
-
-    expect(wrapper.text()).toContain('Remove from library')
-    expect(wrapper.findAllComponents(VBtn).some(btn => btn.props('color') === 'error')).toBe(true)
   })
 })

--- a/web/app/features/comics/components/StatusInfos.vue
+++ b/web/app/features/comics/components/StatusInfos.vue
@@ -2,40 +2,10 @@
 <script setup lang="ts">
 import type { Comic } from '../types'
 
-defineEmits<{ deleted: [] }>()
-const comic = defineModel<Comic>({ required: true })
-const { t } = useI18n()
-const toast = useToast()
-const api = createComicsApi()
-
-const showDeleteModal = ref(false)
-const refreshLoading = ref(false)
-
-async function refreshComic(): Promise<void> {
-  refreshLoading.value = true
-
-  const response = await api.refreshById(comic.value.id)
-  if (response.success) {
-    comic.value = response.data
-  } else {
-    console.error(response.error)
-    toast.error(t('error.unknown'))
-  }
-
-  refreshLoading.value = false
-}
-
-const canRefresh = computed(() => comic.value.status !== 'hiatus' && comic.value.status !== 'completed' && comic.value.status !== 'cancelled')
+defineProps<{ comic: Comic }>()
 </script>
 
 <template>
-  <ComicsModalDelete
-    v-if="comic"
-    v-model="showDeleteModal"
-    :comic
-    @deleted="$emit('deleted')"
-  />
-
   <div
     class="d-flex flex-column ga-4 pa-4 bg-surface"
     style="border-radius: 12px"
@@ -45,27 +15,6 @@ const canRefresh = computed(() => comic.value.status !== 'hiatus' && comic.value
       <ComicsChipType :type="comic.type" />
     </div>
 
-    <div class="d-flex ga-2 ga-4 align-center flex-wrap">
-      <VBtn
-        v-if="canRefresh"
-        v-tooltip="$t('comics.refresh.title')"
-        icon="fa6-solid:repeat"
-        color="secondary"
-        size="small"
-        class="border-thin-secondary"
-        @click="refreshComic"
-      />
-
-      <VBtn
-        variant="tonal"
-        class="border-thin-error"
-        color="error"
-        prepend-icon="fa6-solid:trash"
-        size="large"
-        :text="$t('comics.remove.title')"
-        @click="showDeleteModal = true"
-      />
-    </div>
     <div v-if="comic.author" class="d-flex ga-2 justify-space-between">
       <span class="text-body-large text-medium-emphasis text-uppercase text-truncate">{{ $t('comic.fields.author') }}</span>
       <span class="text-body-large font-weight-bold text-truncate">{{ comic.author }}</span>

--- a/web/app/pages/comic/[id]/index.test.ts
+++ b/web/app/pages/comic/[id]/index.test.ts
@@ -132,8 +132,8 @@ describe('comicPage', () => {
     const wrapper = await mount()
 
     await vi.waitFor(() => expect(wrapper.find('[data-test="status-infos"]').exists()).toBe(true))
-    expect(buttons(wrapper).some(btn => btn.props('icon') === 'fa6-solid:repeat')).toBe(true)
-    expect(buttons(wrapper).some(btn => btn.props('icon') === 'fa6-solid:trash' && btn.props('color') === 'error')).toBe(true)
+    expect(buttons(wrapper).some(btn => (btn as any).props('icon') === 'fa6-solid:repeat')).toBe(true)
+    expect(buttons(wrapper).some(btn => (btn as any).props('icon') === 'fa6-solid:trash' && (btn as any).props('color') === 'error')).toBe(true)
     expect(wrapper.find('[data-test="delete-modal"]').exists()).toBe(true)
   })
 
@@ -143,7 +143,7 @@ describe('comicPage', () => {
     const wrapper = await mount()
 
     await vi.waitFor(() => expect(wrapper.find('[data-test="status-infos"]').exists()).toBe(true))
-    expect(buttons(wrapper).some(btn => btn.props('icon') === 'fa6-solid:repeat')).toBe(false)
+    expect(buttons(wrapper).some(btn => (btn as any).props('icon') === 'fa6-solid:repeat')).toBe(false)
   })
 
   it('redirects to the library when the comic is missing', async () => {

--- a/web/app/pages/comic/[id]/index.test.ts
+++ b/web/app/pages/comic/[id]/index.test.ts
@@ -6,15 +6,16 @@ import type { Comic } from '~/features/comics/types'
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
-import { VApp } from 'vuetify/components'
+import { VApp, VBtn } from 'vuetify/components'
 import { ASURA_SOURCE_NAME } from '~/constants'
 import ComicPage from './index.vue'
 
-const { getById, smAndDown, navigateTo, params, query } = await vi.hoisted(async () => {
+const { getById, refreshById, smAndDown, navigateTo, params, query } = await vi.hoisted(async () => {
   const { ref } = await import('vue')
 
   return {
     getById: vi.fn(),
+    refreshById: vi.fn(),
     smAndDown: ref(false),
     navigateTo: vi.fn(),
     params: { id: 'c1' },
@@ -22,8 +23,8 @@ const { getById, smAndDown, navigateTo, params, query } = await vi.hoisted(async
   }
 })
 
-function comicsApiStub(): { getById: typeof getById } {
-  return { getById }
+function comicsApiStub(): { getById: typeof getById, refreshById: typeof refreshById } {
+  return { getById, refreshById }
 }
 
 function displayStub(): { smAndDown: typeof smAndDown } {
@@ -41,9 +42,8 @@ mockNuxtImport('navigateTo', () => navigateTo)
 
 const StatusStub = defineComponent({
   name: 'ComicsStatusInfos',
-  props: { modelValue: { type: Object, required: true } },
-  emits: ['deleted'],
-  template: '<div data-test="status-infos">{{ modelValue.title }}</div>',
+  props: { comic: { type: Object, required: true } },
+  template: '<div data-test="status-infos">{{ comic.title }}</div>',
 })
 
 const GeneralStub = defineComponent({
@@ -56,6 +56,15 @@ const ChaptersStub = defineComponent({
   name: 'ComicsChapters',
   props: { id: { type: String, required: true } },
   template: '<div data-test="chapters">{{ id }}</div>',
+})
+
+const DeleteStub = defineComponent({
+  name: 'ComicsModalDelete',
+  props: {
+    modelValue: { type: Boolean, default: false },
+    comic: { type: Object, required: true },
+  },
+  template: '<div data-test="delete-modal" />',
 })
 
 function comic(overrides: Partial<Comic> = {}): Comic {
@@ -86,6 +95,7 @@ async function mount(): Promise<VueWrapper> {
           ComicsStatusInfos: StatusStub,
           ComicsGeneralInfos: GeneralStub,
           ComicsChapters: ChaptersStub,
+          ComicsModalDelete: DeleteStub,
           OrganismPageLayout: false,
         },
       },
@@ -93,13 +103,19 @@ async function mount(): Promise<VueWrapper> {
   )
 }
 
+function buttons(wrapper: VueWrapper): ReturnType<VueWrapper['findAllComponents']> {
+  return wrapper.findAllComponents(VBtn)
+}
+
 beforeEach(() => {
   getById.mockReset()
+  refreshById.mockReset()
   navigateTo.mockReset()
   smAndDown.value = false
   params.id = 'c1'
   query.from = undefined
   getById.mockResolvedValue({ success: true, data: comic() })
+  refreshById.mockResolvedValue({ success: true, data: comic() })
 })
 
 describe('comicPage', () => {
@@ -110,6 +126,24 @@ describe('comicPage', () => {
     expect(getById).toHaveBeenCalledWith('c1')
     expect(wrapper.find('[data-test="general-infos"]').exists()).toBe(true)
     expect(wrapper.find('[data-test="chapters"]').text()).toBe('c1')
+  })
+
+  it('shows the refresh and remove-from-library actions', async () => {
+    const wrapper = await mount()
+
+    await vi.waitFor(() => expect(wrapper.find('[data-test="status-infos"]').exists()).toBe(true))
+    expect(buttons(wrapper).some(btn => btn.props('icon') === 'fa6-solid:repeat')).toBe(true)
+    expect(buttons(wrapper).some(btn => btn.props('icon') === 'fa6-solid:trash' && btn.props('color') === 'error')).toBe(true)
+    expect(wrapper.find('[data-test="delete-modal"]').exists()).toBe(true)
+  })
+
+  it('hides the refresh action when the comic cannot be refreshed', async () => {
+    getById.mockResolvedValue({ success: true, data: comic({ status: 'completed' }) })
+
+    const wrapper = await mount()
+
+    await vi.waitFor(() => expect(wrapper.find('[data-test="status-infos"]').exists()).toBe(true))
+    expect(buttons(wrapper).some(btn => btn.props('icon') === 'fa6-solid:repeat')).toBe(false)
   })
 
   it('redirects to the library when the comic is missing', async () => {

--- a/web/app/pages/comic/[id]/index.vue
+++ b/web/app/pages/comic/[id]/index.vue
@@ -68,6 +68,32 @@ const backRoutes = computed((): PageLayoutBackRoute[] => from.value === FEED_ROU
       to: '/library',
       name: t('library.title'),
     }])
+
+const canRefresh = computed(() => comic.value
+  && comic.value.status !== 'hiatus'
+  && comic.value.status !== 'completed'
+  && comic.value.status !== 'cancelled')
+
+const refreshLoading = ref(false)
+async function refreshComic(): Promise<void> {
+  if (!comic.value) {
+    return
+  }
+
+  refreshLoading.value = true
+
+  const response = await api.refreshById(comic.value.id)
+  if (response.success) {
+    comic.value = response.data
+  } else {
+    console.error(response.error)
+    toast.error(t('error.unknown'))
+  }
+
+  refreshLoading.value = false
+}
+
+const showDeleteModal = ref(false)
 </script>
 
 <template>
@@ -82,7 +108,13 @@ const backRoutes = computed((): PageLayoutBackRoute[] => from.value === FEED_ROU
       v-if="comic"
       :class="smAndDown ? 'd-flex flex-column ga-8 px-6' : 'comic-infos-grid'"
     >
-      <div v-if="!smAndDown" class="d-flex flex-column ga-6">
+      <ComicsModalDelete
+        v-model="showDeleteModal"
+        :comic
+        @deleted="onDelete"
+      />
+
+      <div v-if="!smAndDown" class="d-flex flex-column ga-4">
         <VImg
           v-if="coverSrc"
           :src="coverSrc"
@@ -94,14 +126,34 @@ const backRoutes = computed((): PageLayoutBackRoute[] => from.value === FEED_ROU
           @error="coverSrc = defaultCover"
         />
 
+        <div class="d-flex justify-space-between ga-4 w-100 pa-2">
+          <VBtn
+            v-if="canRefresh"
+            v-tooltip="$t('comics.refresh.title')"
+            icon="fa6-solid:repeat"
+            color="secondary"
+            size="small"
+            class="border-thin-secondary"
+            @click="refreshComic"
+          />
+
+          <VBtn
+            v-tooltip="$t('comics.remove.title')"
+            class="border-thin-error"
+            color="error"
+            icon="fa6-solid:trash"
+            size="small"
+            @click="showDeleteModal = true"
+          />
+        </div>
+
         <ComicsStatusInfos
           v-if="!smAndDown"
-          v-model="comic"
-          @deleted="onDelete"
+          :comic
         />
       </div>
 
-      <div class="d-flex flex-column ga-6 w-100">
+      <div class="d-flex flex-column w-100" :class="smAndDown ? 'ga-4' : 'ga-6'">
         <div class="d-flex ga-4 align-center">
           <VImg
             v-if="coverSrc && smAndDown"
@@ -115,12 +167,42 @@ const backRoutes = computed((): PageLayoutBackRoute[] => from.value === FEED_ROU
             @error="coverSrc = defaultCover"
           />
 
-          <span class="font-title font-weight-bold" :class="{ 'text-display-medium': !smAndDown, 'text-title-large': smAndDown }">{{ comic.title }}</span>
+          <span
+            class="font-title font-weight-bold"
+            :class="{
+              'text-display-medium': !smAndDown,
+              'text-title-large': smAndDown,
+            }"
+          >{{ comic.title }}</span>
         </div>
+
+        <div
+          v-if="smAndDown"
+          class="d-flex justify-space-between ga-4 w-100 pa-2"
+        >
+          <VBtn
+            v-if="canRefresh"
+            v-tooltip="$t('comics.refresh.title')"
+            icon="fa6-solid:repeat"
+            color="secondary"
+            size="small"
+            class="border-thin-secondary"
+            @click="refreshComic"
+          />
+
+          <VBtn
+            v-tooltip="$t('comics.remove.title')"
+            class="border-thin-error"
+            color="error"
+            icon="fa6-solid:trash"
+            size="small"
+            @click="showDeleteModal = true"
+          />
+        </div>
+
         <ComicsStatusInfos
           v-if="smAndDown"
-          v-model="comic"
-          @deleted="onDelete"
+          :comic
         />
         <ComicsGeneralInfos :comic />
         <ComicsChapters :id="route.params.id" />


### PR DESCRIPTION
Closes #71

## Summary

- Add reading progress domain, PostgreSQL repository, service, and HTTP handlers for `GET` / `PUT /api/comics/{id}/progress`
- Persist last page per chapter on the library entry; `continue` returns the chapter with the most recent `updatedAt`
- Enforce library membership (403/404 aligned with existing comic routes); validate page ≥ 1 and chapter belongs to comic (400)
- Refactor comic page layout: move refresh/delete actions out of `StatusInfos` into the page shell

## Test plan

- [x] `go test ./...` and `golangci-lint run ./...` pass in `api/`
- [x] Save ch. 10 p. 5 then ch. 3 p. 12 → both rows kept; `continue` points at ch. 3
- [x] Re-PUT ch. 10 p. 6 → only that row updated; `continue` switches to ch. 10
- [x] Progress is scoped per user; comic not in library returns same status as other `/api/comics/{id}` routes
- [x] Web comic page tests pass (`web/app/pages/comic/[id]/index.test.ts`, `StatusInfos.test.ts`)