### PR TITLE
feat(reader): webtoon scroll mode

### DIFF
--- a/web/app/features/reader/components/Mode/Paged.vue
+++ b/web/app/features/reader/components/Mode/Paged.vue
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script setup lang="ts">
 import type { Comic } from '../../../comics/types'
 import type { BetweenChaptersMode } from '../Card/BetweenChapters.vue'

--- a/web/app/features/reader/components/Mode/Scroll/Img.vue
+++ b/web/app/features/reader/components/Mode/Scroll/Img.vue
@@ -1,0 +1,38 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+const props = defineProps<{
+  src: string
+  root?: HTMLElement
+}>()
+
+const emit = defineEmits<{
+  intersecting: [isIntersecting: boolean]
+}>()
+
+const el = useTemplateRef<HTMLElement>('el')
+
+useIntersectionObserver(el, ([entry]) => {
+  if (!entry) {
+    return
+  }
+
+  emit('intersecting', entry.isIntersecting)
+}, {
+  root: () => props.root,
+  threshold: 0,
+})
+
+onBeforeUnmount(() => {
+  emit('intersecting', false)
+})
+</script>
+
+<template>
+  <div ref="el">
+    <VImg
+      eager
+      :src="src"
+      class="w-100"
+    />
+  </div>
+</template>

