### PR TITLE
feat(chapter): local page HTTP, GET by id, and chapter page UI

### DIFF
--- a/api/cmd/uchiyomiserver/setup.go
+++ b/api/cmd/uchiyomiserver/setup.go
@@ -919,6 +919,7 @@ func setupCtrls(deps ctrlsDeps) (*ctrls, error) {
 		httpchapters.Deps{
 			Logger:          deps.Logger,
 			ChaptersService: deps.ChaptersService,
+			Progress:        deps.ReadingProgressService,
 		},
 	)
 	if err != nil {
@@ -955,8 +956,9 @@ func setupCtrls(deps ctrlsDeps) (*ctrls, error) {
 
 	readingProgressCtrl, err := httpreadingprogress.New(
 		httpreadingprogress.Config{
-			Endpoint:    "/comics",
-			Middlewares: chi.Middlewares{authenticator.Middleware},
+			Endpoint:         "/comics",
+			ChaptersEndpoint: "/chapters",
+			Middlewares:      chi.Middlewares{authenticator.Middleware},
 		},
 		httpreadingprogress.Deps{Logger: deps.Logger, Service: deps.ReadingProgressService},
 	)

--- a/api/cmd/uchiyomiserver/setup.go
+++ b/api/cmd/uchiyomiserver/setup.go
@@ -1029,6 +1029,7 @@ func setupChapters(deps chaptersDeps) (*chapters.Service, *download.App, error) 
 		ChapterDownloader: worker,
 		LibraryRepository: deps.LibraryRepository,
 		ComicLookup:       comicsExistsLookup{repo: deps.ComicsRepository},
+		PageStore:         download.DiskPages{Dir: deps.DownloadsDir},
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("chapters.NewService: %w", err)

--- a/api/cmd/uchiyomiserver/setup_internal_test.go
+++ b/api/cmd/uchiyomiserver/setup_internal_test.go
@@ -92,7 +92,13 @@ func (stubReaderSettingsService) Replace(context.Context, readersettings.Replace
 type stubReadingProgressService struct{}
 
 func (stubReadingProgressService) List(context.Context, readingprogress.ListOpts) (readingprogress.ListResult, error) {
-	return readingprogress.ListResult{Chapters: []readingprogress.Progress{}}, nil
+	return readingprogress.ListResult{}, nil
+}
+
+func (stubReadingProgressService) MapByChapterIDs(
+	context.Context, readingprogress.MapOpts,
+) (map[uuid.UUID]readingprogress.Progress, error) {
+	return map[uuid.UUID]readingprogress.Progress{}, nil
 }
 
 func (stubReadingProgressService) Save(context.Context, readingprogress.SaveOpts) (readingprogress.Progress, error) {

--- a/api/pkg/core/app_internal_test.go
+++ b/api/pkg/core/app_internal_test.go
@@ -59,18 +59,33 @@ func TestRouterMountsTheReaderSettingsRoute(t *testing.T) {
 	}
 }
 
-func TestRouterMountsTheReadingProgressRoute(t *testing.T) {
+func TestRouterMountsTheChapterProgressRoute(t *testing.T) {
 	t.Parallel()
 
 	app, _ := newTestApp(t, &fakeDB{}, gatePort)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/comics/"+uuid.Nil.String()+"/progress", nil)
+	req := httptest.NewRequest(http.MethodPut, "/api/chapters/"+uuid.Nil.String()+"/progress", nil)
 	rec := httptest.NewRecorder()
 
 	app.newRouter(nil).ServeHTTP(rec, req)
 
 	if rec.Code == http.StatusNotFound {
-		t.Errorf("GET /api/comics/{id}/progress = 404, want the route to be mounted")
+		t.Errorf("PUT /api/chapters/{id}/progress = 404, want the route to be mounted")
+	}
+}
+
+func TestRouterMountsTheChapterByIDRoute(t *testing.T) {
+	t.Parallel()
+
+	app, _ := newTestApp(t, &fakeDB{}, gatePort)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/chapters/"+uuid.Nil.String(), nil)
+	rec := httptest.NewRecorder()
+
+	app.newRouter(nil).ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusNotFound {
+		t.Errorf("GET /api/chapters/{id} = 404, want the route to be mounted")
 	}
 }
 

--- a/api/pkg/core/chapters/domain.go
+++ b/api/pkg/core/chapters/domain.go
@@ -41,6 +41,22 @@ type ChapterDownloader interface {
 	Resume(context.Context, uuid.UUID) error
 }
 
+type ChapterDetail struct {
+	PreviousID *uuid.UUID
+	NextID     *uuid.UUID
+	Chapter    Chapter
+}
+
+type PageStore interface {
+	OpenPage(comicID uuid.UUID, chapterNumber float64, index int) (diskPath, contentType string, err error)
+}
+
+type ServePageOpts struct {
+	UserID    uuid.UUID
+	ChapterID uuid.UUID
+	Index     int
+}
+
 type ChaptersService interface {
 	CreateAll(context.Context, uuid.UUID, []sources.SourceChapter) ([]Chapter, error)
 	ListByComicID(context.Context, uuid.UUID) ([]Chapter, error)
@@ -52,6 +68,8 @@ type ChaptersService interface {
 	GetByIds(context.Context, GetByIdsOpts) ([]Chapter, error)
 	ListForLibrary(context.Context, ListForLibraryOpts) ([]Chapter, error)
 	GetForLibrary(context.Context, GetForLibraryOpts) (*Chapter, error)
+	GetDetailForLibrary(context.Context, GetForLibraryOpts) (*ChapterDetail, error)
+	ServePage(context.Context, ServePageOpts) (diskPath, contentType string, err error)
 }
 
 type ComicLookup interface {

--- a/api/pkg/core/chapters/domain.go
+++ b/api/pkg/core/chapters/domain.go
@@ -51,6 +51,7 @@ type ChaptersService interface {
 	RetryDownload(context.Context, RetryDownloadOpts) error
 	GetByIds(context.Context, GetByIdsOpts) ([]Chapter, error)
 	ListForLibrary(context.Context, ListForLibraryOpts) ([]Chapter, error)
+	GetForLibrary(context.Context, GetForLibraryOpts) (*Chapter, error)
 }
 
 type ComicLookup interface {
@@ -70,6 +71,11 @@ type GetByIdsOpts struct {
 type ListForLibraryOpts struct {
 	UserID  uuid.UUID
 	ComicID uuid.UUID
+}
+
+type GetForLibraryOpts struct {
+	UserID    uuid.UUID
+	ChapterID uuid.UUID
 }
 
 type CreateOpts struct {

--- a/api/pkg/core/chapters/download/app_test.go
+++ b/api/pkg/core/chapters/download/app_test.go
@@ -71,6 +71,16 @@ func (f *fakeChaptersService) GetForLibrary(context.Context, chapters.GetForLibr
 	panic("GetForLibrary must not be called")
 }
 
+func (f *fakeChaptersService) GetDetailForLibrary(
+	context.Context, chapters.GetForLibraryOpts,
+) (*chapters.ChapterDetail, error) {
+	panic("GetDetailForLibrary must not be called")
+}
+
+func (f *fakeChaptersService) ServePage(context.Context, chapters.ServePageOpts) (string, string, error) {
+	panic("ServePage must not be called")
+}
+
 type blockingWorker struct {
 	started chan struct{}
 }

--- a/api/pkg/core/chapters/download/app_test.go
+++ b/api/pkg/core/chapters/download/app_test.go
@@ -67,6 +67,10 @@ func (f *fakeChaptersService) ListForLibrary(context.Context, chapters.ListForLi
 	panic("ListForLibrary must not be called")
 }
 
+func (f *fakeChaptersService) GetForLibrary(context.Context, chapters.GetForLibraryOpts) (*chapters.Chapter, error) {
+	panic("GetForLibrary must not be called")
+}
+
 type blockingWorker struct {
 	started chan struct{}
 }

--- a/api/pkg/core/chapters/download/storage.go
+++ b/api/pkg/core/chapters/download/storage.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"net/url"
 	"os"
@@ -15,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 )
 
 func comicDir(baseDir string, comicID uuid.UUID) string {
@@ -109,6 +111,41 @@ func deleteComicDir(dir string) error {
 	}
 
 	return nil
+}
+
+type DiskPages struct {
+	Dir string
+}
+
+func (s DiskPages) OpenPage(comicID uuid.UUID, chapterNumber float64, index int) (string, string, error) {
+	pattern := filepath.Join(chapterDir(s.Dir, comicID, chapterNumber), pageFilename(index, ".*"))
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return "", "", fmt.Errorf("filepath.Glob %s: %w", pattern, err)
+	}
+
+	var files []string
+	for _, match := range matches {
+		st, err := os.Stat(match)
+		if err != nil {
+			return "", "", fmt.Errorf("os.Stat %s: %w", match, err)
+		}
+
+		if st.Mode().IsRegular() {
+			files = append(files, match)
+		}
+	}
+
+	if len(files) != 1 {
+		return "", "", domain.ErrNotFound
+	}
+
+	contentType := mime.TypeByExtension(filepath.Ext(files[0]))
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+
+	return files[0], contentType, nil
 }
 
 func downloadPage(ctx context.Context, client *http.Client, imageURL, destPath string) error {

--- a/api/pkg/core/chapters/download/storage_internal_test.go
+++ b/api/pkg/core/chapters/download/storage_internal_test.go
@@ -3,7 +3,13 @@
 package download
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 )
 
 func TestProgressPercent(t *testing.T) {
@@ -41,5 +47,43 @@ func TestParsePageIndex(t *testing.T) {
 
 	if _, ok := parsePageIndex("bad-name.webp"); ok {
 		t.Fatal("parsePageIndex accepted invalid file name")
+	}
+}
+
+func TestDiskPagesOpenPage(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	comicID := uuid.New()
+	pageDir := chapterDir(dir, comicID, 1.5)
+	if err := os.MkdirAll(pageDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	path := filepath.Join(pageDir, "002.png")
+	if err := os.WriteFile(path, []byte("img"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	gotPath, contentType, err := DiskPages{Dir: dir}.OpenPage(comicID, 1.5, 2)
+	if err != nil {
+		t.Fatalf("OpenPage: %v", err)
+	}
+
+	if gotPath != path {
+		t.Errorf("path = %q, want %q", gotPath, path)
+	}
+
+	if contentType != "image/png" {
+		t.Errorf("contentType = %q", contentType)
+	}
+}
+
+func TestDiskPagesOpenPageMissing(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := DiskPages{Dir: t.TempDir()}.OpenPage(uuid.New(), 1, 1)
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("OpenPage = %v, want ErrNotFound", err)
 	}
 }

--- a/api/pkg/core/chapters/gateway/http/controller.go
+++ b/api/pkg/core/chapters/gateway/http/controller.go
@@ -8,8 +8,11 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 	"slices"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -95,6 +98,7 @@ func (c *Controller) InitRouter(r chi.Router) {
 		r.Use(c.cfg.Middlewares...)
 
 		r.Get("/", c.listForLibrary)
+		r.Get("/{id}/pages/{index}", c.servePage)
 		r.Get("/{id}", c.getByID)
 		r.Post("/{id}/retry", c.retryDownload)
 		r.Post("/list", c.postList)
@@ -247,7 +251,7 @@ func (c *Controller) getByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	chapter, err := c.deps.ChaptersService.GetForLibrary(ctx, chapters.GetForLibraryOpts{
+	chapter, err := c.deps.ChaptersService.GetDetailForLibrary(ctx, chapters.GetForLibraryOpts{
 		UserID:    user.ID,
 		ChapterID: chapterID,
 	})
@@ -270,7 +274,7 @@ func (c *Controller) getByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	item, err := c.chapterItem(r.Context(), user.ID, *chapter)
+	item, err := c.chapterDetailItem(r.Context(), user.ID, *chapter)
 	if err != nil {
 		c.deps.Logger.Error("failed to map reading progress", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
@@ -279,6 +283,68 @@ func (c *Controller) getByID(w http.ResponseWriter, r *http.Request) {
 	}
 
 	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, item)
+}
+
+func (c *Controller) servePage(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user, ok := httpsession.UserFrom(ctx)
+	if !ok {
+		c.deps.Logger.Error("user not found in context")
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+
+		return
+	}
+
+	id, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "id must be a valid UUID")
+
+		return
+	}
+
+	index, err := strconv.Atoi(chi.URLParam(r, "index"))
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusNotFound, "page not found")
+
+		return
+	}
+
+	diskPath, contentType, err := c.deps.ChaptersService.ServePage(ctx, chapters.ServePageOpts{
+		UserID:    user.ID,
+		ChapterID: id,
+		Index:     index,
+	})
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusNotFound, "page not found")
+
+			return
+		}
+
+		if errors.Is(err, domain.ErrForbidden) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusForbidden, "comic not in library")
+
+			return
+		}
+
+		c.deps.Logger.Error("failed to serve chapter page", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	f, err := os.Open(diskPath)
+	if err != nil {
+		c.deps.Logger.Error("failed to open chapter page", "path", diskPath, "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	defer f.Close()
+
+	w.Header().Set("Content-Type", contentType)
+	http.ServeContent(w, r, diskPath, time.Time{}, f)
 }
 
 func (c *Controller) writeChapterList(
@@ -293,6 +359,22 @@ func (c *Controller) writeChapterList(
 	}
 
 	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, chapterHTTPList(res, byID))
+}
+
+func (c *Controller) chapterDetailItem(
+	ctx context.Context, userID uuid.UUID, detail chapters.ChapterDetail,
+) (chapterDetailResponse, error) {
+	item, err := c.chapterItem(ctx, userID, detail.Chapter)
+	if err != nil {
+		return chapterDetailResponse{}, fmt.Errorf("c.chapterItem: %w", err)
+	}
+
+	return chapterDetailResponse{
+		postListResponseChapter: item,
+		PageURLs:                pageURLs(detail.Chapter.ID, detail.Chapter.Download, detail.Chapter.PagesNb),
+		NextChapterID:           detail.NextID,
+		PreviousChapterID:       detail.PreviousID,
+	}, nil
 }
 
 func (c *Controller) chapterItem(

--- a/api/pkg/core/chapters/gateway/http/controller.go
+++ b/api/pkg/core/chapters/gateway/http/controller.go
@@ -3,6 +3,7 @@
 package http
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -15,6 +16,7 @@ import (
 	httpsession "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readingprogress"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/httputils"
 )
@@ -44,14 +46,23 @@ func (cfg *Config) Validate() error {
 	return nil
 }
 
+type ProgressReader interface {
+	MapByChapterIDs(context.Context, readingprogress.MapOpts) (map[uuid.UUID]readingprogress.Progress, error)
+}
+
 type Deps struct {
 	ChaptersService chapters.ChaptersService
+	Progress        ProgressReader
 	Logger          *slog.Logger
 }
 
 func (deps *Deps) Validate() error {
 	if deps.ChaptersService == nil {
 		return errors.New("chapters service is required")
+	}
+
+	if deps.Progress == nil {
+		return errors.New("progress is required")
 	}
 
 	if deps.Logger == nil {
@@ -84,6 +95,7 @@ func (c *Controller) InitRouter(r chi.Router) {
 		r.Use(c.cfg.Middlewares...)
 
 		r.Get("/", c.listForLibrary)
+		r.Get("/{id}", c.getByID)
 		r.Post("/{id}/retry", c.retryDownload)
 		r.Post("/list", c.postList)
 	})
@@ -165,7 +177,7 @@ func (c *Controller) postList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, chapterHTTPList(res))
+	c.writeChapterList(w, r, user.ID, res)
 }
 
 func (c *Controller) listForLibrary(w http.ResponseWriter, r *http.Request) {
@@ -215,24 +227,128 @@ func (c *Controller) listForLibrary(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, chapterHTTPList(res))
+	c.writeChapterList(w, r, user.ID, res)
 }
 
-func chapterHTTPList(res []chapters.Chapter) []postListResponseChapter {
+func (c *Controller) getByID(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user, ok := httpsession.UserFrom(ctx)
+	if !ok {
+		c.deps.Logger.Error("user not found in context")
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+
+		return
+	}
+
+	chapterID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "id must be a valid UUID")
+
+		return
+	}
+
+	chapter, err := c.deps.ChaptersService.GetForLibrary(ctx, chapters.GetForLibraryOpts{
+		UserID:    user.ID,
+		ChapterID: chapterID,
+	})
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusNotFound, "chapter not found")
+
+			return
+		}
+
+		if errors.Is(err, domain.ErrForbidden) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusForbidden, "comic not in library")
+
+			return
+		}
+
+		c.deps.Logger.Error("failed to get chapter", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	item, err := c.chapterItem(r.Context(), user.ID, *chapter)
+	if err != nil {
+		c.deps.Logger.Error("failed to map reading progress", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, item)
+}
+
+func (c *Controller) writeChapterList(
+	w http.ResponseWriter, r *http.Request, userID uuid.UUID, res []chapters.Chapter,
+) {
+	byID, err := c.progressByIDs(r.Context(), userID, res)
+	if err != nil {
+		c.deps.Logger.Error("failed to map reading progress", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, chapterHTTPList(res, byID))
+}
+
+func (c *Controller) chapterItem(
+	ctx context.Context, userID uuid.UUID, chapter chapters.Chapter,
+) (postListResponseChapter, error) {
+	byID, err := c.progressByIDs(ctx, userID, []chapters.Chapter{chapter})
+	if err != nil {
+		return postListResponseChapter{}, err
+	}
+
+	return chapterHTTPItem(chapter, byID), nil
+}
+
+func (c *Controller) progressByIDs(
+	ctx context.Context, userID uuid.UUID, res []chapters.Chapter,
+) (map[uuid.UUID]readingprogress.Progress, error) {
+	ids := make([]uuid.UUID, len(res))
+	for i := range res {
+		ids[i] = res[i].ID
+	}
+
+	byID, err := c.deps.Progress.MapByChapterIDs(ctx, readingprogress.MapOpts{
+		UserID: userID,
+		IDs:    ids,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("c.deps.Progress.MapByChapterIDs: %w", err)
+	}
+
+	return byID, nil
+}
+
+func chapterHTTPList(
+	res []chapters.Chapter, byID map[uuid.UUID]readingprogress.Progress,
+) []postListResponseChapter {
 	out := make([]postListResponseChapter, 0, len(res))
 	for _, chapter := range res {
-		out = append(out, postListResponseChapter{
-			PublishedAt:       chapter.PublishedAt,
-			EarlyAccessUntil:  utils.OptionalTime(chapter.EarlyAccessUntil),
-			SourceChapterSlug: chapter.SourceChapterSlug,
-			Title:             chapter.Title,
-			Number:            chapter.Number,
-			PagesNb:           chapter.PagesNb,
-			Download:          chapter.Download,
-			ID:                chapter.ID,
-			ComicID:           chapter.ComicID,
-		})
+		out = append(out, chapterHTTPItem(chapter, byID))
 	}
 
 	return out
+}
+
+func chapterHTTPItem(
+	chapter chapters.Chapter, byID map[uuid.UUID]readingprogress.Progress,
+) postListResponseChapter {
+	return postListResponseChapter{
+		PublishedAt:       chapter.PublishedAt,
+		EarlyAccessUntil:  utils.OptionalTime(chapter.EarlyAccessUntil),
+		Progress:          progressPayload(chapter.ID, chapter.PagesNb, byID),
+		SourceChapterSlug: chapter.SourceChapterSlug,
+		Title:             chapter.Title,
+		Number:            chapter.Number,
+		PagesNb:           chapter.PagesNb,
+		Download:          chapter.Download,
+		ID:                chapter.ID,
+		ComicID:           chapter.ComicID,
+	}
 }

--- a/api/pkg/core/chapters/gateway/http/controller_test.go
+++ b/api/pkg/core/chapters/gateway/http/controller_test.go
@@ -12,6 +12,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -36,16 +38,23 @@ const (
 )
 
 type stubChaptersService struct {
-	retryErr               error
-	getByIdsErr            error
-	listForLibraryErr      error
-	getForLibraryErr       error
-	getByIdsResult         []chapters.Chapter
-	listForLibraryResult   []chapters.Chapter
-	getForLibraryResult    *chapters.Chapter
-	lastGetByIdsOpts       chapters.GetByIdsOpts
-	lastListForLibraryOpts chapters.ListForLibraryOpts
-	lastGetForLibraryOpts  chapters.GetForLibraryOpts
+	retryErr                    error
+	getByIdsErr                 error
+	listForLibraryErr           error
+	getForLibraryErr            error
+	getDetailForLibraryErr      error
+	servePageErr                error
+	getByIdsResult              []chapters.Chapter
+	listForLibraryResult        []chapters.Chapter
+	getForLibraryResult         *chapters.Chapter
+	getDetailForLibraryResult   *chapters.ChapterDetail
+	servePagePath               string
+	servePageType               string
+	lastGetByIdsOpts            chapters.GetByIdsOpts
+	lastListForLibraryOpts      chapters.ListForLibraryOpts
+	lastGetForLibraryOpts       chapters.GetForLibraryOpts
+	lastGetDetailForLibraryOpts chapters.GetForLibraryOpts
+	lastServePageOpts           chapters.ServePageOpts
 }
 
 func (s *stubChaptersService) CreateAll(
@@ -98,6 +107,20 @@ func (s *stubChaptersService) GetForLibrary(
 	s.lastGetForLibraryOpts = opts
 
 	return s.getForLibraryResult, s.getForLibraryErr
+}
+
+func (s *stubChaptersService) GetDetailForLibrary(
+	_ context.Context, opts chapters.GetForLibraryOpts,
+) (*chapters.ChapterDetail, error) {
+	s.lastGetDetailForLibraryOpts = opts
+
+	return s.getDetailForLibraryResult, s.getDetailForLibraryErr
+}
+
+func (s *stubChaptersService) ServePage(_ context.Context, opts chapters.ServePageOpts) (string, string, error) {
+	s.lastServePageOpts = opts
+
+	return s.servePagePath, s.servePageType, s.servePageErr
 }
 
 type stubSessionService struct {
@@ -320,6 +343,7 @@ func TestRetryDownloadInternalError(t *testing.T) {
 	}
 }
 
+//nolint:govet // JSON test DTO; field order matches the API payload, not alignment
 type postListHTTPChapter struct {
 	PublishedAt      time.Time  `json:"publishedAt"`
 	EarlyAccessUntil *time.Time `json:"earlyAccessUntil"`
@@ -327,13 +351,16 @@ type postListHTTPChapter struct {
 		UpdatedAt time.Time `json:"updatedAt"`
 		Page      int       `json:"page"`
 	} `json:"progress"`
-	SourceChapterSlug string    `json:"sourceChapterSlug"`
-	Title             string    `json:"title"`
-	Number            float64   `json:"number"`
-	PagesNb           int       `json:"pagesNb"`
-	Download          int       `json:"download"`
-	ID                uuid.UUID `json:"id"`
-	ComicID           uuid.UUID `json:"comicId"`
+	NextChapterID     *uuid.UUID `json:"nextChapterId"`
+	PreviousChapterID *uuid.UUID `json:"previousChapterId"`
+	PageURLs          []string   `json:"pageUrls"`
+	SourceChapterSlug string     `json:"sourceChapterSlug"`
+	Title             string     `json:"title"`
+	Number            float64    `json:"number"`
+	PagesNb           int        `json:"pagesNb"`
+	Download          int        `json:"download"`
+	ID                uuid.UUID  `json:"id"`
+	ComicID           uuid.UUID  `json:"comicId"`
 }
 
 func TestPostListRequiresAuthentication(t *testing.T) {
@@ -765,7 +792,7 @@ func TestGetByIDNotFound(t *testing.T) {
 
 	user := &users.User{ID: uuid.New(), Name: chaptersUsername}
 	r := newChaptersTestRouter(t, &stubChaptersService{
-		getForLibraryErr: domain.ErrNotFound,
+		getDetailForLibraryErr: domain.ErrNotFound,
 	}, chaptersAuthenticatorFor(t, user))
 
 	req := httptest.NewRequest(http.MethodGet, chaptersEndpoint+"/"+uuid.New().String(), nil)
@@ -783,7 +810,7 @@ func TestGetByIDForbidden(t *testing.T) {
 
 	user := &users.User{ID: uuid.New(), Name: chaptersUsername}
 	r := newChaptersTestRouter(t, &stubChaptersService{
-		getForLibraryErr: domain.ErrForbidden,
+		getDetailForLibraryErr: domain.ErrForbidden,
 	}, chaptersAuthenticatorFor(t, user))
 
 	req := httptest.NewRequest(http.MethodGet, chaptersEndpoint+"/"+uuid.New().String(), nil)
@@ -805,14 +832,16 @@ func TestGetByIDReturnsChapterWithProgress(t *testing.T) {
 	publishedAt := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
 	updatedAt := time.Date(2026, 3, 1, 8, 0, 0, 0, time.UTC)
 	svc := &stubChaptersService{
-		getForLibraryResult: &chapters.Chapter{
-			PublishedAt: publishedAt,
-			Title:       "Chapter 1",
-			Number:      1,
-			PagesNb:     20,
-			Download:    40,
-			ID:          chapterID,
-			ComicID:     comicID,
+		getDetailForLibraryResult: &chapters.ChapterDetail{
+			Chapter: chapters.Chapter{
+				PublishedAt: publishedAt,
+				Title:       "Chapter 1",
+				Number:      1,
+				PagesNb:     20,
+				Download:    40,
+				ID:          chapterID,
+				ComicID:     comicID,
+			},
 		},
 	}
 	progress := &stubProgress{
@@ -831,8 +860,8 @@ func TestGetByIDReturnsChapterWithProgress(t *testing.T) {
 		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
 	}
 
-	if svc.lastGetForLibraryOpts.UserID != user.ID || svc.lastGetForLibraryOpts.ChapterID != chapterID {
-		t.Errorf("GetForLibrary opts = %+v", svc.lastGetForLibraryOpts)
+	if svc.lastGetDetailForLibraryOpts.UserID != user.ID || svc.lastGetDetailForLibraryOpts.ChapterID != chapterID {
+		t.Errorf("GetDetailForLibrary opts = %+v", svc.lastGetDetailForLibraryOpts)
 	}
 
 	var got postListHTTPChapter
@@ -846,6 +875,151 @@ func TestGetByIDReturnsChapterWithProgress(t *testing.T) {
 
 	if got.Progress == nil || got.Progress.Page != 4 || !got.Progress.UpdatedAt.Equal(updatedAt) {
 		t.Errorf("progress = %+v", got.Progress)
+	}
+
+	if got.PageURLs == nil || len(got.PageURLs) != 0 {
+		t.Errorf("pageUrls = %#v, want empty slice", got.PageURLs)
+	}
+
+	if got.NextChapterID != nil || got.PreviousChapterID != nil {
+		t.Errorf("neighbors = next %#v prev %#v, want omitted", got.NextChapterID, got.PreviousChapterID)
+	}
+}
+
+func TestGetByIDPageURLsAndNeighbors(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: chaptersUsername}
+	chapterID := uuid.New()
+	prevID := uuid.New()
+	nextID := uuid.New()
+	svc := &stubChaptersService{
+		getDetailForLibraryResult: &chapters.ChapterDetail{
+			Chapter: chapters.Chapter{
+				ID:       chapterID,
+				ComicID:  uuid.New(),
+				Number:   2,
+				PagesNb:  2,
+				Download: 100,
+			},
+			PreviousID: &prevID,
+			NextID:     &nextID,
+		},
+	}
+	r := newChaptersTestRouter(t, svc, chaptersAuthenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodGet, chaptersEndpoint+"/"+chapterID.String(), nil)
+	req.AddCookie(&http.Cookie{Name: chaptersCookie, Value: chaptersToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var got postListHTTPChapter
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	want0 := "/api/chapters/" + chapterID.String() + "/pages/1"
+	want1 := "/api/chapters/" + chapterID.String() + "/pages/2"
+	if len(got.PageURLs) != 2 || got.PageURLs[0] != want0 || got.PageURLs[1] != want1 {
+		t.Errorf("pageUrls = %#v", got.PageURLs)
+	}
+
+	if got.PreviousChapterID == nil || *got.PreviousChapterID != prevID {
+		t.Errorf("previousChapterId = %v, want %s", got.PreviousChapterID, prevID)
+	}
+
+	if got.NextChapterID == nil || *got.NextChapterID != nextID {
+		t.Errorf("nextChapterId = %v, want %s", got.NextChapterID, nextID)
+	}
+}
+
+func TestServePageOK(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: chaptersUsername}
+	chapterID := uuid.New()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "001.webp")
+	if err := os.WriteFile(path, []byte("page-bytes"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	r := newChaptersTestRouter(t, &stubChaptersService{
+		servePagePath: path,
+		servePageType: "image/webp",
+	}, chaptersAuthenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodGet, chaptersEndpoint+"/"+chapterID.String()+"/pages/1", nil)
+	req.AddCookie(&http.Cookie{Name: chaptersCookie, Value: chaptersToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	if rec.Header().Get("Content-Type") != "image/webp" {
+		t.Errorf("Content-Type = %q", rec.Header().Get("Content-Type"))
+	}
+
+	if rec.Body.String() != "page-bytes" {
+		t.Errorf("body = %q", rec.Body.String())
+	}
+}
+
+func TestServePageUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	r := newChaptersTestRouter(t, &stubChaptersService{}, chaptersAuthenticatorFor(t, &users.User{
+		ID: uuid.New(), Name: chaptersUsername,
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, chaptersEndpoint+"/"+uuid.New().String()+"/pages/1", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestServePageNotFoundWhenIncomplete(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: chaptersUsername}
+	r := newChaptersTestRouter(t, &stubChaptersService{
+		servePageErr: domain.ErrNotFound,
+	}, chaptersAuthenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodGet, chaptersEndpoint+"/"+uuid.New().String()+"/pages/1", nil)
+	req.AddCookie(&http.Cookie{Name: chaptersCookie, Value: chaptersToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestServePageForbidden(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: chaptersUsername}
+	r := newChaptersTestRouter(t, &stubChaptersService{
+		servePageErr: domain.ErrForbidden,
+	}, chaptersAuthenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodGet, chaptersEndpoint+"/"+uuid.New().String()+"/pages/1", nil)
+	req.AddCookie(&http.Cookie{Name: chaptersCookie, Value: chaptersToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", rec.Code)
 	}
 }
 

--- a/api/pkg/core/chapters/gateway/http/controller_test.go
+++ b/api/pkg/core/chapters/gateway/http/controller_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
 	chaptershttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters/gateway/http"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readingprogress"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/users"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
 )
@@ -38,10 +39,13 @@ type stubChaptersService struct {
 	retryErr               error
 	getByIdsErr            error
 	listForLibraryErr      error
+	getForLibraryErr       error
 	getByIdsResult         []chapters.Chapter
 	listForLibraryResult   []chapters.Chapter
+	getForLibraryResult    *chapters.Chapter
 	lastGetByIdsOpts       chapters.GetByIdsOpts
 	lastListForLibraryOpts chapters.ListForLibraryOpts
+	lastGetForLibraryOpts  chapters.GetForLibraryOpts
 }
 
 func (s *stubChaptersService) CreateAll(
@@ -86,6 +90,14 @@ func (s *stubChaptersService) ListForLibrary(
 	s.lastListForLibraryOpts = opts
 
 	return s.listForLibraryResult, s.listForLibraryErr
+}
+
+func (s *stubChaptersService) GetForLibrary(
+	_ context.Context, opts chapters.GetForLibraryOpts,
+) (*chapters.Chapter, error) {
+	s.lastGetForLibraryOpts = opts
+
+	return s.getForLibraryResult, s.getForLibraryErr
 }
 
 type stubSessionService struct {
@@ -134,12 +146,45 @@ func chaptersAuthenticatorFor(t *testing.T, user *users.User) chi.Middlewares {
 	return chi.Middlewares{a.Middleware}
 }
 
+type stubProgress struct {
+	err  error
+	byID map[uuid.UUID]readingprogress.Progress
+	last readingprogress.MapOpts
+}
+
+func (s *stubProgress) MapByChapterIDs(
+	_ context.Context, opts readingprogress.MapOpts,
+) (map[uuid.UUID]readingprogress.Progress, error) {
+	s.last = opts
+	if s.err != nil {
+		return nil, s.err
+	}
+
+	if s.byID != nil {
+		return s.byID, nil
+	}
+
+	return map[uuid.UUID]readingprogress.Progress{}, nil
+}
+
 func newChaptersTestRouter(t *testing.T, svc chapters.ChaptersService, mws chi.Middlewares) chi.Router {
+	t.Helper()
+
+	return newChaptersTestRouterWithProgress(t, svc, &stubProgress{}, mws)
+}
+
+func newChaptersTestRouterWithProgress(
+	t *testing.T, svc chapters.ChaptersService, progress chaptershttp.ProgressReader, mws chi.Middlewares,
+) chi.Router {
 	t.Helper()
 
 	c, err := chaptershttp.New(
 		chaptershttp.Config{Endpoint: chaptersEndpoint, Middlewares: mws},
-		chaptershttp.Deps{Logger: chaptersTestLogger(), ChaptersService: svc},
+		chaptershttp.Deps{
+			Logger:          chaptersTestLogger(),
+			ChaptersService: svc,
+			Progress:        progress,
+		},
 	)
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -276,15 +321,19 @@ func TestRetryDownloadInternalError(t *testing.T) {
 }
 
 type postListHTTPChapter struct {
-	PublishedAt       time.Time  `json:"publishedAt"`
-	EarlyAccessUntil  *time.Time `json:"earlyAccessUntil"`
-	SourceChapterSlug string     `json:"sourceChapterSlug"`
-	Title             string     `json:"title"`
-	Number            float64    `json:"number"`
-	PagesNb           int        `json:"pagesNb"`
-	Download          int        `json:"download"`
-	ID                uuid.UUID  `json:"id"`
-	ComicID           uuid.UUID  `json:"comicId"`
+	PublishedAt      time.Time  `json:"publishedAt"`
+	EarlyAccessUntil *time.Time `json:"earlyAccessUntil"`
+	Progress         *struct {
+		UpdatedAt time.Time `json:"updatedAt"`
+		Page      int       `json:"page"`
+	} `json:"progress"`
+	SourceChapterSlug string    `json:"sourceChapterSlug"`
+	Title             string    `json:"title"`
+	Number            float64   `json:"number"`
+	PagesNb           int       `json:"pagesNb"`
+	Download          int       `json:"download"`
+	ID                uuid.UUID `json:"id"`
+	ComicID           uuid.UUID `json:"comicId"`
 }
 
 func TestPostListRequiresAuthentication(t *testing.T) {
@@ -442,6 +491,10 @@ func TestPostListReturnsChapters(t *testing.T) {
 
 	if got[1].EarlyAccessUntil != nil {
 		t.Errorf("chapters[1].earlyAccessUntil = %v, want nil", got[1].EarlyAccessUntil)
+	}
+
+	if first.Progress != nil || got[1].Progress != nil {
+		t.Errorf("progress = %+v / %+v, want null", first.Progress, got[1].Progress)
 	}
 }
 
@@ -616,6 +669,184 @@ func TestListForLibraryReturnsChapters(t *testing.T) {
 	if got[1].EarlyAccessUntil != nil || got[1].Download != 100 {
 		t.Errorf("chapters[1] = %+v", got[1])
 	}
+
+	if got[0].Progress != nil || got[1].Progress != nil {
+		t.Errorf("progress = %+v / %+v, want null", got[0].Progress, got[1].Progress)
+	}
+}
+
+func TestPostListIncludesProgress(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: chaptersUsername}
+	chapterID := uuid.New()
+	updatedAt := time.Date(2026, 3, 1, 8, 0, 0, 0, time.UTC)
+	svc := &stubChaptersService{
+		getByIdsResult: []chapters.Chapter{{
+			ID:      chapterID,
+			ComicID: uuid.New(),
+			PagesNb: 10,
+		}},
+	}
+	progress := &stubProgress{
+		byID: map[uuid.UUID]readingprogress.Progress{
+			chapterID: {ChapterID: chapterID, Page: 18, UpdatedAt: updatedAt},
+		},
+	}
+	r := newChaptersTestRouterWithProgress(t, svc, progress, chaptersAuthenticatorFor(t, user))
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		chaptersEndpoint+"/list",
+		strings.NewReader(`{"ids":["`+chapterID.String()+`"]}`),
+	)
+	req.AddCookie(&http.Cookie{Name: chaptersCookie, Value: chaptersToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var got []postListHTTPChapter
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if len(got) != 1 || got[0].Progress == nil {
+		t.Fatalf("chapters = %+v, want progress", got)
+	}
+
+	if got[0].Progress.Page != 10 {
+		t.Errorf("progress.page = %d, want clamped 10", got[0].Progress.Page)
+	}
+
+	if !got[0].Progress.UpdatedAt.Equal(updatedAt) {
+		t.Errorf("progress.updatedAt = %v, want %v", got[0].Progress.UpdatedAt, updatedAt)
+	}
+
+	if progress.last.UserID != user.ID || len(progress.last.IDs) != 1 || progress.last.IDs[0] != chapterID {
+		t.Errorf("MapByChapterIDs opts = %+v", progress.last)
+	}
+}
+
+func TestGetByIDRequiresAuthentication(t *testing.T) {
+	t.Parallel()
+
+	r := newChaptersTestRouter(t, &stubChaptersService{}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, chaptersEndpoint+"/"+uuid.New().String(), nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestGetByIDInvalidID(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: chaptersUsername}
+	r := newChaptersTestRouter(t, &stubChaptersService{}, chaptersAuthenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodGet, chaptersEndpoint+"/not-a-uuid", nil)
+	req.AddCookie(&http.Cookie{Name: chaptersCookie, Value: chaptersToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestGetByIDNotFound(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: chaptersUsername}
+	r := newChaptersTestRouter(t, &stubChaptersService{
+		getForLibraryErr: domain.ErrNotFound,
+	}, chaptersAuthenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodGet, chaptersEndpoint+"/"+uuid.New().String(), nil)
+	req.AddCookie(&http.Cookie{Name: chaptersCookie, Value: chaptersToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestGetByIDForbidden(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: chaptersUsername}
+	r := newChaptersTestRouter(t, &stubChaptersService{
+		getForLibraryErr: domain.ErrForbidden,
+	}, chaptersAuthenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodGet, chaptersEndpoint+"/"+uuid.New().String(), nil)
+	req.AddCookie(&http.Cookie{Name: chaptersCookie, Value: chaptersToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
+func TestGetByIDReturnsChapterWithProgress(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: chaptersUsername}
+	chapterID := uuid.New()
+	comicID := uuid.New()
+	publishedAt := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	updatedAt := time.Date(2026, 3, 1, 8, 0, 0, 0, time.UTC)
+	svc := &stubChaptersService{
+		getForLibraryResult: &chapters.Chapter{
+			PublishedAt: publishedAt,
+			Title:       "Chapter 1",
+			Number:      1,
+			PagesNb:     20,
+			Download:    40,
+			ID:          chapterID,
+			ComicID:     comicID,
+		},
+	}
+	progress := &stubProgress{
+		byID: map[uuid.UUID]readingprogress.Progress{
+			chapterID: {ChapterID: chapterID, Page: 4, UpdatedAt: updatedAt},
+		},
+	}
+	r := newChaptersTestRouterWithProgress(t, svc, progress, chaptersAuthenticatorFor(t, user))
+
+	req := httptest.NewRequest(http.MethodGet, chaptersEndpoint+"/"+chapterID.String(), nil)
+	req.AddCookie(&http.Cookie{Name: chaptersCookie, Value: chaptersToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	if svc.lastGetForLibraryOpts.UserID != user.ID || svc.lastGetForLibraryOpts.ChapterID != chapterID {
+		t.Errorf("GetForLibrary opts = %+v", svc.lastGetForLibraryOpts)
+	}
+
+	var got postListHTTPChapter
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if got.ID != chapterID || got.ComicID != comicID || got.Download != 40 {
+		t.Errorf("chapter = %+v", got)
+	}
+
+	if got.Progress == nil || got.Progress.Page != 4 || !got.Progress.UpdatedAt.Equal(updatedAt) {
+		t.Errorf("progress = %+v", got.Progress)
+	}
 }
 
 func TestConfigValidate(t *testing.T) {
@@ -673,14 +904,19 @@ func TestDepsValidate(t *testing.T) {
 			deps: chaptershttp.Deps{
 				Logger:          logger,
 				ChaptersService: &stubChaptersService{},
+				Progress:        &stubProgress{},
 			},
 		},
 		"missing service": {
-			deps:    chaptershttp.Deps{Logger: logger},
+			deps:    chaptershttp.Deps{Logger: logger, Progress: &stubProgress{}},
 			wantErr: "chapters service is required",
 		},
+		"missing progress": {
+			deps:    chaptershttp.Deps{Logger: logger, ChaptersService: &stubChaptersService{}},
+			wantErr: "progress is required",
+		},
 		"missing logger": {
-			deps:    chaptershttp.Deps{ChaptersService: &stubChaptersService{}},
+			deps:    chaptershttp.Deps{ChaptersService: &stubChaptersService{}, Progress: &stubProgress{}},
 			wantErr: "logger is required",
 		},
 	}
@@ -711,7 +947,11 @@ func TestNewRequiresValidConfig(t *testing.T) {
 
 	_, err := chaptershttp.New(
 		chaptershttp.Config{},
-		chaptershttp.Deps{Logger: chaptersTestLogger(), ChaptersService: &stubChaptersService{}},
+		chaptershttp.Deps{
+			Logger:          chaptersTestLogger(),
+			ChaptersService: &stubChaptersService{},
+			Progress:        &stubProgress{},
+		},
 	)
 	if err == nil {
 		t.Fatal("New with invalid config must fail")

--- a/api/pkg/core/chapters/gateway/http/dto.go
+++ b/api/pkg/core/chapters/gateway/http/dto.go
@@ -3,6 +3,7 @@
 package http
 
 import (
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -29,6 +30,26 @@ type postListResponseChapter struct {
 	Download          int                      `json:"download"`
 	ID                uuid.UUID                `json:"id"`
 	ComicID           uuid.UUID                `json:"comicId"`
+}
+
+type chapterDetailResponse struct {
+	NextChapterID     *uuid.UUID `json:"nextChapterId,omitempty"`
+	PreviousChapterID *uuid.UUID `json:"previousChapterId,omitempty"`
+	PageURLs          []string   `json:"pageUrls"`
+	postListResponseChapter
+}
+
+func pageURLs(id uuid.UUID, download, pagesNb int) []string {
+	if download != 100 || pagesNb <= 0 {
+		return []string{}
+	}
+
+	urls := make([]string, pagesNb)
+	for i := range pagesNb {
+		urls[i] = "/api/chapters/" + id.String() + "/pages/" + strconv.Itoa(i+1)
+	}
+
+	return urls
 }
 
 func progressPayload(

--- a/api/pkg/core/chapters/gateway/http/dto.go
+++ b/api/pkg/core/chapters/gateway/http/dto.go
@@ -1,23 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 package http
 
 import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readingprogress"
 )
 
 type postListBody struct {
 	IDs []uuid.UUID `json:"ids" validate:"required,min=1,dive,required"`
 }
 
+type chapterProgressResponse struct {
+	UpdatedAt time.Time `json:"updatedAt"`
+	Page      int       `json:"page"`
+}
+
 type postListResponseChapter struct {
-	PublishedAt       time.Time  `json:"publishedAt"`
-	EarlyAccessUntil  *time.Time `json:"earlyAccessUntil"`
-	SourceChapterSlug string     `json:"sourceChapterSlug"`
-	Title             string     `json:"title"`
-	Number            float64    `json:"number"`
-	PagesNb           int        `json:"pagesNb"`
-	Download          int        `json:"download"`
-	ID                uuid.UUID  `json:"id"`
-	ComicID           uuid.UUID  `json:"comicId"`
+	PublishedAt       time.Time                `json:"publishedAt"`
+	EarlyAccessUntil  *time.Time               `json:"earlyAccessUntil"`
+	Progress          *chapterProgressResponse `json:"progress"`
+	SourceChapterSlug string                   `json:"sourceChapterSlug"`
+	Title             string                   `json:"title"`
+	Number            float64                  `json:"number"`
+	PagesNb           int                      `json:"pagesNb"`
+	Download          int                      `json:"download"`
+	ID                uuid.UUID                `json:"id"`
+	ComicID           uuid.UUID                `json:"comicId"`
+}
+
+func progressPayload(
+	chapterID uuid.UUID,
+	pagesNb int,
+	byID map[uuid.UUID]readingprogress.Progress,
+) *chapterProgressResponse {
+	p, ok := byID[chapterID]
+	if !ok {
+		return nil
+	}
+
+	return &chapterProgressResponse{
+		UpdatedAt: p.UpdatedAt,
+		Page:      readingprogress.ClampPage(p.Page, pagesNb),
+	}
 }

--- a/api/pkg/core/chapters/service.go
+++ b/api/pkg/core/chapters/service.go
@@ -267,3 +267,21 @@ func (s *Service) GetByIds(ctx context.Context, opts GetByIdsOpts) ([]Chapter, e
 
 	return accessible, nil
 }
+
+func (s *Service) GetForLibrary(ctx context.Context, opts GetForLibraryOpts) (*Chapter, error) {
+	chapter, err := s.deps.Repository.GetByID(ctx, opts.ChapterID)
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.Repository.GetByID: %w", err)
+	}
+
+	inLibrary, err := s.deps.LibraryRepository.ExistsByUserAndComic(ctx, opts.UserID, chapter.ComicID)
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.LibraryRepository.ExistsByUserAndComic: %w", err)
+	}
+
+	if !inLibrary {
+		return nil, domain.ErrForbidden
+	}
+
+	return chapter, nil
+}

--- a/api/pkg/core/chapters/service.go
+++ b/api/pkg/core/chapters/service.go
@@ -24,6 +24,7 @@ type Deps struct {
 	ChapterDownloader ChapterDownloader
 	LibraryRepository library.LibraryRepository
 	ComicLookup       ComicLookup
+	PageStore         PageStore
 }
 
 func (deps *Deps) Validate() error {
@@ -41,6 +42,10 @@ func (deps *Deps) Validate() error {
 
 	if deps.ComicLookup == nil {
 		return errors.New("comicLookup is required")
+	}
+
+	if deps.PageStore == nil {
+		return errors.New("pageStore is required")
 	}
 
 	return nil
@@ -284,4 +289,59 @@ func (s *Service) GetForLibrary(ctx context.Context, opts GetForLibraryOpts) (*C
 	}
 
 	return chapter, nil
+}
+
+func (s *Service) GetDetailForLibrary(ctx context.Context, opts GetForLibraryOpts) (*ChapterDetail, error) {
+	chapter, err := s.GetForLibrary(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("s.GetForLibrary: %w", err)
+	}
+
+	siblings, err := s.deps.Repository.ListByComicID(ctx, chapter.ComicID)
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.Repository.ListByComicID: %w", err)
+	}
+
+	detail := &ChapterDetail{Chapter: *chapter}
+
+	for i := range siblings {
+		if siblings[i].ID != chapter.ID {
+			continue
+		}
+
+		if i > 0 {
+			id := siblings[i-1].ID
+			detail.PreviousID = &id
+		}
+
+		if i < len(siblings)-1 {
+			id := siblings[i+1].ID
+			detail.NextID = &id
+		}
+
+		break
+	}
+
+	return detail, nil
+}
+
+func (s *Service) ServePage(ctx context.Context, opts ServePageOpts) (string, string, error) {
+	chapter, err := s.GetForLibrary(ctx, GetForLibraryOpts{
+		UserID:    opts.UserID,
+		ChapterID: opts.ChapterID,
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("s.GetForLibrary: %w", err)
+	}
+
+	if chapter.Download != 100 || opts.Index < 1 || opts.Index > chapter.PagesNb {
+		return "", "", domain.ErrNotFound
+	}
+
+	path, contentType, err := s.deps.PageStore.OpenPage(chapter.ComicID, chapter.Number, opts.Index)
+	if err != nil {
+		return "", "", fmt.Errorf("s.deps.PageStore.OpenPage: %w", err)
+	}
+
+	return path, contentType, nil
 }

--- a/api/pkg/core/chapters/service_test.go
+++ b/api/pkg/core/chapters/service_test.go
@@ -877,3 +877,81 @@ func TestServiceListForLibraryLookupError(t *testing.T) {
 		t.Errorf("ListForLibrary returned %+v in addition to the error", got)
 	}
 }
+
+func TestServiceGetForLibrary(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	comicID := uuid.New()
+	chapterID := uuid.New()
+	want := &chapters.Chapter{ID: chapterID, ComicID: comicID, Download: 40, PagesNb: 12}
+	libraryRepo := &fakeLibraryRepository{existsByUserAndComic: true}
+	svc := newTestService(
+		&fakeChaptersRepository{getByIDResult: want},
+		&fakeChapterDownloader{},
+		libraryRepo,
+	)
+
+	got, err := svc.GetForLibrary(context.Background(), chapters.GetForLibraryOpts{
+		UserID:    userID,
+		ChapterID: chapterID,
+	})
+	if err != nil {
+		t.Fatalf("GetForLibrary: %v", err)
+	}
+
+	if got == nil || got.ID != chapterID || got.Download != 40 {
+		t.Errorf("GetForLibrary() = %+v, want %+v", got, want)
+	}
+
+	if libraryRepo.lastUserID != userID || libraryRepo.lastComicID != comicID {
+		t.Errorf("library check user=%s comic=%s, want user=%s comic=%s",
+			libraryRepo.lastUserID, libraryRepo.lastComicID, userID, comicID)
+	}
+}
+
+func TestServiceGetForLibraryNotFound(t *testing.T) {
+	t.Parallel()
+
+	svc := newTestService(
+		&fakeChaptersRepository{getByIDErr: domain.ErrNotFound},
+		&fakeChapterDownloader{},
+		&fakeLibraryRepository{},
+	)
+
+	got, err := svc.GetForLibrary(context.Background(), chapters.GetForLibraryOpts{
+		UserID:    uuid.New(),
+		ChapterID: uuid.New(),
+	})
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("GetForLibrary = %v, want domain.ErrNotFound", err)
+	}
+
+	if got != nil {
+		t.Errorf("GetForLibrary returned %+v in addition to the error", got)
+	}
+}
+
+func TestServiceGetForLibraryForbidden(t *testing.T) {
+	t.Parallel()
+
+	chapterID := uuid.New()
+	comicID := uuid.New()
+	svc := newTestService(
+		&fakeChaptersRepository{getByIDResult: &chapters.Chapter{ID: chapterID, ComicID: comicID}},
+		&fakeChapterDownloader{},
+		&fakeLibraryRepository{existsByUserAndComic: false},
+	)
+
+	got, err := svc.GetForLibrary(context.Background(), chapters.GetForLibraryOpts{
+		UserID:    uuid.New(),
+		ChapterID: chapterID,
+	})
+	if !errors.Is(err, domain.ErrForbidden) {
+		t.Fatalf("GetForLibrary = %v, want domain.ErrForbidden", err)
+	}
+
+	if got != nil {
+		t.Errorf("GetForLibrary returned %+v in addition to the error", got)
+	}
+}

--- a/api/pkg/core/chapters/service_test.go
+++ b/api/pkg/core/chapters/service_test.go
@@ -209,6 +209,31 @@ func (f *fakeComicLookup) Exists(_ context.Context, id uuid.UUID) (bool, error) 
 	return f.exists, f.existsErr
 }
 
+type nopPageStore struct{}
+
+func (nopPageStore) OpenPage(uuid.UUID, float64, int) (string, string, error) {
+	panic("OpenPage must not be called")
+}
+
+type fakePageStore struct {
+	err         error
+	path        string
+	contentType string
+	lastNumber  float64
+	lastComic   uuid.UUID
+	lastIndex   int
+	calls       int
+}
+
+func (f *fakePageStore) OpenPage(comicID uuid.UUID, chapterNumber float64, index int) (string, string, error) {
+	f.calls++
+	f.lastComic = comicID
+	f.lastNumber = chapterNumber
+	f.lastIndex = index
+
+	return f.path, f.contentType, f.err
+}
+
 func newTestService(
 	repo *fakeChaptersRepository,
 	downloader *fakeChapterDownloader,
@@ -219,6 +244,7 @@ func newTestService(
 		ChapterDownloader: downloader,
 		LibraryRepository: libraryRepo,
 		ComicLookup:       &fakeComicLookup{exists: true},
+		PageStore:         nopPageStore{},
 	})
 	if err != nil {
 		panic(err)
@@ -724,6 +750,7 @@ func TestServiceListForLibraryForbiddenWhenComicExistsButNotInLibrary(t *testing
 		ChapterDownloader: &fakeChapterDownloader{},
 		LibraryRepository: &fakeLibraryRepository{existsByUserAndComic: false},
 		ComicLookup:       lookup,
+		PageStore:         nopPageStore{},
 	})
 	if err != nil {
 		t.Fatalf("NewService: %v", err)
@@ -756,6 +783,7 @@ func TestServiceListForLibraryNotFoundWhenComicMissing(t *testing.T) {
 		ChapterDownloader: &fakeChapterDownloader{},
 		LibraryRepository: &fakeLibraryRepository{existsByUserAndComic: false},
 		ComicLookup:       lookup,
+		PageStore:         nopPageStore{},
 	})
 	if err != nil {
 		t.Fatalf("NewService: %v", err)
@@ -787,6 +815,7 @@ func TestServiceListForLibraryDoesNotLookupComicWhenInLibrary(t *testing.T) {
 		ChapterDownloader: &fakeChapterDownloader{},
 		LibraryRepository: &fakeLibraryRepository{existsByUserAndComic: true},
 		ComicLookup:       lookup,
+		PageStore:         nopPageStore{},
 	})
 	if err != nil {
 		t.Fatalf("NewService: %v", err)
@@ -860,6 +889,7 @@ func TestServiceListForLibraryLookupError(t *testing.T) {
 		ChapterDownloader: &fakeChapterDownloader{},
 		LibraryRepository: &fakeLibraryRepository{existsByUserAndComic: false},
 		ComicLookup:       &fakeComicLookup{existsErr: sentinel},
+		PageStore:         nopPageStore{},
 	})
 	if err != nil {
 		t.Fatalf("NewService: %v", err)
@@ -953,5 +983,165 @@ func TestServiceGetForLibraryForbidden(t *testing.T) {
 
 	if got != nil {
 		t.Errorf("GetForLibrary returned %+v in addition to the error", got)
+	}
+}
+
+func TestServiceGetDetailForLibraryNeighbors(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	comicID := uuid.New()
+	prevID := uuid.New()
+	currentID := uuid.New()
+	nextID := uuid.New()
+	current := &chapters.Chapter{
+		ID: currentID, ComicID: comicID, Number: 2, Download: 100, PagesNb: 3,
+	}
+	svc := newTestService(
+		&fakeChaptersRepository{
+			getByIDResult: current,
+			listByComicIDResult: []chapters.Chapter{
+				{ID: prevID, ComicID: comicID, Number: 1, Download: 42},
+				*current,
+				{ID: nextID, ComicID: comicID, Number: 3, Download: -1},
+			},
+		},
+		&fakeChapterDownloader{},
+		&fakeLibraryRepository{existsByUserAndComic: true},
+	)
+
+	got, err := svc.GetDetailForLibrary(context.Background(), chapters.GetForLibraryOpts{
+		UserID:    userID,
+		ChapterID: currentID,
+	})
+	if err != nil {
+		t.Fatalf("GetDetailForLibrary: %v", err)
+	}
+
+	if got.Chapter.ID != currentID {
+		t.Errorf("chapter id = %s, want %s", got.Chapter.ID, currentID)
+	}
+
+	if got.PreviousID == nil || *got.PreviousID != prevID {
+		t.Errorf("previous = %v, want %s", got.PreviousID, prevID)
+	}
+
+	if got.NextID == nil || *got.NextID != nextID {
+		t.Errorf("next = %v, want %s", got.NextID, nextID)
+	}
+}
+
+func TestServiceGetDetailForLibraryOmitsMissingNeighbors(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	onlyID := uuid.New()
+	only := &chapters.Chapter{ID: onlyID, ComicID: comicID, Number: 1}
+	svc := newTestService(
+		&fakeChaptersRepository{
+			getByIDResult:       only,
+			listByComicIDResult: []chapters.Chapter{*only},
+		},
+		&fakeChapterDownloader{},
+		&fakeLibraryRepository{existsByUserAndComic: true},
+	)
+
+	got, err := svc.GetDetailForLibrary(context.Background(), chapters.GetForLibraryOpts{
+		UserID:    uuid.New(),
+		ChapterID: onlyID,
+	})
+	if err != nil {
+		t.Fatalf("GetDetailForLibrary: %v", err)
+	}
+
+	if got.PreviousID != nil || got.NextID != nil {
+		t.Errorf("neighbors previous=%v next=%v, want both nil", got.PreviousID, got.NextID)
+	}
+}
+
+func TestServiceServePage(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	comicID := uuid.New()
+	chapterID := uuid.New()
+	store := &fakePageStore{path: "/tmp/001.webp", contentType: "image/webp"}
+	svc, err := chapters.NewService(chapters.Deps{
+		Repository: &fakeChaptersRepository{
+			getByIDResult: &chapters.Chapter{
+				ID: chapterID, ComicID: comicID, Number: 1, PagesNb: 3, Download: 100,
+			},
+		},
+		ChapterDownloader: &fakeChapterDownloader{},
+		LibraryRepository: &fakeLibraryRepository{existsByUserAndComic: true},
+		ComicLookup:       &fakeComicLookup{exists: true},
+		PageStore:         store,
+	})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	path, contentType, err := svc.ServePage(context.Background(), chapters.ServePageOpts{
+		UserID:    userID,
+		ChapterID: chapterID,
+		Index:     1,
+	})
+	if err != nil {
+		t.Fatalf("ServePage: %v", err)
+	}
+
+	if path != store.path || contentType != store.contentType {
+		t.Errorf("ServePage = %q %q", path, contentType)
+	}
+
+	if store.lastComic != comicID || store.lastNumber != 1 || store.lastIndex != 1 {
+		t.Errorf("OpenPage args comic=%s number=%v index=%d", store.lastComic, store.lastNumber, store.lastIndex)
+	}
+}
+
+func TestServiceServePageNotFoundWhenIncomplete(t *testing.T) {
+	t.Parallel()
+
+	svc := newTestService(
+		&fakeChaptersRepository{
+			getByIDResult: &chapters.Chapter{
+				ID: uuid.New(), ComicID: uuid.New(), PagesNb: 3, Download: 40,
+			},
+		},
+		&fakeChapterDownloader{},
+		&fakeLibraryRepository{existsByUserAndComic: true},
+	)
+
+	_, _, err := svc.ServePage(context.Background(), chapters.ServePageOpts{
+		UserID:    uuid.New(),
+		ChapterID: uuid.New(),
+		Index:     1,
+	})
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("ServePage = %v, want ErrNotFound", err)
+	}
+}
+
+func TestServiceServePageNotFoundWhenIndexOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	chapterID := uuid.New()
+	svc := newTestService(
+		&fakeChaptersRepository{
+			getByIDResult: &chapters.Chapter{
+				ID: chapterID, ComicID: uuid.New(), PagesNb: 2, Download: 100,
+			},
+		},
+		&fakeChapterDownloader{},
+		&fakeLibraryRepository{existsByUserAndComic: true},
+	)
+
+	_, _, err := svc.ServePage(context.Background(), chapters.ServePageOpts{
+		UserID:    uuid.New(),
+		ChapterID: chapterID,
+		Index:     3,
+	})
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("ServePage = %v, want ErrNotFound", err)
 	}
 }

--- a/api/pkg/core/comics/service_test.go
+++ b/api/pkg/core/comics/service_test.go
@@ -372,6 +372,16 @@ func (f *fakeChaptersService) GetForLibrary(context.Context, chapters.GetForLibr
 	panic("GetForLibrary must not be called")
 }
 
+func (f *fakeChaptersService) GetDetailForLibrary(
+	context.Context, chapters.GetForLibraryOpts,
+) (*chapters.ChapterDetail, error) {
+	panic("GetDetailForLibrary must not be called")
+}
+
+func (f *fakeChaptersService) ServePage(context.Context, chapters.ServePageOpts) (string, string, error) {
+	panic("ServePage must not be called")
+}
+
 //nolint:govet // fieldalignment on a test fake is not worth the unreadable field order
 type fakeSource struct {
 	infos             *sources.GetInfosBySlugResponse

--- a/api/pkg/core/comics/service_test.go
+++ b/api/pkg/core/comics/service_test.go
@@ -368,6 +368,10 @@ func (f *fakeChaptersService) ListForLibrary(context.Context, chapters.ListForLi
 	panic("ListForLibrary must not be called")
 }
 
+func (f *fakeChaptersService) GetForLibrary(context.Context, chapters.GetForLibraryOpts) (*chapters.Chapter, error) {
+	panic("GetForLibrary must not be called")
+}
+
 //nolint:govet // fieldalignment on a test fake is not worth the unreadable field order
 type fakeSource struct {
 	infos             *sources.GetInfosBySlugResponse

--- a/api/pkg/core/feed/domain.go
+++ b/api/pkg/core/feed/domain.go
@@ -16,6 +16,7 @@ type LatestChapter struct {
 	Title            string
 	Number           float64
 	Download         int
+	HasProgress      bool
 	ID               uuid.UUID
 	ComicID          uuid.UUID
 }
@@ -55,6 +56,7 @@ type ListPageOpts struct {
 type ListChaptersOpts struct {
 	Now      time.Time
 	ComicIDs []uuid.UUID
+	UserID   uuid.UUID
 }
 
 type FeedRepository interface {

--- a/api/pkg/core/feed/gateway/http/controller_test.go
+++ b/api/pkg/core/feed/gateway/http/controller_test.go
@@ -126,6 +126,7 @@ type feedChapterResponse struct {
 	EarlyAccessUntil *time.Time `json:"earlyAccessUntil"`
 	Title            string     `json:"title"`
 	Number           float64    `json:"number"`
+	HasProgress      bool       `json:"hasProgress"`
 	Download         int        `json:"download"`
 	ID               uuid.UUID  `json:"id"`
 }
@@ -409,6 +410,10 @@ func TestGetJSON(t *testing.T) {
 		t.Errorf("download = %d, want 2", item.LatestChapters[0].Download)
 	}
 
+	if item.LatestChapters[0].HasProgress {
+		t.Error("hasProgress = true, want false")
+	}
+
 	if item.LatestChapters[0].EarlyAccessUntil == nil || !item.LatestChapters[0].EarlyAccessUntil.Equal(earlyAccessUntil) {
 		t.Errorf("earlyAccessUntil = %v, want %v", item.LatestChapters[0].EarlyAccessUntil, earlyAccessUntil)
 	}
@@ -462,6 +467,10 @@ func TestGetJSONOmitsZeroEarlyAccessUntil(t *testing.T) {
 
 	if got.Items[0].LatestChapters[0].EarlyAccessUntil != nil {
 		t.Errorf("earlyAccessUntil = %v, want nil", got.Items[0].LatestChapters[0].EarlyAccessUntil)
+	}
+
+	if !strings.Contains(body, `"hasProgress":false`) {
+		t.Errorf("body = %s, want hasProgress:false present", body)
 	}
 }
 

--- a/api/pkg/core/feed/gateway/http/dto.go
+++ b/api/pkg/core/feed/gateway/http/dto.go
@@ -17,6 +17,7 @@ type latestChapterResponse struct {
 	EarlyAccessUntil *time.Time `json:"earlyAccessUntil,omitempty"`
 	Title            string     `json:"title"`
 	Number           float64    `json:"number"`
+	HasProgress      bool       `json:"hasProgress"`
 	Download         int        `json:"download"`
 	ID               uuid.UUID  `json:"id"`
 }
@@ -61,6 +62,7 @@ func itemFromDomain(item *feed.Item) itemResponse {
 			PublishedAt:      ch.PublishedAt,
 			EarlyAccessUntil: utils.OptionalTime(ch.EarlyAccessUntil),
 			Download:         ch.Download,
+			HasProgress:      ch.HasProgress,
 		})
 	}
 

--- a/api/pkg/core/feed/repository/pg/repository.go
+++ b/api/pkg/core/feed/repository/pg/repository.go
@@ -66,6 +66,7 @@ type chapterRow struct {
 	Title            string
 	Number           float64
 	Download         int
+	HasProgress      bool
 	ID               uuid.UUID
 	ComicID          uuid.UUID
 }
@@ -112,14 +113,22 @@ func (r *PGFeedRepository) ListUnlockedChapters(
 	}
 
 	const sql = `
-SELECT id, comic_id, title, number, published_at, early_access_until, download
+SELECT chapters.id, chapters.comic_id, chapters.title, chapters.number, chapters.published_at,
+  chapters.early_access_until, chapters.download,
+  EXISTS (
+    SELECT 1
+    FROM reading_progress
+    INNER JOIN library_entries ON library_entries.id = reading_progress.library_entry_id
+    WHERE reading_progress.chapter_id = chapters.id
+      AND library_entries.user_id = ?
+  ) AS has_progress
 FROM chapters
-WHERE comic_id IN ? AND (early_access_until IS NULL OR early_access_until <= ?)
+WHERE chapters.comic_id IN ? AND (chapters.early_access_until IS NULL OR chapters.early_access_until <= ?)
 `
 
 	var rows []chapterRow
 
-	err := pgtx.From(ctx, r.deps.DB).Raw(sql, opts.ComicIDs, opts.Now).Scan(&rows).Error
+	err := pgtx.From(ctx, r.deps.DB).Raw(sql, opts.UserID, opts.ComicIDs, opts.Now).Scan(&rows).Error
 	if err != nil {
 		return nil, fmt.Errorf("chapters: %w", err)
 	}
@@ -134,6 +143,7 @@ WHERE comic_id IN ? AND (early_access_until IS NULL OR early_access_until <= ?)
 			PublishedAt:      rows[i].PublishedAt,
 			EarlyAccessUntil: utils.OptionalTime(rows[i].EarlyAccessUntil),
 			Download:         rows[i].Download,
+			HasProgress:      rows[i].HasProgress,
 		}
 	}
 

--- a/api/pkg/core/feed/repository/pg/repository_test.go
+++ b/api/pkg/core/feed/repository/pg/repository_test.go
@@ -194,20 +194,22 @@ func TestListUnlockedChaptersFiltersLocked(t *testing.T) {
 
 	comicID := uuid.New()
 	chapterID := uuid.New()
+	userID := uuid.New()
 	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
 	published := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
 	until := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
 
 	// GORM expands IN ? to ($1) with PreferSimpleProtocol: comicID, now
-	mock.ExpectQuery(`comic_id IN.*early_access_until IS NULL OR early_access_until <=`).
-		WithArgs(comicID, now).
+	mock.ExpectQuery(`chapters.comic_id IN.*chapters.early_access_until IS NULL OR chapters.early_access_until <=`).
+		WithArgs(userID, comicID, now).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"id", "comic_id", "title", "number", "published_at", "early_access_until", "download",
-		}).AddRow(chapterID, comicID, "Ch 10", 10.0, published, until, 2))
+			"id", "comic_id", "title", "number", "published_at", "early_access_until", "download", "has_progress",
+		}).AddRow(chapterID, comicID, "Ch 10", 10.0, published, until, 2, true))
 
 	got, err := r.ListUnlockedChapters(context.Background(), feed.ListChaptersOpts{
 		Now:      now,
 		ComicIDs: []uuid.UUID{comicID},
+		UserID:   userID,
 	})
 	if err != nil {
 		t.Fatalf("ListUnlockedChapters: %v", err)
@@ -220,7 +222,7 @@ func TestListUnlockedChaptersFiltersLocked(t *testing.T) {
 	ch := got[0]
 	if ch.ID != chapterID || ch.ComicID != comicID || ch.Title != "Ch 10" ||
 		ch.Number != 10.0 || ch.Download != 2 || !ch.PublishedAt.Equal(published) ||
-		ch.EarlyAccessUntil == nil || !ch.EarlyAccessUntil.Equal(until) {
+		ch.EarlyAccessUntil == nil || !ch.EarlyAccessUntil.Equal(until) || !ch.HasProgress {
 		t.Errorf("LatestChapter = %+v", ch)
 	}
 }

--- a/api/pkg/core/feed/service.go
+++ b/api/pkg/core/feed/service.go
@@ -76,6 +76,7 @@ func (s *Service) Get(ctx context.Context, opts GetOpts) (Page, error) {
 	chapters, err := s.deps.FeedRepository.ListUnlockedChapters(ctx, ListChaptersOpts{
 		Now:      now,
 		ComicIDs: ids,
+		UserID:   opts.UserID,
 	})
 	if err != nil {
 		return Page{}, fmt.Errorf("s.deps.FeedRepository.ListUnlockedChapters: %w", err)

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -408,6 +408,16 @@ func (fakeChaptersService) GetForLibrary(context.Context, chapters.GetForLibrary
 	return nil, errors.New(notImplemented)
 }
 
+func (fakeChaptersService) GetDetailForLibrary(
+	context.Context, chapters.GetForLibraryOpts,
+) (*chapters.ChapterDetail, error) {
+	return nil, errors.New(notImplemented)
+}
+
+func (fakeChaptersService) ServePage(context.Context, chapters.ServePageOpts) (string, string, error) {
+	return "", "", errors.New(notImplemented)
+}
+
 type fakeFeedService struct{}
 
 func (fakeFeedService) Get(context.Context, feed.GetOpts) (feed.Page, error) {

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -404,6 +404,10 @@ func (fakeChaptersService) ListForLibrary(context.Context, chapters.ListForLibra
 	return nil, errors.New(notImplemented)
 }
 
+func (fakeChaptersService) GetForLibrary(context.Context, chapters.GetForLibraryOpts) (*chapters.Chapter, error) {
+	return nil, errors.New(notImplemented)
+}
+
 type fakeFeedService struct{}
 
 func (fakeFeedService) Get(context.Context, feed.GetOpts) (feed.Page, error) {
@@ -423,7 +427,13 @@ func (fakeReaderSettingsService) Replace(context.Context, readersettings.Replace
 type fakeReadingProgressService struct{}
 
 func (fakeReadingProgressService) List(context.Context, readingprogress.ListOpts) (readingprogress.ListResult, error) {
-	return readingprogress.ListResult{Chapters: []readingprogress.Progress{}}, nil
+	return readingprogress.ListResult{}, nil
+}
+
+func (fakeReadingProgressService) MapByChapterIDs(
+	context.Context, readingprogress.MapOpts,
+) (map[uuid.UUID]readingprogress.Progress, error) {
+	return map[uuid.UUID]readingprogress.Progress{}, nil
 }
 
 func (fakeReadingProgressService) Save(context.Context, readingprogress.SaveOpts) (readingprogress.Progress, error) {
@@ -587,7 +597,11 @@ func newTestApp(t *testing.T, db Database, port int) (*App, *health.Registry) {
 
 	chaptersCtrl, err := httpchapters.New(
 		httpchapters.Config{Endpoint: "/chapters"},
-		httpchapters.Deps{Logger: logger, ChaptersService: fakeChaptersService{}},
+		httpchapters.Deps{
+			Logger:          logger,
+			ChaptersService: fakeChaptersService{},
+			Progress:        fakeReadingProgressService{},
+		},
 	)
 	if err != nil {
 		t.Fatalf("httpchapters.New: %v", err)
@@ -610,7 +624,7 @@ func newTestApp(t *testing.T, db Database, port int) (*App, *health.Registry) {
 	}
 
 	readingProgressCtrl, err := httpreadingprogress.New(
-		httpreadingprogress.Config{Endpoint: "/comics"},
+		httpreadingprogress.Config{Endpoint: "/comics", ChaptersEndpoint: "/chapters"},
 		httpreadingprogress.Deps{Logger: logger, Service: fakeReadingProgressService{}},
 	)
 	if err != nil {

--- a/api/pkg/core/readingprogress/domain.go
+++ b/api/pkg/core/readingprogress/domain.go
@@ -27,7 +27,6 @@ type Continue struct {
 
 type ListResult struct {
 	Continue *Continue
-	Chapters []Progress
 }
 
 type ListOpts struct {
@@ -35,9 +34,13 @@ type ListOpts struct {
 	ComicID uuid.UUID
 }
 
+type MapOpts struct {
+	IDs    []uuid.UUID
+	UserID uuid.UUID
+}
+
 type SaveOpts struct {
 	UserID    uuid.UUID
-	ComicID   uuid.UUID
 	ChapterID uuid.UUID
 	Page      int
 }
@@ -57,13 +60,15 @@ type UpsertOpts struct {
 }
 
 type Repository interface {
-	ListByUserAndComic(context.Context, ListOpts) ([]Progress, error)
+	GetLatestByUserAndComic(context.Context, ListOpts) (*Progress, error)
+	ListByUserAndChapterIDs(context.Context, MapOpts) ([]Progress, error)
 	Get(context.Context, GetOpts) (*Progress, error)
 	Upsert(context.Context, UpsertOpts) (Progress, error)
 }
 
 type ReadingProgressService interface {
 	List(context.Context, ListOpts) (ListResult, error)
+	MapByChapterIDs(context.Context, MapOpts) (map[uuid.UUID]Progress, error)
 	Save(context.Context, SaveOpts) (Progress, error)
 }
 
@@ -77,7 +82,6 @@ type ComicLookup interface {
 
 type ChapterLookup interface {
 	GetByID(context.Context, uuid.UUID) (*chapters.Chapter, error)
-	GetByIds(context.Context, []uuid.UUID) ([]chapters.Chapter, error)
 }
 
 func ClampPage(page, pagesNb int) int {

--- a/api/pkg/core/readingprogress/gateway/http/controller.go
+++ b/api/pkg/core/readingprogress/gateway/http/controller.go
@@ -19,8 +19,9 @@ import (
 )
 
 type Config struct {
-	Endpoint    string
-	Middlewares chi.Middlewares
+	Endpoint         string
+	ChaptersEndpoint string
+	Middlewares      chi.Middlewares
 }
 
 func (cfg *Config) Validate() error {
@@ -30,6 +31,14 @@ func (cfg *Config) Validate() error {
 
 	if !strings.HasPrefix(cfg.Endpoint, "/") {
 		return fmt.Errorf("endpoint must start with '/', got %q", cfg.Endpoint)
+	}
+
+	if cfg.ChaptersEndpoint == "" {
+		return errors.New("chapters endpoint is required")
+	}
+
+	if !strings.HasPrefix(cfg.ChaptersEndpoint, "/") {
+		return fmt.Errorf("chapters endpoint must start with '/', got %q", cfg.ChaptersEndpoint)
 	}
 
 	hasNilMiddlewares := slices.ContainsFunc(cfg.Middlewares, func(m func(http.Handler) http.Handler) bool {
@@ -84,7 +93,7 @@ func (c *Controller) InitRouter(r chi.Router) {
 	r.Group(func(r chi.Router) {
 		r.Use(c.cfg.Middlewares...)
 		r.Get(c.cfg.Endpoint+"/{id}/progress", c.get)
-		r.Put(c.cfg.Endpoint+"/{id}/progress", c.put)
+		r.Put(c.cfg.ChaptersEndpoint+"/{id}/progress", c.put)
 	})
 }
 
@@ -139,7 +148,7 @@ func (c *Controller) put(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	comicID, err := uuid.Parse(chi.URLParam(r, "id"))
+	chapterID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
 		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "id must be a valid UUID")
 
@@ -161,8 +170,7 @@ func (c *Controller) put(w http.ResponseWriter, r *http.Request) {
 
 	saved, err := c.deps.Service.Save(ctx, readingprogress.SaveOpts{
 		UserID:    user.ID,
-		ComicID:   comicID,
-		ChapterID: req.ChapterID,
+		ChapterID: chapterID,
 		Page:      *req.Page,
 	})
 	if err != nil {

--- a/api/pkg/core/readingprogress/gateway/http/controller_test.go
+++ b/api/pkg/core/readingprogress/gateway/http/controller_test.go
@@ -24,10 +24,11 @@ import (
 )
 
 const (
-	endpoint     = "/comics"
-	cookieName   = "uchiyomi_session"
-	testToken    = "letoken"
-	testUsername = "alice"
+	endpoint         = "/comics"
+	chaptersEndpoint = "/chapters"
+	cookieName       = "uchiyomi_session"
+	testToken        = "letoken"
+	testUsername     = "alice"
 )
 
 type stubService struct {
@@ -51,6 +52,12 @@ func (s *stubService) Save(_ context.Context, opts readingprogress.SaveOpts) (re
 	return s.saveResult, s.saveErr
 }
 
+func (s *stubService) MapByChapterIDs(
+	_ context.Context, _ readingprogress.MapOpts,
+) (map[uuid.UUID]readingprogress.Progress, error) {
+	return map[uuid.UUID]readingprogress.Progress{}, nil
+}
+
 type stubSessionService struct {
 	result *sessions.AuthenticatedSession
 }
@@ -69,12 +76,11 @@ type progressJSON struct {
 	Page      int    `json:"page"`
 }
 
-type listJSON struct {
+type continueJSON struct {
 	Continue *struct {
 		ChapterID string `json:"chapterId"`
 		Page      int    `json:"page"`
 	} `json:"continue"`
-	Chapters []progressJSON `json:"chapters"`
 }
 
 func testLogger() *slog.Logger {
@@ -115,7 +121,11 @@ func newTestRouter(t *testing.T, svc *stubService, mws chi.Middlewares) chi.Rout
 	t.Helper()
 
 	c, err := httpreadingprogress.New(
-		httpreadingprogress.Config{Endpoint: endpoint, Middlewares: mws},
+		httpreadingprogress.Config{
+			Endpoint:         endpoint,
+			ChaptersEndpoint: chaptersEndpoint,
+			Middlewares:      mws,
+		},
 		httpreadingprogress.Deps{Logger: testLogger(), Service: svc},
 	)
 	if err != nil {
@@ -146,10 +156,10 @@ func getProgress(t *testing.T, r chi.Router, comicID string, withCookie bool) *h
 	return rec
 }
 
-func putProgress(t *testing.T, r chi.Router, comicID, body string, withCookie bool) *httptest.ResponseRecorder {
+func putProgress(t *testing.T, r chi.Router, chapterID, body string, withCookie bool) *httptest.ResponseRecorder {
 	t.Helper()
 
-	req := httptest.NewRequest(http.MethodPut, endpoint+"/"+comicID+"/progress", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPut, chaptersEndpoint+"/"+chapterID+"/progress", strings.NewReader(body))
 	if withCookie {
 		req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
 	}
@@ -173,25 +183,31 @@ func TestNewValidatesConfigAndDeps(t *testing.T) {
 		cfg     httpreadingprogress.Config
 	}{
 		"empty endpoint": {
-			cfg:     httpreadingprogress.Config{},
+			cfg:     httpreadingprogress.Config{ChaptersEndpoint: chaptersEndpoint},
 			deps:    httpreadingprogress.Deps{Logger: logger, Service: svc},
 			wantErr: "cfg.Validate: endpoint is required",
 		},
+		"empty chapters endpoint": {
+			cfg:     httpreadingprogress.Config{Endpoint: endpoint},
+			deps:    httpreadingprogress.Deps{Logger: logger, Service: svc},
+			wantErr: "cfg.Validate: chapters endpoint is required",
+		},
 		"nil middleware": {
 			cfg: httpreadingprogress.Config{
-				Endpoint:    endpoint,
-				Middlewares: chi.Middlewares{passthrough, nil},
+				Endpoint:         endpoint,
+				ChaptersEndpoint: chaptersEndpoint,
+				Middlewares:      chi.Middlewares{passthrough, nil},
 			},
 			deps:    httpreadingprogress.Deps{Logger: logger, Service: svc},
 			wantErr: "cfg.Validate: all middlewares must not be nil",
 		},
 		"nil logger": {
-			cfg:     httpreadingprogress.Config{Endpoint: endpoint},
+			cfg:     httpreadingprogress.Config{Endpoint: endpoint, ChaptersEndpoint: chaptersEndpoint},
 			deps:    httpreadingprogress.Deps{Service: svc},
 			wantErr: "deps.Validate: logger is required",
 		},
 		"nil service": {
-			cfg:     httpreadingprogress.Config{Endpoint: endpoint},
+			cfg:     httpreadingprogress.Config{Endpoint: endpoint, ChaptersEndpoint: chaptersEndpoint},
 			deps:    httpreadingprogress.Deps{Logger: logger},
 			wantErr: "deps.Validate: service is required",
 		},
@@ -236,7 +252,7 @@ func TestPutUnauthorized(t *testing.T) {
 	user := testUser()
 	r := newTestRouter(t, &stubService{}, authenticatorFor(t, user))
 
-	rec := putProgress(t, r, uuid.New().String(), `{"chapterId":"`+uuid.New().String()+`","page":1}`, false)
+	rec := putProgress(t, r, uuid.New().String(), `{"page":1}`, false)
 
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusUnauthorized, rec.Body.String())
@@ -249,17 +265,10 @@ func TestGetOK(t *testing.T) {
 	user := testUser()
 	comicID := uuid.New()
 	chapterNewer := uuid.New()
-	chapterOlder := uuid.New()
-	updatedNewer := time.Date(2026, 2, 2, 10, 0, 0, 0, time.UTC)
-	updatedOlder := time.Date(2026, 2, 1, 10, 0, 0, 0, time.UTC)
 
 	svc := &stubService{
 		listResult: readingprogress.ListResult{
 			Continue: &readingprogress.Continue{ChapterID: chapterNewer, Page: 5},
-			Chapters: []readingprogress.Progress{
-				{UpdatedAt: updatedNewer, ChapterID: chapterNewer, Page: 5},
-				{UpdatedAt: updatedOlder, ChapterID: chapterOlder, Page: 12},
-			},
 		},
 	}
 	r := newTestRouter(t, svc, authenticatorFor(t, user))
@@ -278,25 +287,9 @@ func TestGetOK(t *testing.T) {
 		t.Errorf("lastList.ComicID = %s, want %s", svc.lastList.ComicID, comicID)
 	}
 
-	var got listJSON
+	var got continueJSON
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatalf("body not decodable (%q): %v", rec.Body.String(), err)
-	}
-
-	if len(got.Chapters) != 2 {
-		t.Fatalf("chapters len = %d, want 2", len(got.Chapters))
-	}
-
-	if got.Chapters[0].ChapterID != chapterNewer.String() || got.Chapters[0].Page != 5 {
-		t.Errorf("chapters[0] = %+v", got.Chapters[0])
-	}
-
-	if got.Chapters[0].UpdatedAt == "" {
-		t.Error("chapters[0].updatedAt is empty, want RFC3339 timestamp")
-	}
-
-	if got.Chapters[1].ChapterID != chapterOlder.String() || got.Chapters[1].Page != 12 {
-		t.Errorf("chapters[1] = %+v", got.Chapters[1])
 	}
 
 	if got.Continue == nil {
@@ -310,6 +303,10 @@ func TestGetOK(t *testing.T) {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
 		t.Fatalf("decode raw body: %v", err)
+	}
+
+	if _, ok := raw["chapters"]; ok {
+		t.Error("body must not include chapters")
 	}
 
 	var continueRaw map[string]json.RawMessage
@@ -328,7 +325,7 @@ func TestGetEmptyContinueNull(t *testing.T) {
 	user := testUser()
 	comicID := uuid.New()
 	svc := &stubService{
-		listResult: readingprogress.ListResult{Chapters: []readingprogress.Progress{}},
+		listResult: readingprogress.ListResult{},
 	}
 	r := newTestRouter(t, svc, authenticatorFor(t, user))
 
@@ -338,7 +335,7 @@ func TestGetEmptyContinueNull(t *testing.T) {
 		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
 	}
 
-	var got listJSON
+	var got continueJSON
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatalf("body not decodable (%q): %v", rec.Body.String(), err)
 	}
@@ -347,12 +344,12 @@ func TestGetEmptyContinueNull(t *testing.T) {
 		t.Errorf("continue = %+v, want null", got.Continue)
 	}
 
-	if len(got.Chapters) != 0 {
-		t.Errorf("chapters len = %d, want 0", len(got.Chapters))
+	if !bytes.Contains(rec.Body.Bytes(), []byte(`"continue":null`)) {
+		t.Errorf("body = %s, want continue:null", rec.Body.String())
 	}
 
-	if !bytes.Contains(rec.Body.Bytes(), []byte(`"chapters":[]`)) {
-		t.Errorf("body = %s, want chapters:[]", rec.Body.String())
+	if bytes.Contains(rec.Body.Bytes(), []byte(`"chapters"`)) {
+		t.Errorf("body = %s, must not include chapters", rec.Body.String())
 	}
 }
 
@@ -360,7 +357,6 @@ func TestPutOK(t *testing.T) {
 	t.Parallel()
 
 	user := testUser()
-	comicID := uuid.New()
 	chapterID := uuid.New()
 	savedAt := time.Date(2026, 3, 1, 8, 0, 0, 0, time.UTC)
 
@@ -369,8 +365,7 @@ func TestPutOK(t *testing.T) {
 	}
 	r := newTestRouter(t, svc, authenticatorFor(t, user))
 
-	body := `{"chapterId":"` + chapterID.String() + `","page":8}`
-	rec := putProgress(t, r, comicID.String(), body, true)
+	rec := putProgress(t, r, chapterID.String(), `{"page":8}`, true)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
@@ -378,10 +373,6 @@ func TestPutOK(t *testing.T) {
 
 	if svc.lastSave.UserID != user.ID {
 		t.Errorf("lastSave.UserID = %s, want %s", svc.lastSave.UserID, user.ID)
-	}
-
-	if svc.lastSave.ComicID != comicID {
-		t.Errorf("lastSave.ComicID = %s, want %s", svc.lastSave.ComicID, comicID)
 	}
 
 	if svc.lastSave.ChapterID != chapterID {
@@ -406,13 +397,13 @@ func TestPutOK(t *testing.T) {
 	}
 }
 
-func TestPutInvalidComicID(t *testing.T) {
+func TestPutInvalidChapterID(t *testing.T) {
 	t.Parallel()
 
 	user := testUser()
 	r := newTestRouter(t, &stubService{}, authenticatorFor(t, user))
 
-	rec := putProgress(t, r, "not-a-uuid", `{"chapterId":"`+uuid.New().String()+`","page":1}`, true)
+	rec := putProgress(t, r, "not-a-uuid", `{"page":1}`, true)
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
@@ -438,7 +429,7 @@ func TestPutPageZero(t *testing.T) {
 	user := testUser()
 	r := newTestRouter(t, &stubService{}, authenticatorFor(t, user))
 
-	rec := putProgress(t, r, uuid.New().String(), `{"chapterId":"`+uuid.New().String()+`","page":0}`, true)
+	rec := putProgress(t, r, uuid.New().String(), `{"page":0}`, true)
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
@@ -452,7 +443,7 @@ func TestPutForbidden(t *testing.T) {
 	svc := &stubService{saveErr: domain.ErrForbidden}
 	r := newTestRouter(t, svc, authenticatorFor(t, user))
 
-	rec := putProgress(t, r, uuid.New().String(), `{"chapterId":"`+uuid.New().String()+`","page":1}`, true)
+	rec := putProgress(t, r, uuid.New().String(), `{"page":1}`, true)
 
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusForbidden, rec.Body.String())
@@ -488,7 +479,6 @@ func TestPutUsesSessionUser(t *testing.T) {
 	t.Parallel()
 
 	user := testUser()
-	comicID := uuid.New()
 	chapterID := uuid.New()
 
 	svc := &stubService{
@@ -496,8 +486,7 @@ func TestPutUsesSessionUser(t *testing.T) {
 	}
 	r := newTestRouter(t, svc, authenticatorFor(t, user))
 
-	body := `{"chapterId":"` + chapterID.String() + `","page":3}`
-	rec := putProgress(t, r, comicID.String(), body, true)
+	rec := putProgress(t, r, chapterID.String(), `{"page":3}`, true)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())

--- a/api/pkg/core/readingprogress/gateway/http/dto.go
+++ b/api/pkg/core/readingprogress/gateway/http/dto.go
@@ -21,13 +21,11 @@ type continueResponse struct {
 }
 
 type listResponse struct {
-	Continue *continueResponse  `json:"continue"`
-	Chapters []progressResponse `json:"chapters"`
+	Continue *continueResponse `json:"continue"`
 }
 
 type saveRequest struct {
-	Page      *int      `json:"page" validate:"required"`
-	ChapterID uuid.UUID `json:"chapterId" validate:"required"`
+	Page *int `json:"page" validate:"required"`
 }
 
 func progressFromDomain(p readingprogress.Progress) progressResponse {
@@ -39,11 +37,6 @@ func progressFromDomain(p readingprogress.Progress) progressResponse {
 }
 
 func listFromDomain(result readingprogress.ListResult) listResponse {
-	chapters := make([]progressResponse, 0, len(result.Chapters))
-	for _, p := range result.Chapters {
-		chapters = append(chapters, progressFromDomain(p))
-	}
-
 	var cont *continueResponse
 	if result.Continue != nil {
 		cont = &continueResponse{
@@ -52,8 +45,5 @@ func listFromDomain(result readingprogress.ListResult) listResponse {
 		}
 	}
 
-	return listResponse{
-		Continue: cont,
-		Chapters: chapters,
-	}
+	return listResponse{Continue: cont}
 }

--- a/api/pkg/core/readingprogress/repository/pg/repository.go
+++ b/api/pkg/core/readingprogress/repository/pg/repository.go
@@ -18,6 +18,8 @@ import (
 
 var _ readingprogress.Repository = (*PGReadingProgressRepository)(nil)
 
+const libraryEntryAssoc = "LibraryEntry"
+
 type Deps struct {
 	DB *gorm.DB
 }
@@ -48,13 +50,38 @@ func (r *PGReadingProgressRepository) db(ctx context.Context) gorm.Interface[pgm
 	return gorm.G[pgmodels.ReadingProgress](pgtx.From(ctx, r.deps.DB))
 }
 
-func (r *PGReadingProgressRepository) ListByUserAndComic(
+func (r *PGReadingProgressRepository) GetLatestByUserAndComic(
 	ctx context.Context, opts readingprogress.ListOpts,
-) ([]readingprogress.Progress, error) {
+) (*readingprogress.Progress, error) {
 	models, err := r.db(ctx).
-		Joins(clause.JoinTarget{Association: "LibraryEntry"}, nil).
-		Where("library_entries.user_id = ? AND library_entries.comic_id = ?", opts.UserID, opts.ComicID).
+		Joins(clause.JoinTarget{Association: libraryEntryAssoc}, nil).
+		Where(`"LibraryEntry".user_id = ? AND "LibraryEntry".comic_id = ?`, opts.UserID, opts.ComicID).
 		Order("reading_progress.updated_at DESC").
+		Limit(1).
+		Find(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("r.db(ctx).Find: %w", err)
+	}
+
+	if len(models) == 0 {
+		return nil, nil
+	}
+
+	ret := models[0].Domain()
+
+	return &ret, nil
+}
+
+func (r *PGReadingProgressRepository) ListByUserAndChapterIDs(
+	ctx context.Context, opts readingprogress.MapOpts,
+) ([]readingprogress.Progress, error) {
+	if len(opts.IDs) == 0 {
+		return []readingprogress.Progress{}, nil
+	}
+
+	models, err := r.db(ctx).
+		Joins(clause.JoinTarget{Association: libraryEntryAssoc}, nil).
+		Where(`"LibraryEntry".user_id = ? AND reading_progress.chapter_id IN ?`, opts.UserID, opts.IDs).
 		Find(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("r.db(ctx).Find: %w", err)
@@ -72,9 +99,9 @@ func (r *PGReadingProgressRepository) Get(
 	ctx context.Context, opts readingprogress.GetOpts,
 ) (*readingprogress.Progress, error) {
 	model, err := r.db(ctx).
-		Joins(clause.JoinTarget{Association: "LibraryEntry"}, nil).
+		Joins(clause.JoinTarget{Association: libraryEntryAssoc}, nil).
 		Where(
-			"library_entries.user_id = ? AND library_entries.comic_id = ? AND reading_progress.chapter_id = ?",
+			`"LibraryEntry".user_id = ? AND "LibraryEntry".comic_id = ? AND reading_progress.chapter_id = ?`,
 			opts.UserID, opts.ComicID, opts.ChapterID,
 		).
 		First(ctx)

--- a/api/pkg/core/readingprogress/repository/pg/repository_test.go
+++ b/api/pkg/core/readingprogress/repository/pg/repository_test.go
@@ -51,7 +51,7 @@ func readingProgressSelectColumns() []string {
 	return []string{"id", "library_entry_id", "chapter_id", "page", "updated_at"}
 }
 
-func TestListByUserAndComicJoinsLibraryEntry(t *testing.T) {
+func TestGetLatestByUserAndComicJoinsLibraryEntry(t *testing.T) {
 	t.Parallel()
 
 	r, mock := newReadingProgressRepo(t)
@@ -62,24 +62,24 @@ func TestListByUserAndComicJoinsLibraryEntry(t *testing.T) {
 	chapterID := uuid.New()
 	updatedAt := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
 
-	mock.ExpectQuery(`reading_progress.*library_entries`).
-		WithArgs(userID, comicID).
+	mock.ExpectQuery(`JOIN "library_entries" "LibraryEntry".*WHERE "LibraryEntry"\.(user_id|"user_id")`).
+		WithArgs(userID, comicID, 1).
 		WillReturnRows(
 			sqlmock.NewRows(readingProgressSelectColumns()).AddRow(
 				uuid.New(), uuid.New(), chapterID, 5, updatedAt,
 			),
 		)
 
-	got, err := r.ListByUserAndComic(context.Background(), readingprogress.ListOpts{
+	got, err := r.GetLatestByUserAndComic(context.Background(), readingprogress.ListOpts{
 		UserID:  userID,
 		ComicID: comicID,
 	})
 	if err != nil {
-		t.Fatalf("ListByUserAndComic: %v", err)
+		t.Fatalf("GetLatestByUserAndComic: %v", err)
 	}
 
-	if len(got) != 1 {
-		t.Fatalf("ListByUserAndComic() len = %d, want 1", len(got))
+	if got == nil {
+		t.Fatal("GetLatestByUserAndComic() = nil, want progress")
 	}
 
 	want := readingprogress.Progress{
@@ -87,8 +87,8 @@ func TestListByUserAndComicJoinsLibraryEntry(t *testing.T) {
 		Page:      5,
 		UpdatedAt: updatedAt,
 	}
-	if got[0] != want {
-		t.Errorf("ListByUserAndComic()[0] = %+v, want %+v", got[0], want)
+	if *got != want {
+		t.Errorf("GetLatestByUserAndComic() = %+v, want %+v", *got, want)
 	}
 
 	if otherUserID == userID {
@@ -96,7 +96,7 @@ func TestListByUserAndComicJoinsLibraryEntry(t *testing.T) {
 	}
 }
 
-func TestListOrdersByUpdatedAtDesc(t *testing.T) {
+func TestGetLatestOrdersByUpdatedAtDesc(t *testing.T) {
 	t.Parallel()
 
 	r, mock := newReadingProgressRepo(t)
@@ -105,15 +105,67 @@ func TestListOrdersByUpdatedAtDesc(t *testing.T) {
 	comicID := uuid.New()
 
 	mock.ExpectQuery(`ORDER BY.*updated_at`).
-		WithArgs(userID, comicID).
+		WithArgs(userID, comicID, 1).
 		WillReturnRows(sqlmock.NewRows(readingProgressSelectColumns()))
 
-	_, err := r.ListByUserAndComic(context.Background(), readingprogress.ListOpts{
+	got, err := r.GetLatestByUserAndComic(context.Background(), readingprogress.ListOpts{
 		UserID:  userID,
 		ComicID: comicID,
 	})
 	if err != nil {
-		t.Fatalf("ListByUserAndComic: %v", err)
+		t.Fatalf("GetLatestByUserAndComic: %v", err)
+	}
+
+	if got != nil {
+		t.Errorf("GetLatestByUserAndComic() = %+v, want nil", got)
+	}
+}
+
+func TestListByUserAndChapterIDsEmptySkipsQuery(t *testing.T) {
+	t.Parallel()
+
+	r, _ := newReadingProgressRepo(t)
+
+	got, err := r.ListByUserAndChapterIDs(context.Background(), readingprogress.MapOpts{
+		UserID: uuid.New(),
+		IDs:    nil,
+	})
+	if err != nil {
+		t.Fatalf("ListByUserAndChapterIDs: %v", err)
+	}
+
+	if len(got) != 0 {
+		t.Errorf("ListByUserAndChapterIDs() = %+v, want empty", got)
+	}
+}
+
+func TestListByUserAndChapterIDsJoinsLibraryEntry(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newReadingProgressRepo(t)
+
+	userID := uuid.New()
+	chapterID := uuid.New()
+	updatedAt := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(`JOIN "library_entries" "LibraryEntry".*chapter_id`).
+		WithArgs(userID, chapterID).
+		WillReturnRows(
+			sqlmock.NewRows(readingProgressSelectColumns()).AddRow(
+				uuid.New(), uuid.New(), chapterID, 9, updatedAt,
+			),
+		)
+
+	got, err := r.ListByUserAndChapterIDs(context.Background(), readingprogress.MapOpts{
+		UserID: userID,
+		IDs:    []uuid.UUID{chapterID},
+	})
+	if err != nil {
+		t.Fatalf("ListByUserAndChapterIDs: %v", err)
+	}
+
+	if len(got) != 1 || got[0].ChapterID != chapterID || got[0].Page != 9 {
+		t.Errorf("ListByUserAndChapterIDs() = %+v", got)
 	}
 }
 
@@ -126,7 +178,7 @@ func TestGetNotFound(t *testing.T) {
 	comicID := uuid.New()
 	chapterID := uuid.New()
 
-	mock.ExpectQuery(`reading_progress.*library_entries`).
+	mock.ExpectQuery(`JOIN "library_entries" "LibraryEntry".*WHERE "LibraryEntry"\.(user_id|"user_id")`).
 		WithArgs(userID, comicID, chapterID, 1).
 		WillReturnRows(sqlmock.NewRows(readingProgressSelectColumns()))
 

--- a/api/pkg/core/readingprogress/service.go
+++ b/api/pkg/core/readingprogress/service.go
@@ -58,54 +58,53 @@ func (s *Service) List(ctx context.Context, opts ListOpts) (ListResult, error) {
 		return ListResult{}, err
 	}
 
-	rows, err := s.deps.Repository.ListByUserAndComic(ctx, opts)
+	row, err := s.deps.Repository.GetLatestByUserAndComic(ctx, opts)
 	if err != nil {
-		return ListResult{}, fmt.Errorf("s.deps.Repository.ListByUserAndComic: %w", err)
+		return ListResult{}, fmt.Errorf("s.deps.Repository.GetLatestByUserAndComic: %w", err)
 	}
 
-	if len(rows) == 0 {
-		return ListResult{Chapters: []Progress{}}, nil
+	if row == nil {
+		return ListResult{}, nil
 	}
 
-	ids := make([]uuid.UUID, len(rows))
-	for i, row := range rows {
-		ids[i] = row.ChapterID
-	}
-
-	chapterList, err := s.deps.Chapters.GetByIds(ctx, ids)
+	chapter, err := s.deps.Chapters.GetByID(ctx, row.ChapterID)
 	if err != nil {
-		return ListResult{}, fmt.Errorf("s.deps.Chapters.GetByIds: %w", err)
-	}
-
-	pagesNb := make(map[uuid.UUID]int, len(chapterList))
-	for _, chapter := range chapterList {
-		pagesNb[chapter.ID] = chapter.PagesNb
-	}
-
-	chapters := make([]Progress, len(rows))
-	for i, row := range rows {
-		chapters[i] = Progress{
-			UpdatedAt: row.UpdatedAt,
-			ChapterID: row.ChapterID,
-			Page:      ClampPage(row.Page, pagesNb[row.ChapterID]),
+		if errors.Is(err, domain.ErrNotFound) {
+			return ListResult{
+				Continue: &Continue{ChapterID: row.ChapterID, Page: row.Page},
+			}, nil
 		}
+
+		return ListResult{}, fmt.Errorf("s.deps.Chapters.GetByID: %w", err)
 	}
 
-	result := ListResult{Chapters: chapters}
-	first := chapters[0]
-	result.Continue = &Continue{
-		ChapterID: first.ChapterID,
-		Page:      first.Page,
+	return ListResult{
+		Continue: &Continue{
+			ChapterID: row.ChapterID,
+			Page:      ClampPage(row.Page, chapter.PagesNb),
+		},
+	}, nil
+}
+
+func (s *Service) MapByChapterIDs(ctx context.Context, opts MapOpts) (map[uuid.UUID]Progress, error) {
+	if len(opts.IDs) == 0 {
+		return map[uuid.UUID]Progress{}, nil
 	}
 
-	return result, nil
+	rows, err := s.deps.Repository.ListByUserAndChapterIDs(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.Repository.ListByUserAndChapterIDs: %w", err)
+	}
+
+	out := make(map[uuid.UUID]Progress, len(rows))
+	for _, row := range rows {
+		out[row.ChapterID] = row
+	}
+
+	return out, nil
 }
 
 func (s *Service) Save(ctx context.Context, opts SaveOpts) (Progress, error) {
-	if err := s.requireLibrary(ctx, opts.UserID, opts.ComicID); err != nil {
-		return Progress{}, err
-	}
-
 	chapter, err := s.deps.Chapters.GetByID(ctx, opts.ChapterID)
 	if err != nil {
 		if errors.Is(err, domain.ErrNotFound) {
@@ -115,13 +114,13 @@ func (s *Service) Save(ctx context.Context, opts SaveOpts) (Progress, error) {
 		return Progress{}, fmt.Errorf("s.deps.Chapters.GetByID: %w", err)
 	}
 
-	if chapter.ComicID != opts.ComicID {
-		return Progress{}, domain.ErrNotFound
+	if err = s.requireLibrary(ctx, opts.UserID, chapter.ComicID); err != nil {
+		return Progress{}, err
 	}
 
 	stored, err := s.deps.Repository.Get(ctx, GetOpts{
 		UserID:    opts.UserID,
-		ComicID:   opts.ComicID,
+		ComicID:   chapter.ComicID,
 		ChapterID: opts.ChapterID,
 	})
 	if err != nil {
@@ -146,7 +145,7 @@ func (s *Service) Save(ctx context.Context, opts SaveOpts) (Progress, error) {
 	saved, err := s.deps.Repository.Upsert(ctx, UpsertOpts{
 		UpdatedAt: time.Now().UTC(),
 		UserID:    opts.UserID,
-		ComicID:   opts.ComicID,
+		ComicID:   chapter.ComicID,
 		ChapterID: opts.ChapterID,
 		Page:      page,
 	})

--- a/api/pkg/core/readingprogress/service_test.go
+++ b/api/pkg/core/readingprogress/service_test.go
@@ -28,14 +28,35 @@ type fakeRepo struct {
 	listed      readingprogress.ListOpts
 }
 
-func (f *fakeRepo) ListByUserAndComic(
+func (f *fakeRepo) GetLatestByUserAndComic(
 	_ context.Context,
 	opts readingprogress.ListOpts,
-) ([]readingprogress.Progress, error) {
+) (*readingprogress.Progress, error) {
 	f.listCalls++
 	f.listed = opts
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
 
-	return f.rows, f.listErr
+	if len(f.rows) == 0 {
+		return nil, nil
+	}
+
+	row := f.rows[0]
+
+	return &row, nil
+}
+
+func (f *fakeRepo) ListByUserAndChapterIDs(
+	_ context.Context,
+	_ readingprogress.MapOpts,
+) ([]readingprogress.Progress, error) {
+	f.listCalls++
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+
+	return f.rows, nil
 }
 
 func (f *fakeRepo) Get(_ context.Context, opts readingprogress.GetOpts) (*readingprogress.Progress, error) {
@@ -91,12 +112,9 @@ func (f *fakeComics) Exists(_ context.Context, id uuid.UUID) (bool, error) {
 
 type fakeChapters struct {
 	getErr   error
-	idsErr   error
 	chapter  *chapters.Chapter
-	byID     map[uuid.UUID]chapters.Chapter
 	lastID   uuid.UUID
 	getCalls int
-	idsCalls int
 }
 
 func (f *fakeChapters) GetByID(_ context.Context, id uuid.UUID) (*chapters.Chapter, error) {
@@ -107,22 +125,6 @@ func (f *fakeChapters) GetByID(_ context.Context, id uuid.UUID) (*chapters.Chapt
 	}
 
 	return f.chapter, nil
-}
-
-func (f *fakeChapters) GetByIds(_ context.Context, ids []uuid.UUID) ([]chapters.Chapter, error) {
-	f.idsCalls++
-	if f.idsErr != nil {
-		return nil, f.idsErr
-	}
-
-	out := make([]chapters.Chapter, 0, len(ids))
-	for _, id := range ids {
-		if ch, ok := f.byID[id]; ok {
-			out = append(out, ch)
-		}
-	}
-
-	return out, nil
 }
 
 func newService(
@@ -168,14 +170,14 @@ func TestSaveTwoChaptersContinueIsLastOpened(t *testing.T) {
 	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, chap)
 
 	if _, err := svc.Save(context.Background(), readingprogress.SaveOpts{
-		UserID: userID, ComicID: comicID, ChapterID: ch10, Page: 5,
+		UserID: userID, ChapterID: ch10, Page: 5,
 	}); err != nil {
 		t.Fatalf("Save ch10: %v", err)
 	}
 
 	chap.chapter = &chapters.Chapter{ID: ch3, ComicID: comicID, PagesNb: 20, Download: 100}
 	got, err := svc.Save(context.Background(), readingprogress.SaveOpts{
-		UserID: userID, ComicID: comicID, ChapterID: ch3, Page: 12,
+		UserID: userID, ChapterID: ch3, Page: 12,
 	})
 	if err != nil {
 		t.Fatalf("Save ch3: %v", err)
@@ -205,7 +207,7 @@ func TestSaveDoesNotReadDownload(t *testing.T) {
 	})
 
 	if _, err := svc.Save(context.Background(), readingprogress.SaveOpts{
-		UserID: uuid.New(), ComicID: comicID, ChapterID: chID, Page: 2,
+		UserID: uuid.New(), ChapterID: chID, Page: 2,
 	}); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
@@ -228,7 +230,7 @@ func TestSaveLowerPageKeepsFurthestAndWrites(t *testing.T) {
 	})
 
 	got, err := svc.Save(context.Background(), readingprogress.SaveOpts{
-		UserID: uuid.New(), ComicID: comicID, ChapterID: chID, Page: 8,
+		UserID: uuid.New(), ChapterID: chID, Page: 8,
 	})
 	if err != nil {
 		t.Fatalf("Save: %v", err)
@@ -254,7 +256,7 @@ func TestSaveGetNotFoundTreatsAsNoStoredRow(t *testing.T) {
 	})
 
 	got, err := svc.Save(context.Background(), readingprogress.SaveOpts{
-		UserID: uuid.New(), ComicID: comicID, ChapterID: chID, Page: 3,
+		UserID: uuid.New(), ChapterID: chID, Page: 3,
 	})
 	if err != nil {
 		t.Fatalf("Save: %v", err)
@@ -281,7 +283,7 @@ func TestSaveGetErrorWraps(t *testing.T) {
 	})
 
 	_, err := svc.Save(context.Background(), readingprogress.SaveOpts{
-		UserID: uuid.New(), ComicID: comicID, ChapterID: chID, Page: 1,
+		UserID: uuid.New(), ChapterID: chID, Page: 1,
 	})
 	if err == nil {
 		t.Fatal("expected error")
@@ -296,11 +298,14 @@ func TestSaveForbiddenWhenNotInLibrary(t *testing.T) {
 	t.Parallel()
 
 	comicID := uuid.New()
+	chID := uuid.New()
 	repo := &fakeRepo{}
-	svc := newService(t, repo, &fakeLibrary{inLib: false}, &fakeComics{exists: true}, &fakeChapters{})
+	svc := newService(t, repo, &fakeLibrary{inLib: false}, &fakeComics{exists: true}, &fakeChapters{
+		chapter: &chapters.Chapter{ID: chID, ComicID: comicID, PagesNb: 10},
+	})
 
 	_, err := svc.Save(context.Background(), readingprogress.SaveOpts{
-		UserID: uuid.New(), ComicID: comicID, ChapterID: uuid.New(), Page: 1,
+		UserID: uuid.New(), ChapterID: chID, Page: 1,
 	})
 	if !errors.Is(err, domain.ErrForbidden) {
 		t.Errorf("err = %v, want ErrForbidden", err)
@@ -314,11 +319,15 @@ func TestSaveForbiddenWhenNotInLibrary(t *testing.T) {
 func TestSaveNotFoundWhenComicMissing(t *testing.T) {
 	t.Parallel()
 
+	comicID := uuid.New()
+	chID := uuid.New()
 	repo := &fakeRepo{}
-	svc := newService(t, repo, &fakeLibrary{inLib: false}, &fakeComics{exists: false}, &fakeChapters{})
+	svc := newService(t, repo, &fakeLibrary{inLib: false}, &fakeComics{exists: false}, &fakeChapters{
+		chapter: &chapters.Chapter{ID: chID, ComicID: comicID, PagesNb: 10},
+	})
 
 	_, err := svc.Save(context.Background(), readingprogress.SaveOpts{
-		UserID: uuid.New(), ComicID: uuid.New(), ChapterID: uuid.New(), Page: 1,
+		UserID: uuid.New(), ChapterID: chID, Page: 1,
 	})
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Errorf("err = %v, want ErrNotFound", err)
@@ -334,7 +343,7 @@ func TestSaveUnknownChapter(t *testing.T) {
 	})
 
 	_, err := svc.Save(context.Background(), readingprogress.SaveOpts{
-		UserID: uuid.New(), ComicID: uuid.New(), ChapterID: uuid.New(), Page: 1,
+		UserID: uuid.New(), ChapterID: uuid.New(), Page: 1,
 	})
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Errorf("err = %v, want ErrNotFound", err)
@@ -342,22 +351,6 @@ func TestSaveUnknownChapter(t *testing.T) {
 
 	if repo.upsertCalls != 0 {
 		t.Error("upsert for unknown chapter")
-	}
-}
-
-func TestSaveChapterOfAnotherComic(t *testing.T) {
-	t.Parallel()
-
-	repo := &fakeRepo{}
-	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{}, &fakeChapters{
-		chapter: &chapters.Chapter{ID: uuid.New(), ComicID: uuid.New(), PagesNb: 10},
-	})
-
-	_, err := svc.Save(context.Background(), readingprogress.SaveOpts{
-		UserID: uuid.New(), ComicID: uuid.New(), ChapterID: uuid.New(), Page: 1,
-	})
-	if !errors.Is(err, domain.ErrNotFound) {
-		t.Errorf("err = %v, want ErrNotFound", err)
 	}
 }
 
@@ -372,7 +365,7 @@ func TestSaveRejectsPageAbovePagesNb(t *testing.T) {
 	})
 
 	_, err := svc.Save(context.Background(), readingprogress.SaveOpts{
-		UserID: uuid.New(), ComicID: comicID, ChapterID: chID, Page: 16,
+		UserID: uuid.New(), ChapterID: chID, Page: 16,
 	})
 	if !errors.Is(err, readingprogress.ErrInvalid) {
 		t.Errorf("err = %v, want ErrInvalid", err)
@@ -400,10 +393,6 @@ func TestListEmptyContinueNull(t *testing.T) {
 		t.Errorf("continue = %+v, want nil", got.Continue)
 	}
 
-	if got.Chapters == nil || len(got.Chapters) != 0 {
-		t.Errorf("chapters = %#v, want empty non-nil", got.Chapters)
-	}
-
 	if repo.listed.UserID != userID || repo.listed.ComicID != comicID {
 		t.Errorf("list opts = %+v", repo.listed)
 	}
@@ -419,18 +408,12 @@ func TestListClampsWithoutWrite(t *testing.T) {
 		UpdatedAt: time.Unix(2, 0).UTC(),
 	}}}
 	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{}, &fakeChapters{
-		byID: map[uuid.UUID]chapters.Chapter{
-			chID: {ID: chID, PagesNb: 12, Download: 50},
-		},
+		chapter: &chapters.Chapter{ID: chID, PagesNb: 12, Download: 50},
 	})
 
 	got, err := svc.List(context.Background(), readingprogress.ListOpts{UserID: uuid.New(), ComicID: uuid.New()})
 	if err != nil {
 		t.Fatalf("List: %v", err)
-	}
-
-	if len(got.Chapters) != 1 || got.Chapters[0].Page != 12 {
-		t.Errorf("chapters = %+v, want page 12", got.Chapters)
 	}
 
 	if got.Continue == nil || got.Continue.Page != 12 || got.Continue.ChapterID != chID {

--- a/api/pkg/sources/asurascans/pkg/core/app_test.go
+++ b/api/pkg/sources/asurascans/pkg/core/app_test.go
@@ -224,6 +224,16 @@ func (s libraryChaptersService) GetForLibrary(context.Context, chapters.GetForLi
 	return nil, nil
 }
 
+func (s libraryChaptersService) GetDetailForLibrary(
+	context.Context, chapters.GetForLibraryOpts,
+) (*chapters.ChapterDetail, error) {
+	return nil, nil
+}
+
+func (s libraryChaptersService) ServePage(context.Context, chapters.ServePageOpts) (string, string, error) {
+	return "", "", nil
+}
+
 func newCache[P any, T any](
 	t *testing.T, key func(P) string, fn func(context.Context, P) (*T, error),
 ) *fncache.Cache[P, T] {

--- a/api/pkg/sources/asurascans/pkg/core/app_test.go
+++ b/api/pkg/sources/asurascans/pkg/core/app_test.go
@@ -220,6 +220,10 @@ func (s libraryChaptersService) ListForLibrary(context.Context, chapters.ListFor
 	return nil, nil
 }
 
+func (s libraryChaptersService) GetForLibrary(context.Context, chapters.GetForLibraryOpts) (*chapters.Chapter, error) {
+	return nil, nil
+}
+
 func newCache[P any, T any](
 	t *testing.T, key func(P) string, fn func(context.Context, P) (*T, error),
 ) *fncache.Cache[P, T] {

--- a/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
+++ b/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
@@ -173,6 +173,10 @@ func (s libraryChaptersService) ListForLibrary(context.Context, chapters.ListFor
 	return nil, nil
 }
 
+func (s libraryChaptersService) GetForLibrary(context.Context, chapters.GetForLibraryOpts) (*chapters.Chapter, error) {
+	return nil, nil
+}
+
 func newTestAsuraApp(t *testing.T) *asura.App {
 	t.Helper()
 

--- a/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
+++ b/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
@@ -177,6 +177,16 @@ func (s libraryChaptersService) GetForLibrary(context.Context, chapters.GetForLi
 	return nil, nil
 }
 
+func (s libraryChaptersService) GetDetailForLibrary(
+	context.Context, chapters.GetForLibraryOpts,
+) (*chapters.ChapterDetail, error) {
+	return nil, nil
+}
+
+func (s libraryChaptersService) ServePage(context.Context, chapters.ServePageOpts) (string, string, error) {
+	return "", "", nil
+}
+
 func newTestAsuraApp(t *testing.T) *asura.App {
 	t.Helper()
 

--- a/web/app/features/asura/composables/asura-chapters.composable.test.ts
+++ b/web/app/features/asura/composables/asura-chapters.composable.test.ts
@@ -32,6 +32,8 @@ function createChaptersApiStub(): ChaptersApi {
     retryDownload: retryDownloadApi,
     getByIds: vi.fn(),
     getByComicId: vi.fn(),
+    getById: vi.fn(),
+    saveProgress: vi.fn(),
   }
 }
 

--- a/web/app/features/chapters/composables/chapters.api.ts
+++ b/web/app/features/chapters/composables/chapters.api.ts
@@ -1,4 +1,4 @@
-import type { Chapter } from '../types'
+import type { Chapter, ChapterProgress, DetailedChapter, SaveChapterProgressRequest } from '../types'
 import type { ApiResponse } from '~/utils/api'
 import { ApiError, initApi } from '~/utils/api'
 
@@ -6,6 +6,20 @@ export interface ChaptersApi {
   retryDownload: (chapterId: string) => Promise<ApiResponse<void>>
   getByIds: (ids: string[]) => Promise<ApiResponse<Chapter[]>>
   getByComicId: (comicId: string) => Promise<ApiResponse<Chapter[]>>
+  getById: (id: string) => Promise<ApiResponse<DetailedChapter>>
+  saveProgress: (req: SaveChapterProgressRequest) => Promise<ApiResponse<ChapterProgress>>
+}
+
+function chapterFromHTTP({ progress, ...chapter }: Chapter): Chapter {
+  return {
+    ...chapter,
+    progress: progress
+      ? {
+          updatedAt: new Date(progress.updatedAt),
+          page: progress.page,
+        }
+      : undefined,
+  }
 }
 
 export function createChaptersApi(): ChaptersApi {
@@ -25,7 +39,10 @@ export function createChaptersApi(): ChaptersApi {
     try {
       const response = await api<Chapter[]>(`/list`, { method: 'POST', body: { ids } })
 
-      return { success: true, data: response }
+      return {
+        success: true,
+        data: response.map(chapter => chapterFromHTTP(chapter)),
+      }
     } catch (error) {
       return { success: false, error: ApiError.fromFetchError(error) }
     }
@@ -34,6 +51,37 @@ export function createChaptersApi(): ChaptersApi {
   async function getByComicId(comicId: string): Promise<ApiResponse<Chapter[]>> {
     try {
       const response = await api<Chapter[]>(`/`, { params: { comicId } })
+
+      return {
+        success: true,
+        data: response.map(chapter => chapterFromHTTP(chapter)),
+      }
+    } catch (error) {
+      return { success: false, error: ApiError.fromFetchError(error) }
+    }
+  }
+
+  async function getById(id: string): Promise<ApiResponse<DetailedChapter>> {
+    try {
+      const { previousChapterId, nextChapterId, pageUrls, ...response } = await api<DetailedChapter>(`/${id}`)
+
+      return {
+        success: true,
+        data: {
+          ...chapterFromHTTP(response),
+          pageUrls: pageUrls ?? [],
+          nextChapterId,
+          previousChapterId,
+        },
+      }
+    } catch (error) {
+      return { success: false, error: ApiError.fromFetchError(error) }
+    }
+  }
+
+  async function saveProgress({ id, ...body }: SaveChapterProgressRequest): Promise<ApiResponse<ChapterProgress>> {
+    try {
+      const response = await api<ChapterProgress>(`/${id}/progress`, { method: 'PUT', body })
 
       return { success: true, data: response }
     } catch (error) {
@@ -45,5 +93,7 @@ export function createChaptersApi(): ChaptersApi {
     retryDownload,
     getByIds,
     getByComicId,
+    getById,
+    saveProgress,
   }
 }

--- a/web/app/features/chapters/types.ts
+++ b/web/app/features/chapters/types.ts
@@ -8,4 +8,21 @@ export interface Chapter {
   number: number
   pagesNb: number
   download: number
+  progress?: ChapterProgress
+}
+
+export interface ChapterProgress {
+  updatedAt: Date
+  page: number
+}
+
+export interface SaveChapterProgressRequest {
+  id: string
+  page: number
+}
+
+export type DetailedChapter = Chapter & {
+  pageUrls: string[]
+  nextChapterId?: string
+  previousChapterId?: string
 }

--- a/web/app/features/comics/components/Chapters/Item.vue
+++ b/web/app/features/comics/components/Chapters/Item.vue
@@ -1,11 +1,12 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script setup lang="ts">
-import type { Chapter } from '~/features/chapters/types'
+import type { Chapter, ChapterProgress } from '~/features/chapters/types'
 import { formatRelativeTime } from '~/utils/date.utils'
 
 const props = defineProps<{
   chapter: Chapter
   retryLoading: boolean
+  progress?: ChapterProgress
 }>()
 
 defineEmits<{ retry: [] }>()
@@ -34,77 +35,94 @@ const isChapterDownloading = computed(() => props.chapter.download !== undefined
 
 const isChapterDownloaded = computed(() => props.chapter.download === 100)
 const isChapterDownloadingError = computed(() => props.chapter.download === -1 && !props.retryLoading)
+
+const to = computed(() => {
+  if (props.chapter.download !== 100) {
+    return
+  }
+
+  return `/comic/${props.chapter.comicId}/${props.chapter.id}`
+})
 </script>
 
 <template>
-  <div
-    class="d-flex justify-space-between ga-6 pa-4 border-b-thin bg-surface align-center text-truncate transition-smooth"
-    :class="{
-      'early-access-chapter': isEarlyAccess,
-      'readable-chapter': !isEarlyAccess,
-    }"
-  >
-    <div class="d-flex align-center ga-4">
-      <div v-if="isEarlyAccess" class="d-flex flex-column items-center justify-center border-thin-gold pa-2 text-body-small rounded-lg early-access-icon">
-        <VIcon
-          icon="fa6-solid:lock"
-          size="x-small"
-          color="gold"
-        />
-      </div>
-      <div
-        class="d-flex flex-wrap text-truncate"
-        :class="{
-          'flex-column': isEarlyAccess,
-          'align-center': !isEarlyAccess,
-          'ga-4': !isEarlyAccess,
-        }"
-      >
-        <span class="text-body-large font-weight-bold">{{ $t('sources.asurascans.comic.chapter', { number: chapter.number }) }}</span>
-        <span v-if="chapter.title && !isEarlyAccess" class="text-body-medium text-medium-emphasis text-truncate">{{ chapter.title }}</span>
-        <span
-          v-else-if="isEarlyAccess"
-          class="text-body-medium text-medium-emphasis text-truncate text-gold"
+  <AtomLink :to>
+    <div
+      class="d-flex justify-space-between ga-6 pa-4 border-b-thin bg-surface align-center text-truncate transition-smooth"
+      :class="{
+        'early-access-chapter': isEarlyAccess,
+        'readable-chapter': !isEarlyAccess,
+      }"
+    >
+      <div class="d-flex align-center ga-4">
+        <div v-if="isEarlyAccess" class="d-flex flex-column items-center justify-center border-thin-gold pa-2 text-body-small rounded-lg early-access-icon">
+          <VIcon
+            icon="fa6-solid:lock"
+            size="x-small"
+            color="gold"
+          />
+        </div>
+        <div
+          class="d-flex flex-wrap text-truncate"
+          :class="{
+            'flex-column': isEarlyAccess,
+            'align-center': !isEarlyAccess,
+            'ga-4': !isEarlyAccess,
+          }"
         >
-          {{ $t('sources.asurascans.comic.chapterUnlocksIn', { time: formatRelativeTime(chapter.earlyAccessUntil as Date, { locale, direction: 'future' }) }) }}
-        </span>
+          <span
+            class="text-body-large"
+            :class="{
+              'font-weight-bold': chapter.download === 100,
+              'text-medium-emphasis': chapter.download !== 100 || progress,
+              'text-primary': chapter.download === 100 && progress,
+            }"
+          >{{ $t('sources.asurascans.comic.chapter', { number: chapter.number }) }}</span>
+          <span v-if="chapter.title && !isEarlyAccess" class="text-body-medium text-medium-emphasis text-truncate">{{ chapter.title }}</span>
+          <span
+            v-else-if="isEarlyAccess"
+            class="text-body-medium text-medium-emphasis text-truncate text-gold"
+          >
+            {{ $t('sources.asurascans.comic.chapterUnlocksIn', { time: formatRelativeTime(chapter.earlyAccessUntil as Date, { locale, direction: 'future' }) }) }}
+          </span>
+        </div>
+      </div>
+
+      <div class="d-flex align-center ga-3">
+        <VProgressCircular
+          v-if="isChapterDownloading"
+          :model-value="chapter.download"
+          size="18"
+          :indeterminate="chapter.download === 0"
+          width="2"
+          color="primary"
+        />
+        <VIcon
+          v-if="isChapterDownloaded"
+          icon="fa6-solid:check"
+          size="x-small"
+          color="success"
+        />
+        <VIcon
+          v-if="isChapterDownloadingError && !props.retryLoading"
+          v-tooltip:bottom="$t('sources.asurascans.comic.retryDownloadChapter.tooltip')"
+          icon="fa6-solid:exclamation"
+          classs="cursor-pointer"
+          size="x-small"
+          color="error"
+          @click.prevent="$emit('retry')"
+        />
+        <VProgressCircular
+          v-if="isChapterDownloadingError && props.retryLoading"
+          indeterminate
+          size="18"
+          width="2"
+          color="error"
+        />
+        <span class="text-body-medium text-medium-emphasis" :class="{ 'text-gold': isEarlyAccess }">{{ date }}</span>
       </div>
     </div>
-
-    <div class="d-flex align-center ga-3">
-      <VProgressCircular
-        v-if="isChapterDownloading"
-        :model-value="chapter.download"
-        size="18"
-        :indeterminate="chapter.download === 0"
-        width="2"
-        color="primary"
-      />
-      <VIcon
-        v-if="isChapterDownloaded"
-        icon="fa6-solid:check"
-        size="x-small"
-        color="success"
-      />
-      <VIcon
-        v-if="isChapterDownloadingError && !props.retryLoading"
-        v-tooltip:bottom="$t('sources.asurascans.comic.retryDownloadChapter.tooltip')"
-        icon="fa6-solid:exclamation"
-        classs="cursor-pointer"
-        size="x-small"
-        color="error"
-        @click.prevent="$emit('retry')"
-      />
-      <VProgressCircular
-        v-if="isChapterDownloadingError && props.retryLoading"
-        indeterminate
-        size="18"
-        width="2"
-        color="error"
-      />
-      <span class="text-body-medium text-medium-emphasis" :class="{ 'text-gold': isEarlyAccess }">{{ date }}</span>
-    </div>
-  </div>
+  </AtomLink>
 </template>
 
 <style lang="scss">

--- a/web/app/features/comics/components/Chapters/index.vue
+++ b/web/app/features/comics/components/Chapters/index.vue
@@ -1,13 +1,18 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script setup lang="ts">
+import type { ComicProgressContinue } from '../../types'
 import type { Chapter } from '~/features/chapters/types'
 
-const props = defineProps<{ id: string }>()
+const props = defineProps<{
+  id: string
+  continue?: ComicProgressContinue
+}>()
 
 const POLL_INTERVAL_MS = 2000
 
 const { t } = useI18n()
 const toast = useToast()
+const { smAndDown } = useDisplay()
 const api = createChaptersApi()
 
 const chapters = ref<Chapter[]>([])
@@ -126,18 +131,77 @@ async function retryChapter(chapterId: string): Promise<void> {
 
   delete retryChaptersLoading.value[chapterId]
 }
+
+const nextChapter = computed(() => {
+  if (!props.continue) {
+    return
+  }
+
+  const chaptersCpy = sort.value === 'asc' ? chapters.value : chapters.value.toSorted((a, b) => a.number - b.number)
+  const continueCpy = props.continue
+
+  if (!continueCpy) {
+    return chaptersCpy[0] as Chapter
+  }
+
+  const i = chaptersCpy.findIndex(chapter => chapter.id === continueCpy.chapterId)
+  if (i === -1) {
+    return
+  }
+
+  if (continueCpy.page === chaptersCpy[i]!.pagesNb) {
+    if (i === chaptersCpy.length - 1) {
+      return
+    }
+
+    return chaptersCpy[i + 1] as Chapter
+  }
+
+  return chaptersCpy[i] as Chapter
+})
+const nextChapterText = computed(() => {
+  if (!nextChapter.value || smAndDown.value) {
+    return
+  }
+
+  return nextChapter.value.number === 1 ? $t('common.start') : $t('common.continue')
+})
+
+const sortIcon = computed(() => sort.value === 'asc' ? 'fa6-solid:arrow-down-short-wide' : 'fa6-solid:arrow-up-short-wide')
+const sortText = computed(() => {
+  if (smAndDown.value) {
+    return
+  }
+
+  return sort.value === 'asc' ? $t('common.sort.oldest') : $t('common.sort.latest')
+})
 </script>
 
 <template>
   <div class="d-flex flex-column w-100 position-relative bg-surface" style="border-radius: 12px; max-height: 40rem;">
     <div class="d-flex justify-space-between ga-6 pa-4 border-b-thin bg-surface align-center" style="z-index: 1; border-top-left-radius: 12px; border-top-right-radius: 12px;">
       <span class="text-title-large font-weight-bold">{{ $t('sources.asurascans.comic.chaptersCount', { count: chapters.length }) }}</span>
+      <AtomLink
+        v-if="nextChapter"
+        :to="nextChapter && nextChapter.download === 100 ? `/comic/${props.id}/${nextChapter.id}` : undefined"
+      >
+        <VBtn
+          variant="tonal"
+          class="border-thin-primary"
+          :icon="smAndDown ? 'fa6-solid:play' : undefined"
+          :prepend-icon="smAndDown ? undefined : 'fa6-solid:play'"
+          :text="nextChapterText"
+          :size="smAndDown ? 'small' : undefined"
+        />
+      </AtomLink>
       <VBtn
         variant="tonal"
         class="text-body-medium"
         color="surfaceVariant"
-        :text="sort === 'asc' ? $t('common.sort.oldest') : $t('common.sort.latest')"
-        :prepend-icon="sort === 'desc' ? 'fa6-solid:arrow-down-short-wide' : 'fa6-solid:arrow-up-short-wide'"
+        :icon="smAndDown ? sortIcon : undefined"
+        :text="sortText"
+        :size="smAndDown ? 'small' : undefined"
+        :prepend-icon="smAndDown ? undefined : sortIcon"
         @click="sort = sort === 'asc' ? 'desc' : 'asc'"
       />
     </div>

--- a/web/app/features/comics/composables/comics.api.ts
+++ b/web/app/features/comics/composables/comics.api.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import type { Comic, LightComic, SearchComicParams, SearchComicResponse } from '../types'
+import type { Comic, ComicProgress, LightComic, SearchComicParams, SearchComicResponse } from '../types'
 import type { ApiResponse } from '~/utils/api'
 import { ApiError, initApi } from '~/utils/api'
 
@@ -10,6 +10,7 @@ export interface ComicsApi {
   search: (params: SearchComicParams) => Promise<ApiResponse<SearchComicResponse>>
   getById: (id: string) => Promise<ApiResponse<Comic>>
   refreshById: (id: string) => Promise<ApiResponse<Comic>>
+  getProgress: (id: string) => Promise<ApiResponse<ComicProgress>>
 }
 
 export interface CreateComicParams {
@@ -81,11 +82,27 @@ export function createComicsApi(): ComicsApi {
     }
   }
 
+  async function getProgress(id: string): Promise<ApiResponse<ComicProgress>> {
+    try {
+      const response = await api<ComicProgress>(`/${id}/progress`, { method: 'GET' })
+
+      return {
+        success: true,
+        data: {
+          continue: response.continue,
+        },
+      }
+    } catch (error) {
+      return { success: false, error: ApiError.fromFetchError(error) }
+    }
+  }
+
   return {
     create,
     deleteById,
     search,
     getById,
     refreshById,
+    getProgress,
   }
 }

--- a/web/app/features/comics/types.ts
+++ b/web/app/features/comics/types.ts
@@ -48,3 +48,12 @@ export interface Comic {
   altTitles: string[]
   chapterCount: number
 }
+
+export interface ComicProgress {
+  continue?: ComicProgressContinue
+}
+
+export interface ComicProgressContinue {
+  chapterId: string
+  page: number
+}

--- a/web/app/features/feed/components/ComicCard/Chapter.test.ts
+++ b/web/app/features/feed/components/ComicCard/Chapter.test.ts
@@ -21,7 +21,7 @@ function chapter(overrides: Partial<FeedChapter> = {}): FeedChapter {
 
 async function mount(value: FeedChapter): Promise<VueWrapper> {
   return mountSuspended({
-    render: () => h(VApp, () => [h(Chapter, { chapter: value })]),
+    render: () => h(VApp, () => [h(Chapter, { comicId: 'comic-1', chapter: value })]),
   })
 }
 

--- a/web/app/features/feed/components/ComicCard/Chapter.vue
+++ b/web/app/features/feed/components/ComicCard/Chapter.vue
@@ -2,7 +2,10 @@
 import type { FeedChapter } from '../../types'
 import { formatRelativeTime } from '~/utils/date.utils'
 
-const props = defineProps<{ chapter: FeedChapter }>()
+const props = defineProps<{
+  comicId: string
+  chapter: FeedChapter
+}>()
 
 const { locale } = useI18n()
 
@@ -12,32 +15,34 @@ const date = computed(() => {
 </script>
 
 <template>
-  <div class="d-flex justify-space-between ga-2 transition-smooth align-center" :class="{ 'feed-chapter': chapter.download === 100 }">
-    <div class="d-flex ga-2 align-center">
-      <span
-        class="text-body-large feed-chapter-title"
-        style="font-size: 1.05rem;"
-        :class="{ 'text-medium-emphasis': chapter.download !== 100 }"
-      > {{ $t('feed.chapter.number', { number: chapter.number }) }} </span>
-      <template v-if="chapter.download !== 100">
-        <VIcon
-          v-if="chapter.download === -1"
-          icon="fa6-solid:exclamation"
-          size="x-small"
-          color="error"
-        />
-        <VProgressCircular
-          v-else
-          :value="chapter.download"
-          size="18"
-          :indeterminate="chapter.download === 0"
-          width="2"
-          color="primary"
-        />
-      </template>
+  <AtomLink :to="chapter.download === 100 ? `/comic/${props.comicId}/${props.chapter.id}` : undefined">
+    <div class="d-flex justify-space-between ga-2 transition-smooth align-center" :class="{ 'feed-chapter': chapter.download === 100 }">
+      <div class="d-flex ga-2 align-center">
+        <span
+          class="text-body-large feed-chapter-title"
+          style="font-size: 1.05rem;"
+          :class="{ 'text-medium-emphasis': chapter.download !== 100 }"
+        > {{ $t('feed.chapter.number', { number: chapter.number }) }} </span>
+        <template v-if="chapter.download !== 100">
+          <VIcon
+            v-if="chapter.download === -1"
+            icon="fa6-solid:exclamation"
+            size="x-small"
+            color="error"
+          />
+          <VProgressCircular
+            v-else
+            :value="chapter.download"
+            size="18"
+            :indeterminate="chapter.download === 0"
+            width="2"
+            color="primary"
+          />
+        </template>
+      </div>
+      <span class="text-body-medium text-medium-emphasis"> {{ date }} </span>
     </div>
-    <span class="text-body-medium text-medium-emphasis"> {{ date }} </span>
-  </div>
+  </AtomLink>
 </template>
 
 <style lang="scss">

--- a/web/app/features/feed/components/ComicCard/index.test.ts
+++ b/web/app/features/feed/components/ComicCard/index.test.ts
@@ -18,6 +18,7 @@ function item(overrides: Partial<FeedItem> = {}): FeedItem {
     source: 'asurascans',
     status: 'ongoing',
     type: 'manhwa',
+    hasProgress: true,
     latestChapters: [{
       id: 'ch-1',
       number: 12,

--- a/web/app/features/feed/components/ComicCard/index.vue
+++ b/web/app/features/feed/components/ComicCard/index.vue
@@ -39,6 +39,7 @@ watch(() => props.item.cover, () => {
           <FeedComicCardChapter
             v-for="(chapter, index) in item.latestChapters"
             :key="index"
+            :comic-id="item.id"
             :chapter
           />
         </div>

--- a/web/app/features/feed/composables/feed.composable.test.ts
+++ b/web/app/features/feed/composables/feed.composable.test.ts
@@ -49,6 +49,7 @@ function item(overrides: Partial<FeedItem> = {}): FeedItem {
     source: 'asurascans',
     status: 'ongoing',
     type: 'manhwa',
+    hasProgress: true,
     latestChapters: [{
       id: 'ch-1',
       number: 1,

--- a/web/app/features/feed/composables/feed.composable.test.ts
+++ b/web/app/features/feed/composables/feed.composable.test.ts
@@ -41,7 +41,7 @@ mockNuxtImport('useDebounceFn', debounceStub)
 mockNuxtImport('createChaptersApi', () => createChaptersApiStub)
 
 function item(overrides: Partial<FeedItem> = {}): FeedItem {
-  return {
+  const defaults: FeedItem = {
     id: 'comic-1',
     title: 'Solo Leveling',
     slug: 'solo-leveling',
@@ -56,8 +56,9 @@ function item(overrides: Partial<FeedItem> = {}): FeedItem {
       download: 100,
       publishedAt: new Date('2026-01-01'),
     }],
-    ...overrides,
   }
+
+  return { ...defaults, ...overrides }
 }
 
 function chapter(overrides: Partial<Chapter> = {}): Chapter {

--- a/web/app/features/feed/types.ts
+++ b/web/app/features/feed/types.ts
@@ -8,6 +8,7 @@ export interface FeedItem {
   source: ComicSource
   status: ComicStatus
   type: ComicType
+  hasProgress: boolean
   latestChapters: FeedChapter[]
 }
 

--- a/web/app/layouts/chapter.vue
+++ b/web/app/layouts/chapter.vue
@@ -1,0 +1,14 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+const { messages } = useToast()
+</script>
+
+<template>
+  <VApp>
+    <VMain>
+      <slot />
+    </VMain>
+
+    <VSnackbarQueue v-model="messages" />
+  </VApp>
+</template>

--- a/web/app/pages/comic/[id]/[chapterId].vue
+++ b/web/app/pages/comic/[id]/[chapterId].vue
@@ -1,6 +1,8 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script setup lang="ts">
 import type { DetailedChapter } from '~/features/chapters/types'
+import type { Comic } from '~/features/comics/types'
+import type { ReaderSettings } from '~/features/reader/types'
 import { AUTHENTICATED_ROUTE_GROUP } from '~/constants/auth'
 
 definePageMeta({
@@ -10,12 +12,17 @@ definePageMeta({
 
 const route = useRoute('comic-id-chapterId')
 const api = createChaptersApi()
+const comicsApi = createComicsApi()
+const readerSettingsApi = createReaderSettingsApi()
 const { t } = useI18n()
 const toast = useToast()
 const { smAndDown } = useDisplay()
 
 const chapter = ref<DetailedChapter>()
+const comic = ref<Comic>()
 const isLoading = ref(true)
+
+const readerSettings = ref<ReaderSettings>()
 
 async function fetchChapter(): Promise<void> {
   const res = await api.getById(route.params.chapterId)
@@ -33,8 +40,47 @@ async function fetchChapter(): Promise<void> {
   chapter.value = res.data
 }
 
+async function fetchReaderSettings(): Promise<ReaderSettings[]> {
+  const res = await readerSettingsApi.getReaderSettings()
+  if (!res.success) {
+    console.error('readerSettingsApi.get', res.error)
+    toast.error(t('error.unknown'))
+
+    return []
+  }
+
+  return res.data
+}
+
+async function fetchComic(): Promise<void> {
+  const res = await comicsApi.getById(route.params.id)
+  if (!res.success) {
+    console.error('comicsApi.getById', res.error)
+    toast.error(res.error.status === 404 || res.error.status === 403
+      ? t('sources.asura.comic.notFound')
+      : t('error.unknown'))
+
+    navigateTo({ name: 'library' })
+
+    return
+  }
+
+  comic.value = res.data
+}
+
 onMounted(async () => {
-  fetchChapter()
+  const [_, __, settings] = await Promise.all([
+    fetchChapter(),
+    fetchComic(),
+    fetchReaderSettings(),
+  ])
+
+  readerSettings.value = settings.find(({ type }) => type === comic.value?.type)
+  if (!readerSettings.value) {
+    navigateTo({ name: 'comic-id', params: { id: route.params.id } })
+
+    return
+  }
 
   isLoading.value = false
 })
@@ -53,6 +99,14 @@ async function retryDownload(): Promise<void> {
 
   isRetrying.value = false
 }
+
+watch(() => route.params.chapterId, async (): Promise<void> => {
+  isLoading.value = true
+
+  await fetchChapter()
+
+  isLoading.value = false
+})
 </script>
 
 <template>

--- a/web/app/pages/comic/[id]/[chapterId].vue
+++ b/web/app/pages/comic/[id]/[chapterId].vue
@@ -38,6 +38,7 @@ async function fetchChapter(): Promise<void> {
   }
 
   chapter.value = res.data
+  syncPolling()
 }
 
 async function fetchReaderSettings(): Promise<ReaderSettings[]> {
@@ -107,6 +108,31 @@ watch(() => route.params.chapterId, async (): Promise<void> => {
 
   isLoading.value = false
 })
+
+const isInFlight = ref(false)
+const { pause, resume } = useIntervalFn(async () => {
+  if (isInFlight.value || isLoading.value) {
+    return
+  }
+
+  isInFlight.value = true
+  await fetchChapter()
+  isInFlight.value = false
+}, 2000, { immediate: false })
+
+function syncPolling(): void {
+  if (!chapter.value) {
+    pause()
+
+    return
+  }
+
+  if (chapter.value.download >= 0 && chapter.value.download < 100) {
+    resume()
+  } else {
+    pause()
+  }
+}
 </script>
 
 <template>
@@ -144,50 +170,43 @@ watch(() => route.params.chapterId, async (): Promise<void> => {
         />
       </template>
 
-      <div class="d-flex align-center flex-wrap ga-4">
-        <AtomLink v-if="chapter.previousChapterId" :to="{ name: 'comic-id-chapterId', params: { id: route.params.id, chapterId: chapter.previousChapterId } }">
+      <div
+        class="d-flex align-center ga-4 px-4"
+        :class="{
+          'justify-space-between': smAndDown,
+          'w-100': smAndDown,
+        }"
+      >
+        <AtomLink :to="chapter.previousChapterId ? `comic/${route.params.id}/${chapter.previousChapterId}` : undefined">
           <VBtn
-            v-if="chapter.previousChapterId"
-            color="primary"
-            :class="{
-              'w-100': !chapter.previousChapterId,
-              'w-auto': chapter.previousChapterId,
-              'px-3': smAndDown,
-            }"
-            :prepend-icon="smAndDown ? undefined : 'fa6-solid:angle-left'"
-            :text="smAndDown ? undefined : $t('comic.chapter.previous')"
-            :icon="smAndDown ? 'fa6-solid:angle-left' : undefined"
-            class="border-thin-primary"
+            :color="chapter.previousChapterId ? 'primary' : undefined"
+            :variant="chapter.previousChapterId ? 'tonal' : 'text'"
+            :disabled="!chapter.previousChapterId"
+            prepend-icon="fa6-solid:angle-left"
+            :text="$t('comic.chapter.previous')"
+            :class="{ 'border-thin-primary': chapter.previousChapterId }"
           />
         </AtomLink>
 
-        <AtomLink v-if="chapter.nextChapterId" :to="{ name: 'comic-id-chapterId', params: { id: route.params.id, chapterId: chapter.nextChapterId } }">
+        <AtomLink :to="`comic/${route.params.id}`">
           <VBtn
-            v-if="chapter.nextChapterId"
-            color="primary"
-            :icon="smAndDown ? 'fa6-solid:angle-right' : undefined"
-            :text="smAndDown ? undefined : $t('comic.chapter.next')"
-            :append-icon="smAndDown ? undefined : 'fa6-solid:angle-right'"
-            :class="{
-              'w-100': !chapter.nextChapterId,
-              'w-auto': chapter.nextChapterId,
-              'px-3': smAndDown,
-            }"
-            class="border-thin-primary"
+            :text="$t('comic.chapter.exitToComic')"
+            color="secondary"
+            variant="flat"
+          />
+        </AtomLink>
+
+        <AtomLink :to="chapter.nextChapterId ? `comic/${route.params.id}/${chapter.nextChapterId}` : undefined">
+          <VBtn
+            :color="chapter.nextChapterId ? 'primary' : undefined"
+            :disabled="!chapter.nextChapterId"
+            :variant="chapter.nextChapterId ? 'tonal' : 'text'"
+            append-icon="fa6-solid:angle-right"
+            :text="$t('comic.chapter.next')"
+            :class="{ 'border-thin-primary': chapter.nextChapterId }"
           />
         </AtomLink>
       </div>
-      <AtomLink :to="{ name: 'comic-id', params: { id: route.params.id } }">
-        <VBtn
-          class="border-thin-secondary"
-          :class="{
-            'w-100': smAndDown,
-            'w-fit-content': !smAndDown,
-          }"
-          :text="$t('comic.chapter.exitToComic')"
-          color="secondary"
-        />
-      </AtomLink>
     </div>
   </template>
 </template>

--- a/web/app/pages/comic/[id]/[chapterId].vue
+++ b/web/app/pages/comic/[id]/[chapterId].vue
@@ -1,0 +1,139 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+import type { DetailedChapter } from '~/features/chapters/types'
+import { AUTHENTICATED_ROUTE_GROUP } from '~/constants/auth'
+
+definePageMeta({
+  layout: 'chapter',
+  authGroups: [AUTHENTICATED_ROUTE_GROUP],
+})
+
+const route = useRoute('comic-id-chapterId')
+const api = createChaptersApi()
+const { t } = useI18n()
+const toast = useToast()
+const { smAndDown } = useDisplay()
+
+const chapter = ref<DetailedChapter>()
+const isLoading = ref(true)
+
+async function fetchChapter(): Promise<void> {
+  const res = await api.getById(route.params.chapterId)
+  if (!res.success) {
+    console.error('api.getById', res.error)
+    toast.error(res.error.status === 404 || res.error.status === 403
+      ? t('sources.asura.chapter.notFound')
+      : t('error.unknown'))
+
+    navigateTo({ name: 'comic-id', params: { id: route.params.id } })
+
+    return
+  }
+
+  chapter.value = res.data
+}
+
+onMounted(async () => {
+  fetchChapter()
+
+  isLoading.value = false
+})
+
+const isRetrying = ref(false)
+
+async function retryDownload(): Promise<void> {
+  isRetrying.value = true
+  const res = await api.retryDownload(route.params.chapterId)
+  if (!res.success) {
+    console.error('api.retryDownload', res.error)
+    toast.error(res.error.status === 404 || res.error.status === 403
+      ? t('sources.asura.chapter.notFound')
+      : t('error.unknown'))
+  }
+
+  isRetrying.value = false
+}
+</script>
+
+<template>
+  <div v-if="isLoading" class="d-flex flex-column align-center justify-center w-screen h-screen">
+    <VProgressCircular
+      indeterminate
+      class="mx-auto pa-2"
+      color="primary"
+      size="100"
+    />
+  </div>
+
+  <template v-else-if="chapter">
+    <div v-if="chapter.download !== 100" class="d-flex flex-column w-screen h-screen justify-center align-center ga-4">
+      <VProgressCircular
+        v-if="chapter.download !== -1"
+        :indeterminate="chapter.download === 0"
+        :value="chapter.download"
+        size="48"
+        color="primary"
+      />
+      <template v-if="chapter.download === -1">
+        <VIcon
+          icon="fa6-solid:circle-exclamation"
+          size="48"
+          color="error"
+        />
+        <span class="text-body-large text-medium-emphasis">{{ $t('comic.chapter.download.error') }}</span>
+        <VBtn
+          color="error"
+          class="border-thin-error"
+          :text="$t('comic.chapter.download.retry')"
+          :loading="isRetrying"
+          @click="retryDownload"
+        />
+      </template>
+
+      <div class="d-flex align-center flex-wrap ga-4">
+        <AtomLink v-if="chapter.previousChapterId" :to="{ name: 'comic-id-chapterId', params: { id: route.params.id, chapterId: chapter.previousChapterId } }">
+          <VBtn
+            v-if="chapter.previousChapterId"
+            color="primary"
+            :class="{
+              'w-100': !chapter.previousChapterId,
+              'w-auto': chapter.previousChapterId,
+              'px-3': smAndDown,
+            }"
+            :prepend-icon="smAndDown ? undefined : 'fa6-solid:angle-left'"
+            :text="smAndDown ? undefined : $t('comic.chapter.previous')"
+            :icon="smAndDown ? 'fa6-solid:angle-left' : undefined"
+            class="border-thin-primary"
+          />
+        </AtomLink>
+
+        <AtomLink v-if="chapter.nextChapterId" :to="{ name: 'comic-id-chapterId', params: { id: route.params.id, chapterId: chapter.nextChapterId } }">
+          <VBtn
+            v-if="chapter.nextChapterId"
+            color="primary"
+            :icon="smAndDown ? 'fa6-solid:angle-right' : undefined"
+            :text="smAndDown ? undefined : $t('comic.chapter.next')"
+            :append-icon="smAndDown ? undefined : 'fa6-solid:angle-right'"
+            :class="{
+              'w-100': !chapter.nextChapterId,
+              'w-auto': chapter.nextChapterId,
+              'px-3': smAndDown,
+            }"
+            class="border-thin-primary"
+          />
+        </AtomLink>
+      </div>
+      <AtomLink :to="{ name: 'comic-id', params: { id: route.params.id } }">
+        <VBtn
+          class="border-thin-secondary"
+          :class="{
+            'w-100': smAndDown,
+            'w-fit-content': !smAndDown,
+          }"
+          :text="$t('comic.chapter.exitToComic')"
+          color="secondary"
+        />
+      </AtomLink>
+    </div>
+  </template>
+</template>

--- a/web/app/pages/comic/[id]/index.test.ts
+++ b/web/app/pages/comic/[id]/index.test.ts
@@ -10,12 +10,13 @@ import { VApp, VBtn } from 'vuetify/components'
 import { ASURA_SOURCE_NAME } from '~/constants'
 import ComicPage from './index.vue'
 
-const { getById, refreshById, smAndDown, navigateTo, params, query } = await vi.hoisted(async () => {
+const { getById, refreshById, getProgress, smAndDown, navigateTo, params, query } = await vi.hoisted(async () => {
   const { ref } = await import('vue')
 
   return {
     getById: vi.fn(),
     refreshById: vi.fn(),
+    getProgress: vi.fn(),
     smAndDown: ref(false),
     navigateTo: vi.fn(),
     params: { id: 'c1' },
@@ -23,8 +24,8 @@ const { getById, refreshById, smAndDown, navigateTo, params, query } = await vi.
   }
 })
 
-function comicsApiStub(): { getById: typeof getById, refreshById: typeof refreshById } {
-  return { getById, refreshById }
+function comicsApiStub(): { getById: typeof getById, refreshById: typeof refreshById, getProgress: typeof getProgress } {
+  return { getById, refreshById, getProgress }
 }
 
 function displayStub(): { smAndDown: typeof smAndDown } {
@@ -110,12 +111,14 @@ function buttons(wrapper: VueWrapper): ReturnType<VueWrapper['findAllComponents'
 beforeEach(() => {
   getById.mockReset()
   refreshById.mockReset()
+  getProgress.mockReset()
   navigateTo.mockReset()
   smAndDown.value = false
   params.id = 'c1'
   query.from = undefined
   getById.mockResolvedValue({ success: true, data: comic() })
   refreshById.mockResolvedValue({ success: true, data: comic() })
+  getProgress.mockResolvedValue({ success: true, data: {} })
 })
 
 describe('comicPage', () => {

--- a/web/app/pages/comic/[id]/index.vue
+++ b/web/app/pages/comic/[id]/index.vue
@@ -2,7 +2,7 @@
 <script setup lang="ts">
 import type { RouteRecordName } from 'vue-router'
 import type { PageLayoutBackRoute } from '~/components/Organism/PageLayout.vue'
-import type { Comic } from '~/features/comics/types'
+import type { Comic, ComicProgressContinue } from '~/features/comics/types'
 import defaultCover from '~/assets/images/default/comic-cover.webp'
 import { AUTHENTICATED_ROUTE_GROUP } from '~/constants/auth'
 
@@ -22,17 +22,23 @@ const api = createComicsApi()
 
 const isLoading = ref(true)
 const comic = ref<Comic>()
+const continueProgress = ref<ComicProgressContinue>()
 const coverSrc = ref<string>()
 
 const from = computed(() => route.query.from as string)
 
-onMounted(() => {
-  fetchComic()
+onMounted(async () => {
+  isLoading.value = true
+
+  await Promise.all([
+    fetchComic(),
+    fetchProgress(),
+  ])
+
+  isLoading.value = false
 })
 
 async function fetchComic(): Promise<void> {
-  isLoading.value = true
-
   const res = await api.getById(route.params.id)
   if (!res.success) {
     console.error('api.getById', res.error)
@@ -51,8 +57,18 @@ async function fetchComic(): Promise<void> {
 
   comic.value = res.data
   coverSrc.value = res.data.cover
+}
 
-  isLoading.value = false
+async function fetchProgress(): Promise<void> {
+  const res = await api.getProgress(route.params.id)
+  if (!res.success) {
+    console.error('api.getProgress', res.error)
+    toast.error(t('error.unknown'))
+
+    return
+  }
+
+  continueProgress.value = res.data.continue
 }
 
 function onDelete(): void {
@@ -205,7 +221,7 @@ const showDeleteModal = ref(false)
           :comic
         />
         <ComicsGeneralInfos :comic />
-        <ComicsChapters :id="route.params.id" />
+        <ComicsChapters :id="route.params.id" :continue="continueProgress" />
       </div>
     </div>
   </OrganismPageLayout>

--- a/web/i18n/locales/en.json
+++ b/web/i18n/locales/en.json
@@ -211,7 +211,9 @@
     "sort": {
       "latest": "Latest",
       "oldest": "Oldest"
-    }
+    },
+    "start": "Start",
+    "continue": "Continue"
   },
   "role": {
     "admin": "Admin",
@@ -274,6 +276,9 @@
             }
           }
         }
+      },
+      "chapter": {
+        "notFound": "Chapter not found"
       }
     },
     "add": {
@@ -309,6 +314,15 @@
     "fields": {
       "author": "Author",
       "artist": "Artist"
+    },
+    "chapter": {
+      "previous": "Previous",
+      "next": "Next",
+      "exitToComic": "Exit to comic",
+      "download": {
+        "error": "Chapter download error",
+        "retry": "Retry"
+      }
     }
   },
   "library": {

--- a/web/i18n/locales/en.json
+++ b/web/i18n/locales/en.json
@@ -316,7 +316,7 @@
       "artist": "Artist"
     },
     "chapter": {
-      "previous": "Previous",
+      "previous": "Prev",
       "next": "Next",
       "exitToComic": "Exit to comic",
       "download": {

--- a/web/i18n/locales/fr.json
+++ b/web/i18n/locales/fr.json
@@ -350,7 +350,7 @@
   },
   "comic": {
     "chapter": {
-      "previous": "Précédent",
+      "previous": "Préc",
       "next": "Suivant",
       "exitToComic": "Retourner a la BD",
       "download": {

--- a/web/i18n/locales/fr.json
+++ b/web/i18n/locales/fr.json
@@ -211,7 +211,9 @@
     "sort": {
       "oldest": "Plus ancien",
       "latest": "Plus récent"
-    }
+    },
+    "start": "Commencer",
+    "continue": "Continuer"
   },
   "role": {
     "admin": "Administrateur",
@@ -276,6 +278,9 @@
             }
           }
         }
+      },
+      "chapter": {
+        "notFound": "Chapitre introuvable"
       }
     },
     "add": {
@@ -341,6 +346,17 @@
       "doublePage": "Double-page",
       "singlePage": "Page unique",
       "title": "Mode page"
+    }
+  },
+  "comic": {
+    "chapter": {
+      "previous": "Précédent",
+      "next": "Suivant",
+      "exitToComic": "Retourner a la BD",
+      "download": {
+        "error": "Erreur de téléchargement de chapitre",
+        "retry": "Réessayer"
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #69

## Summary

- **API — local chapter pages**: add `GET /api/chapters/{id}/pages/{index}` (session-gated, 1-based index) to serve downloaded page files from disk; returns 403 when the comic is not in the user's library, 404 when the chapter is incomplete or the page is missing.
- **API — richer chapter detail**: extend `GET /api/chapters/{id}` with `pageUrls`, `previousChapterId`, and `nextChapterId`; include reading progress on chapter list/detail responses via `MapByChapterIDs`.
- **API — reading progress**: move progress writes from `PUT /api/comics/{id}/progress` to `PUT /api/chapters/{id}/progress` and align the service/repository layer.
- **Web — chapter page**: add `/comic/:id/:chapterId` with a dedicated layout, chapter detail fetch, page image display, retry download, and navigation links from the comic chapter list and feed cards.

## Test plan

- [ ] `go test ./...` and `golangci-lint run ./...` pass
- [ ] `pnpm test`, `pnpm lint`, and `pnpm typecheck` pass in `web/`
- [ ] Authenticated user with a fully downloaded chapter in library can load page bytes via `/api/chapters/{id}/pages/1`
- [ ] Unauthenticated or non-library user gets 401/403 on page route
- [ ] Incomplete/failed chapter returns 404 on page route and empty `pageUrls` on get-by-id
- [ ] `GET /api/chapters/{id}` returns ordered `pageUrls` and correct neighbor ids (omitempty when absent)
- [ ] Chapter list endpoints unchanged (no `pageUrls` on list)
- [ ] Web chapter page loads images, handles 403/404 with redirect, and prev/next navigation works