--- a/web/app/features/reader/components/Mode/Scroll/index.test.ts
+++ b/web/app/features/reader/components/Mode/Scroll/index.test.ts
@@ -74,9 +74,11 @@ async function mount(opts: { page?: number } = {}): Promise<{
 }
 
 function setScrollMetrics(el: HTMLElement, metrics: { scrollHeight: number, scrollTop: number, clientHeight: number }): void {
-  Object.defineProperty(el, 'scrollHeight', { configurable: true, value: metrics.scrollHeight })
-  Object.defineProperty(el, 'scrollTop', { configurable: true, value: metrics.scrollTop })
-  Object.defineProperty(el, 'clientHeight', { configurable: true, value: metrics.clientHeight })
+  Object.defineProperties(el, {
+    scrollHeight: { configurable: true, value: metrics.scrollHeight },
+    scrollTop: { configurable: true, value: metrics.scrollTop },
+    clientHeight: { configurable: true, value: metrics.clientHeight },
+  })
 }
 
 describe('readerModeScroll', () => {

--- a/web/app/features/reader/components/Mode/Scroll/index.test.ts
+++ b/web/app/features/reader/components/Mode/Scroll/index.test.ts
@@ -7,7 +7,7 @@ import type { Comic } from '~/features/comics/types'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { describe, expect, it } from 'vitest'
 import { h, ref } from 'vue'
-import { VApp } from 'vuetify/components'
+import { VApp, VImg } from 'vuetify/components'
 import { ASURA_SOURCE_NAME } from '~/constants'
 import Scroll from './index.vue'
 
@@ -45,11 +45,14 @@ function chapter(overrides: Partial<DetailedChapter> = {}): DetailedChapter {
   }
 }
 
-async function mount(opts: { page?: number } = {}): Promise<VueWrapper> {
+async function mount(opts: { page?: number } = {}): Promise<{
+  wrapper: VueWrapper
+  showOverlay: ReturnType<typeof ref<boolean>>
+}> {
   const page = ref(opts.page ?? 0)
   const showOverlay = ref(true)
 
-  return await mountSuspended({
+  const wrapper = await mountSuspended({
     setup: () => ({ page, showOverlay }),
     render: () => h(VApp, () => [
       h(Scroll, {
@@ -66,12 +69,61 @@ async function mount(opts: { page?: number } = {}): Promise<VueWrapper> {
       }),
     ]),
   })
+
+  return { wrapper, showOverlay }
+}
+
+function setScrollMetrics(el: HTMLElement, metrics: { scrollHeight: number, scrollTop: number, clientHeight: number }): void {
+  Object.defineProperty(el, 'scrollHeight', { configurable: true, value: metrics.scrollHeight })
+  Object.defineProperty(el, 'scrollTop', { configurable: true, value: metrics.scrollTop })
+  Object.defineProperty(el, 'clientHeight', { configurable: true, value: metrics.clientHeight })
 }
 
 describe('readerModeScroll', () => {
   it('constrains the virtual list to the viewport so scrollToIndex can move', async () => {
-    const wrapper = await mount({ page: 2 })
+    const { wrapper } = await mount({ page: 2 })
 
     expect(wrapper.find('.v-virtual-scroll').classes()).toContain('h-100')
+  })
+
+  it('renders a page image per url', async () => {
+    const { wrapper } = await mount()
+
+    expect(wrapper.findAllComponents(VImg).map(img => img.props('src'))).toEqual(['/p1', '/p2', '/p3'])
+  })
+
+  it('ignores the first scroll so restore does not hide the overlay', async () => {
+    const { wrapper, showOverlay } = await mount()
+    const el = wrapper.find('.v-virtual-scroll').element as HTMLElement
+    setScrollMetrics(el, { scrollHeight: 1000, scrollTop: 40, clientHeight: 100 })
+
+    await wrapper.find('.v-virtual-scroll').trigger('scroll')
+
+    expect(showOverlay.value).toBe(true)
+  })
+
+  it('hides the overlay on a later scroll that is not at the bottom', async () => {
+    const { wrapper, showOverlay } = await mount()
+    const el = wrapper.find('.v-virtual-scroll').element as HTMLElement
+    setScrollMetrics(el, { scrollHeight: 1000, scrollTop: 40, clientHeight: 100 })
+
+    await wrapper.find('.v-virtual-scroll').trigger('scroll')
+    await wrapper.find('.v-virtual-scroll').trigger('scroll')
+
+    expect(showOverlay.value).toBe(false)
+  })
+
+  it('shows the overlay when scrolled to the bottom', async () => {
+    const { wrapper, showOverlay } = await mount()
+    const el = wrapper.find('.v-virtual-scroll').element as HTMLElement
+    setScrollMetrics(el, { scrollHeight: 1000, scrollTop: 40, clientHeight: 100 })
+    await wrapper.find('.v-virtual-scroll').trigger('scroll')
+    await wrapper.find('.v-virtual-scroll').trigger('scroll')
+    expect(showOverlay.value).toBe(false)
+
+    setScrollMetrics(el, { scrollHeight: 1000, scrollTop: 900, clientHeight: 100 })
+    await wrapper.find('.v-virtual-scroll').trigger('scroll')
+
+    expect(showOverlay.value).toBe(true)
   })
 })

--- a/web/app/features/reader/components/Mode/Scroll/index.test.ts
+++ b/web/app/features/reader/components/Mode/Scroll/index.test.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { VueWrapper } from '@vue/test-utils'
+import type { DetailedChapter } from '~/features/chapters/types'
+import type { Comic } from '~/features/comics/types'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it } from 'vitest'
+import { h, ref } from 'vue'
+import { VApp } from 'vuetify/components'
+import { ASURA_SOURCE_NAME } from '~/constants'
+import Scroll from './index.vue'
+
+function comic(overrides: Partial<Comic> = {}): Comic {
+  return {
+    id: 'c1',
+    title: 'Solo Leveling',
+    slug: 'solo-leveling',
+    source: ASURA_SOURCE_NAME,
+    status: 'ongoing',
+    type: 'manhwa',
+    author: 'Chugong',
+    artist: 'Jang',
+    description: 'A hunter',
+    cover: '/cover',
+    genres: [],
+    altTitles: [],
+    chapterCount: 1,
+    ...overrides,
+  }
+}
+
+function chapter(overrides: Partial<DetailedChapter> = {}): DetailedChapter {
+  return {
+    id: 'ch-2',
+    comicId: 'c1',
+    publishedAt: new Date('2026-01-01'),
+    sourceChapterSlug: 'ch-2',
+    title: 'Two',
+    number: 2,
+    pagesNb: 3,
+    download: 100,
+    pageUrls: ['/p1', '/p2', '/p3'],
+    ...overrides,
+  }
+}
+
+async function mount(opts: { page?: number } = {}): Promise<VueWrapper> {
+  const page = ref(opts.page ?? 0)
+  const showOverlay = ref(true)
+
+  return await mountSuspended({
+    setup: () => ({ page, showOverlay }),
+    render: () => h(VApp, () => [
+      h(Scroll, {
+        'comic': comic(),
+        'chapter': chapter(),
+        'page': page.value,
+        'showOverlay': showOverlay.value,
+        'onUpdate:page': (value: number) => {
+          page.value = value
+        },
+        'onUpdate:showOverlay': (isShown: boolean) => {
+          showOverlay.value = isShown
+        },
+      }),
+    ]),
+  })
+}
+
+describe('readerModeScroll', () => {
+  it('constrains the virtual list to the viewport so scrollToIndex can move', async () => {
+    const wrapper = await mount({ page: 2 })
+
+    expect(wrapper.find('.v-virtual-scroll').classes()).toContain('h-100')
+  })
+})

--- a/web/app/features/reader/components/Mode/Scroll/index.vue
+++ b/web/app/features/reader/components/Mode/Scroll/index.vue
@@ -1,0 +1,102 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+import type { DetailedChapter } from '~/features/chapters/types'
+import type { Comic } from '~/features/comics/types'
+import { VVirtualScroll } from 'vuetify/components'
+import { pageFromVisibleIndices, recordIntersection } from './visible-page'
+
+defineProps<{
+  comic: Comic
+  chapter: DetailedChapter
+}>()
+
+const page = defineModel<number>('page', { default: 0 })
+const showOverlay = defineModel<boolean>('showOverlay', { required: true })
+
+const virtualScrollRef = ref<InstanceType<typeof VVirtualScroll>>()
+const scrollRoot = computed(() => {
+  const el = virtualScrollRef.value?.$el
+
+  return el instanceof HTMLElement ? el : undefined
+})
+
+const restoredPage = page.value
+const restoring = ref(restoredPage > 0)
+
+const unwatchVirtualScroll = watch(virtualScrollRef, async (value) => {
+  if (!value) {
+    return
+  }
+
+  if (restoring.value) {
+    await nextTick()
+    value.scrollToIndex(restoredPage)
+  }
+
+  unwatchVirtualScroll()
+})
+
+const intersectingPages = new Set<number>()
+
+function onIntersecting(index: number, isIntersecting: boolean): void {
+  recordIntersection(intersectingPages, index, isIntersecting)
+
+  const current = pageFromVisibleIndices(intersectingPages, {
+    restoredPage,
+    restoring: restoring.value,
+  })
+  if (current === undefined) {
+    return
+  }
+
+  if (restoring.value) {
+    restoring.value = false
+    for (const intersectingIndex of intersectingPages) {
+      if (intersectingIndex < restoredPage) {
+        intersectingPages.delete(intersectingIndex)
+      }
+    }
+  }
+
+  if (page.value !== current) {
+    page.value = current
+  }
+}
+
+const preventFirstScroll = ref(true)
+
+function onScroll(event: Event): void {
+  if (preventFirstScroll.value) {
+    preventFirstScroll.value = false
+
+    return
+  }
+
+  const el = event.currentTarget as HTMLElement
+  const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight <= 1
+  if (!atBottom && showOverlay.value) {
+    showOverlay.value = false
+  } else if (atBottom && !showOverlay.value) {
+    showOverlay.value = true
+  }
+}
+</script>
+
+<template>
+  <div class="h-screen w-screen overflow-hidden" @click="showOverlay = !showOverlay">
+    <VVirtualScroll
+      ref="virtualScrollRef"
+      class="h-100"
+      :items="chapter.pageUrls"
+      @scroll="onScroll"
+    >
+      <template #default="{ item, index }">
+        <ReaderModeScrollImg
+          :src="item"
+          :root="scrollRoot"
+          @intersecting="onIntersecting(index, $event)"
+        />
+      </template>
+    </VVirtualScroll>
+  </div>
+</template>

--- a/web/app/features/reader/components/Mode/Scroll/visible-page.test.ts
+++ b/web/app/features/reader/components/Mode/Scroll/visible-page.test.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it } from 'vitest'
+import { pageFromVisibleIndices, recordIntersection } from './visible-page'
+
+describe('recordIntersection', () => {
+  it('adds and removes indices', () => {
+    const indices = new Set<number>()
+
+    recordIntersection(indices, 2, true)
+    recordIntersection(indices, 3, true)
+    expect(indices).toEqual(new Set([2, 3]))
+
+    recordIntersection(indices, 2, false)
+    expect(indices).toEqual(new Set([3]))
+  })
+})
+
+describe('pageFromVisibleIndices', () => {
+  it('returns the topmost visible page', () => {
+    expect(pageFromVisibleIndices(new Set([2, 3, 4]), { restoredPage: 0, restoring: false })).toBe(2)
+  })
+
+  it('returns undefined when nothing is visible', () => {
+    expect(pageFromVisibleIndices(new Set(), { restoredPage: 0, restoring: false })).toBeUndefined()
+  })
+
+  it('ignores pages above the restored position while restoring progress', () => {
+    expect(pageFromVisibleIndices(new Set([0, 1, 2]), { restoredPage: 10, restoring: true })).toBeUndefined()
+  })
+
+  it('uses the restored window once that page is on screen, ignoring leftover top pages', () => {
+    expect(pageFromVisibleIndices(new Set([0, 1, 10, 11]), { restoredPage: 10, restoring: true })).toBe(10)
+  })
+})

--- a/web/app/features/reader/components/Mode/Scroll/visible-page.ts
+++ b/web/app/features/reader/components/Mode/Scroll/visible-page.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+export function recordIntersection(
+  indices: Set<number>,
+  index: number,
+  isIntersecting: boolean,
+): void {
+  if (isIntersecting) {
+    indices.add(index)
+  } else {
+    indices.delete(index)
+  }
+}
+
+export function pageFromVisibleIndices(
+  indices: Set<number>,
+  opts: { restoredPage: number, restoring: boolean },
+): number | undefined {
+  if (indices.size === 0) {
+    return undefined
+  }
+
+  const relevant = opts.restoring
+    ? [...indices].filter(index => index >= opts.restoredPage)
+    : [...indices]
+
+  if (relevant.length === 0) {
+    return undefined
+  }
+
+  return Math.min(...relevant)
+}

--- a/web/app/features/reader/components/Overlay/Footer/ChaptersMenu.vue
+++ b/web/app/features/reader/components/Overlay/Footer/ChaptersMenu.vue
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script setup lang="ts">
 import type { Chapter } from '~/features/chapters/types'
 import { VVirtualScroll } from 'vuetify/components'

--- a/web/app/features/reader/components/Overlay/Footer/index.test.ts
+++ b/web/app/features/reader/components/Overlay/Footer/index.test.ts
@@ -88,8 +88,8 @@ describe('readerOverlayFooter', () => {
   it('links to the previous and next chapters', async () => {
     const wrapper = await mount()
 
-    expect(wrapper.find('a[href="/comic/c1/ch-1"]').exists()).toBe(true)
-    expect(wrapper.find('a[href="/comic/c1/ch-3"]').exists()).toBe(true)
+    expect(wrapper.find('a[href="/comic/c1/ch-1?ignoreProgress=true"]').exists()).toBe(true)
+    expect(wrapper.find('a[href="/comic/c1/ch-3?ignoreProgress=true"]').exists()).toBe(true)
     expect(buttons(wrapper).find(b => b.text().includes('Prev'))?.props('disabled')).toBe(false)
     expect(buttons(wrapper).find(b => b.text().includes('Next'))?.props('disabled')).toBe(false)
   })

--- a/web/app/features/reader/components/Overlay/Footer/index.vue
+++ b/web/app/features/reader/components/Overlay/Footer/index.vue
@@ -14,7 +14,7 @@ defineProps<{
     style="z-index: 2;"
   >
     <div class="d-flex ga-4 justify-space-between align-center w-100 mx-auto" style="max-width: 80rem;">
-      <AtomLink :to="chapter.previous ? `/comic/${comic.id}/${chapter.previous.id}` : undefined">
+      <AtomLink :to="chapter.previous ? `/comic/${comic.id}/${chapter.previous.id}?ignoreProgress=true` : undefined">
         <VBtn
           :disabled="!chapter.previous"
           :variant="chapter.previous ? 'tonal' : 'text'"
@@ -26,7 +26,7 @@ defineProps<{
 
       <ReaderOverlayFooterChaptersMenu :comic-id="comic.id" :current-chapter="chapter" />
 
-      <AtomLink :to="chapter.next ? `/comic/${comic.id}/${chapter.next.id}` : undefined">
+      <AtomLink :to="chapter.next ? `/comic/${comic.id}/${chapter.next.id}?ignoreProgress=true` : undefined">
         <VBtn
           :disabled="!chapter.next"
           :variant="chapter.next ? 'tonal' : 'text'"

--- a/web/app/features/reader/components/Overlay/Footer/index.vue
+++ b/web/app/features/reader/components/Overlay/Footer/index.vue
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script setup lang="ts">
 import type { DetailedChapter } from '~/features/chapters/types'
 import type { Comic } from '~/features/comics/types'

--- a/web/app/features/reader/components/Overlay/Header.vue
+++ b/web/app/features/reader/components/Overlay/Header.vue
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script setup lang="ts">
 import type { Comic } from '../../../comics/types'
 import type { Chapter } from '~/features/chapters/types'

--- a/web/app/features/reader/components/Overlay/index.vue
+++ b/web/app/features/reader/components/Overlay/index.vue
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script setup lang="ts">
 import type { DetailedChapter } from '~/features/chapters/types'
 import type { Comic } from '~/features/comics/types'

--- a/web/app/features/reader/components/index.test.ts
+++ b/web/app/features/reader/components/index.test.ts
@@ -34,6 +34,17 @@ const PagedStub = defineComponent({
   template: '<div data-test="paged" />',
 })
 
+const ScrollStub = defineComponent({
+  name: 'ReaderModeScroll',
+  props: {
+    comic: { type: Object, required: true },
+    chapter: { type: Object, required: true },
+    page: { type: Number, required: true },
+    showOverlay: { type: Boolean, required: true },
+  },
+  template: '<div data-test="scroll" />',
+})
+
 function comic(overrides: Partial<Comic> = {}): Comic {
   return {
     id: 'c1',
@@ -105,6 +116,7 @@ async function mount(opts: {
       stubs: {
         ReaderOverlay: OverlayStub,
         ReaderModePaged: PagedStub,
+        ReaderModeScroll: ScrollStub,
       },
     },
   })
@@ -140,6 +152,13 @@ describe('reader', () => {
   it('does not mount paged mode for webtoon settings', async () => {
     const { wrapper } = await mount({ settings: { readingMode: 'webtoon' } })
 
+    expect(wrapper.find('[data-test="paged"]').exists()).toBe(false)
+  })
+
+  it('shows scroll mode for webtoon settings', async () => {
+    const { wrapper } = await mount({ settings: { readingMode: 'webtoon' } })
+
+    expect(wrapper.find('[data-test="scroll"]').exists()).toBe(true)
     expect(wrapper.find('[data-test="paged"]').exists()).toBe(false)
   })
 })

--- a/web/app/features/reader/components/index.vue
+++ b/web/app/features/reader/components/index.vue
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script setup lang="ts">
 import type { ReaderSettings } from '../types'
 import type { DetailedChapter } from '~/features/chapters/types'
@@ -86,6 +87,14 @@ const page = defineModel<number>('page', { required: true })
       @fetch-previous-chapter="$emit('fetchPreviousChapter')"
       @previous-chapter="$emit('previousChapter')"
       @next-chapter="$emit('nextChapter')"
+    />
+
+    <ReaderModeScroll
+      v-else
+      v-model:page="page"
+      v-model:show-overlay="showOverlay"
+      :comic
+      :chapter
     />
   </div>
 </template>

--- a/web/app/features/reader/composables/reader.composable.test.ts
+++ b/web/app/features/reader/composables/reader.composable.test.ts
@@ -117,13 +117,22 @@ async function waitUntilIdle(reader: ReaderComposable): Promise<void> {
 
 const wrappers: VueWrapper[] = []
 
-async function setup(chapterId = 'ch-2'): Promise<{ reader: ReaderComposable, chapterId: Ref<string> }> {
+async function setup(
+  chapterId = 'ch-2',
+  opts: { ignoreProgress?: boolean, onAfterProgressIgnored?: () => void } = {},
+): Promise<{ reader: ReaderComposable, chapterId: Ref<string> }> {
   const id = ref(chapterId)
+  const ignoreProgress = ref(opts.ignoreProgress ?? false)
   let reader: ReaderComposable | undefined
 
   const wrapper = await mountSuspended({
     setup: () => {
-      reader = useReader('c1', id)
+      reader = useReader({
+        comicId: 'c1',
+        chapterId: id,
+        ignoreProgress,
+        onAfterProgressIgnored: opts.onAfterProgressIgnored,
+      })
 
       return { reader }
     },
@@ -182,6 +191,19 @@ describe('useReader', () => {
     await waitUntilIdle(reader)
 
     expect(reader.page.value).toBe(2)
+  })
+
+  it('skips restored progress when ignoreProgress is set', async () => {
+    const onAfterProgressIgnored = vi.fn()
+    getById.mockResolvedValue(chapterResponse({
+      progress: { page: 2, updatedAt: new Date('2026-08-22') },
+    }))
+
+    const { reader } = await setup('ch-2', { ignoreProgress: true, onAfterProgressIgnored })
+    await waitUntilIdle(reader)
+
+    expect(reader.page.value).toBe(0)
+    expect(onAfterProgressIgnored).toHaveBeenCalledOnce()
   })
 
   it('redirects to the library when the comic is missing', async () => {

--- a/web/app/features/reader/composables/reader.composable.ts
+++ b/web/app/features/reader/composables/reader.composable.ts
@@ -19,7 +19,13 @@ export interface ReaderComposable {
   startEnd: Ref<boolean>
 }
 
-export function useReader(comicId: string, chapterId: Ref<string>): ReaderComposable {
+export interface ReaderComposableOptions {
+  ignoreProgress?: Ref<boolean>
+  comicId: string
+  chapterId: Ref<string>
+}
+
+export function useReader({ comicId, chapterId, ignoreProgress }: ReaderComposableOptions): ReaderComposable {
   const api = createChaptersApi()
   const comicsApi = createComicsApi()
   const readerSettingsApi = createReaderSettingsApi()
@@ -121,7 +127,7 @@ export function useReader(comicId: string, chapterId: Ref<string>): ReaderCompos
       return
     }
 
-    if (chapter.value.progress) {
+    if (!ignoreProgress?.value && chapter.value.progress) {
       page.value = chapter.value.progress.page
     }
 

--- a/web/app/features/reader/composables/reader.composable.ts
+++ b/web/app/features/reader/composables/reader.composable.ts
@@ -23,9 +23,10 @@ export interface ReaderComposableOptions {
   ignoreProgress?: Ref<boolean>
   comicId: string
   chapterId: Ref<string>
+  onAfterProgressIgnored?: () => void
 }
 
-export function useReader({ comicId, chapterId, ignoreProgress }: ReaderComposableOptions): ReaderComposable {
+export function useReader(opts: ReaderComposableOptions): ReaderComposable {
   const api = createChaptersApi()
   const comicsApi = createComicsApi()
   const readerSettingsApi = createReaderSettingsApi()
@@ -33,7 +34,7 @@ export function useReader({ comicId, chapterId, ignoreProgress }: ReaderComposab
   const toast = useToast()
 
   const loadedChapters = ref<DetailedChapter[]>([])
-  const chapter = computed(() => loadedChapters.value.find(({ id }) => id === chapterId.value))
+  const chapter = computed(() => loadedChapters.value.find(({ id }) => id === opts.chapterId.value))
   const comic = ref<Comic>()
   const isLoading = ref(true)
   const fetchChapterLoading = ref(false)
@@ -85,7 +86,7 @@ export function useReader({ comicId, chapterId, ignoreProgress }: ReaderComposab
   }
 
   async function fetchComic(): Promise<void> {
-    const res = await comicsApi.getById(comicId)
+    const res = await comicsApi.getById(opts.comicId)
     if (!res.success) {
       console.error('comicsApi.getById', res.error)
 
@@ -103,7 +104,7 @@ export function useReader({ comicId, chapterId, ignoreProgress }: ReaderComposab
 
   onMounted(async () => {
     const [_, __, settings] = await Promise.all([
-      fetchChapter(chapterId.value),
+      fetchChapter(opts.chapterId.value),
       fetchComic(),
       fetchReaderSettings(),
     ])
@@ -115,20 +116,24 @@ export function useReader({ comicId, chapterId, ignoreProgress }: ReaderComposab
     }
 
     if (!chapter.value) {
-      navigateTo(`/comic/${comicId}`)
+      navigateTo(`/comic/${opts.comicId}`)
 
       return
     }
 
     readerSettings.value = settings.find(({ type }) => type === comic.value?.type)
     if (!readerSettings.value) {
-      navigateTo(`/comic/${comicId}`)
+      navigateTo(`/comic/${opts.comicId}`)
 
       return
     }
 
-    if (!ignoreProgress?.value && chapter.value.progress) {
+    if (!opts.ignoreProgress?.value && chapter.value.progress) {
       page.value = chapter.value.progress.page
+    }
+
+    if (opts.ignoreProgress?.value && opts.onAfterProgressIgnored) {
+      opts.onAfterProgressIgnored()
     }
 
     isLoading.value = false
@@ -138,9 +143,9 @@ export function useReader({ comicId, chapterId, ignoreProgress }: ReaderComposab
 
   async function retryDownload(): Promise<void> {
     retryDownloadLoading.value = true
-    const res = await api.retryDownload(chapterId.value)
+    const res = await api.retryDownload(opts.chapterId.value)
     if (res.success) {
-      await fetchChapter(chapterId.value)
+      await fetchChapter(opts.chapterId.value)
     } else {
       console.error('api.retryDownload', res.error)
       if (res.error.status === 404 || res.error.status === 403) {
@@ -153,15 +158,15 @@ export function useReader({ comicId, chapterId, ignoreProgress }: ReaderComposab
     retryDownloadLoading.value = false
   }
 
-  watch(chapterId, async (): Promise<void> => {
-    const loadedChapter = loadedChapters.value.find(({ id }) => id === chapterId.value)
+  watch(opts.chapterId, async (): Promise<void> => {
+    const loadedChapter = loadedChapters.value.find(({ id }) => id === opts.chapterId.value)
     if (loadedChapter || fetchChapterLoading.value) {
       return
     }
 
     isLoading.value = true
 
-    await fetchChapter(chapterId.value)
+    await fetchChapter(opts.chapterId.value)
 
     isLoading.value = false
   })
@@ -188,11 +193,11 @@ export function useReader({ comicId, chapterId, ignoreProgress }: ReaderComposab
     }
 
     isInFlight.value = true
-    await fetchChapter(chapterId.value)
+    await fetchChapter(opts.chapterId.value)
     isInFlight.value = false
   }, 2000, { immediate: false })
 
-  watch(chapterId, () => {
+  watch(opts.chapterId, () => {
     syncPolling()
   })
 
@@ -201,7 +206,7 @@ export function useReader({ comicId, chapterId, ignoreProgress }: ReaderComposab
       return
     }
 
-    if (loadedChapters.value.at(-1)?.id === chapterId.value) {
+    if (loadedChapters.value.at(-1)?.id === opts.chapterId.value) {
       syncPolling()
     }
   })

--- a/web/app/pages/comic/[id]/[chapterId].vue
+++ b/web/app/pages/comic/[id]/[chapterId].vue
@@ -27,6 +27,7 @@ const {
   comicId: route.value.params.id,
   chapterId: computed(() => route.value.params.chapterId),
   ignoreProgress: computed(() => route.value.query.ignoreProgress === 'true'),
+  onAfterProgressIgnored: () => updateRoute(route.value.params.chapterId),
 })
 
 function toPreviousChapter(): void {
@@ -54,6 +55,7 @@ function updateRoute(chapterId: string): void {
       id: route.value.params.id,
       chapterId,
     },
+    query: {},
   })
 }
 </script>

--- a/web/app/pages/comic/[id]/[chapterId].vue
+++ b/web/app/pages/comic/[id]/[chapterId].vue
@@ -23,7 +23,11 @@ const {
   nextChapter,
   previousChapter,
   startEnd,
-} = useReader(route.value.params.id, computed(() => route.value.params.chapterId))
+} = useReader({
+  comicId: route.value.params.id,
+  chapterId: computed(() => route.value.params.chapterId),
+  ignoreProgress: computed(() => route.value.query.ignoreProgress === 'true'),
+})
 
 function toPreviousChapter(): void {
   if (!previousChapter.value) {


### PR DESCRIPTION
## Summary

Webtoon reading mode for the chapter reader when `readingMode` is `webtoon` (#74).

This is **not** infinite scroll: the strip is the current chapter only. The next chapter is never appended.

- `ReaderModeScroll` stacks the current chapter’s pages in a viewport-tall `VVirtualScroll` (fit-width images)
- IntersectionObserver tracks the topmost visible page for progress restore and save
- Overlay: tap toggles; the first programmatic scroll after restore is ignored so resume does not hide it; later scroll hides it until the last page (bottom of the strip) shows it again
- Footer prev/next use `?ignoreProgress=true` so a chapter change starts at page 0 instead of restored progress; the query is then cleared from the URL
- Paged mode is unchanged (including the between-chapters card)

## Test plan

- [x] `pnpm vitest run` (web)
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm knip` (pre-push)
- [x] Manual: open a webtoon chapter, resume mid-chapter, scroll hides overlay, last page shows overlay, prev/next start at page 0, paged mode still paginates

Closes #74
