### PR TITLE
feat(reader): overlay page rail (#100)

### DIFF
--- a/web/app/features/reader/components/Mode/Paged.test.ts
+++ b/web/app/features/reader/components/Mode/Paged.test.ts
@@ -7,7 +7,7 @@ import type { Comic } from '~/features/comics/types'
 import type { ReaderSettings } from '~/features/reader/types'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { describe, expect, it } from 'vitest'
-import { h, ref } from 'vue'
+import { h, nextTick, ref } from 'vue'
 import { VApp, VImg } from 'vuetify/components'
 import { ASURA_SOURCE_NAME } from '~/constants'
 import Paged from './Paged.vue'
@@ -145,6 +145,23 @@ describe('readerModePaged', () => {
     const { wrapper, showOverlay } = await mount({ showOverlay: true })
 
     await wrapper.find('.h-screen.w-screen').trigger('click')
+
+    expect(showOverlay.value).toBe(false)
+  })
+
+  it('keeps the overlay when the page changes from the rail', async () => {
+    const { page, showOverlay } = await mount({ showOverlay: true })
+
+    page.value = 1
+    await nextTick()
+
+    expect(showOverlay.value).toBe(true)
+  })
+
+  it('hides the overlay when turning the page from a click zone', async () => {
+    const { wrapper, showOverlay } = await mount({ showOverlay: true })
+
+    await clickZones(wrapper)[1]?.trigger('click')
 
     expect(showOverlay.value).toBe(false)
   })

--- a/web/app/features/reader/components/Mode/Paged.vue
+++ b/web/app/features/reader/components/Mode/Paged.vue
@@ -59,10 +59,6 @@ watch(page, () => {
   if (betweenChaptersMode.value) {
     betweenChaptersMode.value = undefined
   }
-
-  if (showOverlay.value) {
-    showOverlay.value = false
-  }
 })
 
 watch(betweenChaptersMode, (value) => {
@@ -93,7 +89,15 @@ function clickRight(): void {
   }
 }
 
+function hideOverlay(): void {
+  if (showOverlay.value) {
+    showOverlay.value = false
+  }
+}
+
 function previousPage(): void {
+  hideOverlay()
+
   if (page.value > 0) {
     page.value = page.value - (props.settings.doublePage ? 2 : 1)
   } else if (!betweenChaptersMode.value) {
@@ -104,6 +108,8 @@ function previousPage(): void {
 }
 
 function nextPage(): void {
+  hideOverlay()
+
   if (page.value < props.chapter.pageUrls.length - (props.settings.doublePage ? 2 : 1)) {
     page.value = page.value + (props.settings.doublePage ? 2 : 1)
   } else if (!betweenChaptersMode.value) {

--- a/web/app/features/reader/components/Mode/Scroll/index.test.ts
+++ b/web/app/features/reader/components/Mode/Scroll/index.test.ts
@@ -5,10 +5,11 @@ import type { VueWrapper } from '@vue/test-utils'
 import type { DetailedChapter } from '~/features/chapters/types'
 import type { Comic } from '~/features/comics/types'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { h, ref } from 'vue'
-import { VApp, VImg } from 'vuetify/components'
+import { VApp, VImg, VVirtualScroll } from 'vuetify/components'
 import { ASURA_SOURCE_NAME } from '~/constants'
+import Img from './Img.vue'
 import Scroll from './index.vue'
 
 function comic(overrides: Partial<Comic> = {}): Comic {
@@ -47,6 +48,7 @@ function chapter(overrides: Partial<DetailedChapter> = {}): DetailedChapter {
 
 async function mount(opts: { page?: number } = {}): Promise<{
   wrapper: VueWrapper
+  page: ReturnType<typeof ref<number>>
   showOverlay: ReturnType<typeof ref<boolean>>
 }> {
   const page = ref(opts.page ?? 0)
@@ -70,7 +72,7 @@ async function mount(opts: { page?: number } = {}): Promise<{
     ]),
   })
 
-  return { wrapper, showOverlay }
+  return { wrapper, page, showOverlay }
 }
 
 function setScrollMetrics(el: HTMLElement, metrics: { scrollHeight: number, scrollTop: number, clientHeight: number }): void {
@@ -113,6 +115,73 @@ describe('readerModeScroll', () => {
     await wrapper.find('.v-virtual-scroll').trigger('scroll')
 
     expect(showOverlay.value).toBe(false)
+  })
+
+  it('follows the topmost intersecting page', async () => {
+    const { wrapper, page } = await mount()
+    const imgs = wrapper.findAllComponents(Img)
+
+    await imgs[1]!.vm.$emit('intersecting', true)
+    await imgs[2]!.vm.$emit('intersecting', true)
+
+    expect(page.value).toBe(1)
+  })
+
+  it('does not let leftover intersecting pages overwrite page while moving to another page', async () => {
+    const { wrapper, page } = await mount({ page: 2 })
+    const imgs = wrapper.findAllComponents(Img)
+
+    await imgs[0]!.vm.$emit('intersecting', true)
+    await imgs[1]!.vm.$emit('intersecting', true)
+
+    expect(page.value).toBe(2)
+  })
+
+  it('does not let the target intersecting unlock page updates before the scroll ends', async () => {
+    const { wrapper, page } = await mount({ page: 2 })
+    const imgs = wrapper.findAllComponents(Img)
+
+    await imgs[2]!.vm.$emit('intersecting', true)
+    await imgs[2]!.vm.$emit('intersecting', false)
+    await imgs[1]!.vm.$emit('intersecting', true)
+
+    expect(page.value).toBe(2)
+  })
+
+  it('does not hide the overlay on scroll after the target page intersects but before scroll ends', async () => {
+    const { wrapper, page, showOverlay } = await mount()
+    const el = wrapper.find('.v-virtual-scroll')
+    setScrollMetrics(el.element as HTMLElement, { scrollHeight: 1000, scrollTop: 40, clientHeight: 100 })
+    await el.trigger('scroll')
+
+    page.value = 2
+    await wrapper.vm.$nextTick()
+    await wrapper.findAllComponents(Img)[2]!.vm.$emit('intersecting', true)
+    await el.trigger('scroll')
+
+    expect(showOverlay.value).toBe(true)
+  })
+
+  it('follows intersecting pages again after the rail scroll ends', async () => {
+    const { wrapper, page } = await mount({ page: 2 })
+    const imgs = wrapper.findAllComponents(Img)
+
+    await imgs[2]!.vm.$emit('intersecting', true)
+    await wrapper.find('.v-virtual-scroll').trigger('scrollend')
+    await imgs[2]!.vm.$emit('intersecting', false)
+    await imgs[0]!.vm.$emit('intersecting', true)
+
+    expect(page.value).toBe(0)
+  })
+
+  it('scrolls the list when the page model changes from the rail', async () => {
+    const { wrapper, page } = await mount()
+    const scrollToIndex = vi.spyOn(wrapper.findComponent(VVirtualScroll).vm, 'scrollToIndex')
+
+    page.value = 2
+    await wrapper.vm.$nextTick()
+
+    expect(scrollToIndex).toHaveBeenCalledWith(2)
   })
 
   it('shows the overlay when scrolled to the bottom', async () => {

--- a/web/app/features/reader/components/Mode/Scroll/index.vue
+++ b/web/app/features/reader/components/Mode/Scroll/index.vue
@@ -20,20 +20,29 @@ const scrollRoot = computed(() => {
   return el instanceof HTMLElement ? el : undefined
 })
 
-const restoredPage = page.value
-const restoring = ref(restoredPage > 0)
+const internalPage = ref<number>()
+const movingToPage = ref<number | null>(page.value === 0 ? null : page.value)
 
 const unwatchVirtualScroll = watch(virtualScrollRef, async (value) => {
   if (!value) {
     return
   }
 
-  if (restoring.value) {
+  if (movingToPage.value !== null) {
     await nextTick()
-    value.scrollToIndex(restoredPage)
+    value.scrollToIndex(movingToPage.value)
   }
 
   unwatchVirtualScroll()
+})
+
+watch(page, (value) => {
+  if (value === internalPage.value) {
+    return
+  }
+
+  movingToPage.value = value
+  virtualScrollRef.value?.scrollToIndex(value)
 })
 
 const intersectingPages = new Set<number>()
@@ -42,25 +51,31 @@ function onIntersecting(index: number, isIntersecting: boolean): void {
   recordIntersection(intersectingPages, index, isIntersecting)
 
   const current = pageFromVisibleIndices(intersectingPages, {
-    restoredPage,
-    restoring: restoring.value,
+    movingToPage: movingToPage.value,
   })
   if (current === undefined) {
     return
   }
 
-  if (restoring.value) {
-    restoring.value = false
-    for (const intersectingIndex of intersectingPages) {
-      if (intersectingIndex < restoredPage) {
-        intersectingPages.delete(intersectingIndex)
-      }
-    }
+  internalPage.value = current
+
+  if (movingToPage.value !== null) {
+    return
   }
 
   if (page.value !== current) {
     page.value = current
   }
+}
+
+function onScrollEnd(): void {
+  if (movingToPage.value === null) {
+    return
+  }
+
+  intersectingPages.clear()
+  internalPage.value = movingToPage.value
+  movingToPage.value = null
 }
 
 const preventFirstScroll = ref(true)
@@ -69,6 +84,10 @@ function onScroll(event: Event): void {
   if (preventFirstScroll.value) {
     preventFirstScroll.value = false
 
+    return
+  }
+
+  if (movingToPage.value !== null) {
     return
   }
 
@@ -92,6 +111,7 @@ function onScroll(event: Event): void {
       class="h-100"
       :items="chapter.pageUrls"
       @scroll="onScroll"
+      @scrollend="onScrollEnd"
     >
       <template #default="{ item, index }">
         <ReaderModeScrollImg

--- a/web/app/features/reader/components/Mode/Scroll/index.vue
+++ b/web/app/features/reader/components/Mode/Scroll/index.vue
@@ -84,8 +84,7 @@ function onScroll(event: Event): void {
 
 <template>
   <div
-    class="h-screen overflow-hidden mx-auto"
-    style="max-width: 70rem;"
+    class="h-screen w-screen mx-auto"
     @click="showOverlay = !showOverlay"
   >
     <VVirtualScroll
@@ -97,6 +96,7 @@ function onScroll(event: Event): void {
       <template #default="{ item, index }">
         <ReaderModeScrollImg
           :src="item"
+          style="max-width: 70rem; margin-right: auto; margin-left: auto;"
           :root="scrollRoot"
           @intersecting="onIntersecting(index, $event)"
         />

--- a/web/app/features/reader/components/Mode/Scroll/index.vue
+++ b/web/app/features/reader/components/Mode/Scroll/index.vue
@@ -83,7 +83,11 @@ function onScroll(event: Event): void {
 </script>
 
 <template>
-  <div class="h-screen w-screen overflow-hidden" @click="showOverlay = !showOverlay">
+  <div
+    class="h-screen overflow-hidden mx-auto"
+    style="max-width: 70rem;"
+    @click="showOverlay = !showOverlay"
+  >
     <VVirtualScroll
       ref="virtualScrollRef"
       class="h-100"

--- a/web/app/features/reader/components/Mode/Scroll/visible-page.test.ts
+++ b/web/app/features/reader/components/Mode/Scroll/visible-page.test.ts
@@ -17,19 +17,23 @@ describe('recordIntersection', () => {
 })
 
 describe('pageFromVisibleIndices', () => {
-  it('returns the topmost visible page', () => {
-    expect(pageFromVisibleIndices(new Set([2, 3, 4]), { restoredPage: 0, restoring: false })).toBe(2)
+  it('returns the topmost visible page when following the scroll', () => {
+    expect(pageFromVisibleIndices(new Set([2, 3, 4]), { movingToPage: null })).toBe(2)
   })
 
   it('returns undefined when nothing is visible', () => {
-    expect(pageFromVisibleIndices(new Set(), { restoredPage: 0, restoring: false })).toBeUndefined()
+    expect(pageFromVisibleIndices(new Set(), { movingToPage: null })).toBeUndefined()
   })
 
-  it('ignores pages above the restored position while restoring progress', () => {
-    expect(pageFromVisibleIndices(new Set([0, 1, 2]), { restoredPage: 10, restoring: true })).toBeUndefined()
+  it('ignores other visible pages until the page we are moving to is on screen', () => {
+    expect(pageFromVisibleIndices(new Set([0, 1, 2]), { movingToPage: 10 })).toBeUndefined()
   })
 
-  it('uses the restored window once that page is on screen, ignoring leftover top pages', () => {
-    expect(pageFromVisibleIndices(new Set([0, 1, 10, 11]), { restoredPage: 10, restoring: true })).toBe(10)
+  it('returns the target page once it is visible, even if leftover pages are still listed', () => {
+    expect(pageFromVisibleIndices(new Set([0, 1, 10, 11]), { movingToPage: 10 })).toBe(10)
+  })
+
+  it('returns the target page when jumping backward past leftover later pages', () => {
+    expect(pageFromVisibleIndices(new Set([5, 20, 40]), { movingToPage: 5 })).toBe(5)
   })
 })

--- a/web/app/features/reader/components/Mode/Scroll/visible-page.ts
+++ b/web/app/features/reader/components/Mode/Scroll/visible-page.ts
@@ -14,19 +14,15 @@ export function recordIntersection(
 
 export function pageFromVisibleIndices(
   indices: Set<number>,
-  opts: { restoredPage: number, restoring: boolean },
+  opts: { movingToPage: number | null },
 ): number | undefined {
   if (indices.size === 0) {
     return undefined
   }
 
-  const relevant = opts.restoring
-    ? [...indices].filter(index => index >= opts.restoredPage)
-    : [...indices]
-
-  if (relevant.length === 0) {
-    return undefined
+  if (opts.movingToPage !== null) {
+    return indices.has(opts.movingToPage) ? opts.movingToPage : undefined
   }
 
-  return Math.min(...relevant)
+  return Math.min(...indices)
 }

--- a/web/app/features/reader/components/Overlay/Footer/ChaptersMenu.vue
+++ b/web/app/features/reader/components/Overlay/Footer/ChaptersMenu.vue
@@ -116,6 +116,7 @@ async function pollChapters(): Promise<void> {
   <VBtn
     prepend-icon="fa6-solid:bars"
     color="grey"
+    class="border-thin"
     :loading="chaptersLoading"
     :disabled="!chaptersLoading && chapters.length === 0"
     :append-icon="showMenu ? 'fa6-solid:chevron-up' : 'fa6-solid:chevron-down'"

--- a/web/app/features/reader/components/Overlay/Rail.test.ts
+++ b/web/app/features/reader/components/Overlay/Rail.test.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { VueWrapper } from '@vue/test-utils'
+import type { DetailedChapter } from '~/features/chapters/types'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it } from 'vitest'
+import { h } from 'vue'
+import { VApp, VSlider } from 'vuetify/components'
+import Rail from './Rail.vue'
+
+function chapter(overrides: Partial<DetailedChapter> = {}): DetailedChapter {
+  return {
+    id: 'ch-2',
+    comicId: 'c1',
+    publishedAt: new Date('2026-01-01'),
+    sourceChapterSlug: 'ch-2',
+    title: 'Two',
+    number: 2,
+    pagesNb: 5,
+    download: 100,
+    pageUrls: ['/p1', '/p2', '/p3', '/p4', '/p5'],
+    ...overrides,
+  }
+}
+
+async function mount(
+  page = 2,
+  value: DetailedChapter = chapter(),
+  isDoublePage = false,
+): Promise<VueWrapper> {
+  return mountSuspended({
+    render: () => h(VApp, () => [
+      h(Rail, {
+        'chapter': value,
+        'page': page,
+        'doublePage': isDoublePage,
+        'onUpdate:page': () => {},
+      }),
+    ]),
+  })
+}
+
+describe('readerOverlayRail', () => {
+  it('shows the 1-based current page and the page count', async () => {
+    const wrapper = await mount(2)
+
+    expect(wrapper.text()).toContain('3')
+    expect(wrapper.text()).toContain('5')
+  })
+
+  it('renders a readonly vertical reversed slider snapped to pages', async () => {
+    const wrapper = await mount(2)
+    const slider = wrapper.findComponent(VSlider)
+
+    expect(slider.exists()).toBe(true)
+    expect(slider.props('direction')).toBe('vertical')
+    expect(slider.props('reverse')).toBe(true)
+    expect(slider.props('readonly')).toBe(true)
+    expect(slider.props('step')).toBe(1)
+    expect(slider.props('min')).toBe(0)
+    expect(slider.props('max')).toBe(4)
+    expect(slider.props('modelValue')).toBe(2)
+    expect(slider.props('showTicks')).toBe('always')
+    expect(slider.props('color')).toBe('primary')
+  })
+
+  it('keeps max at 0 for a one-page chapter', async () => {
+    const wrapper = await mount(0, chapter({
+      pagesNb: 1,
+      pageUrls: ['/p1'],
+    }))
+    const slider = wrapper.findComponent(VSlider)
+
+    expect(wrapper.text()).toContain('1')
+    expect(slider.props('max')).toBe(0)
+    expect(slider.props('modelValue')).toBe(0)
+  })
+
+  it('shows a page pair and steps by two when double page is on', async () => {
+    const wrapper = await mount(0, chapter(), true)
+    const slider = wrapper.findComponent(VSlider)
+
+    expect(wrapper.get('[data-test="rail-current"]').text()).toBe('1–2')
+    expect(slider.props('step')).toBe(2)
+    expect(slider.props('max')).toBe(4)
+  })
+
+  it('shows the leftover last page alone in double page', async () => {
+    const wrapper = await mount(4, chapter(), true)
+
+    expect(wrapper.get('[data-test="rail-current"]').text()).toBe('5')
+  })
+})

--- a/web/app/features/reader/components/Overlay/Rail.test.ts
+++ b/web/app/features/reader/components/Overlay/Rail.test.ts
@@ -4,7 +4,7 @@
 import type { VueWrapper } from '@vue/test-utils'
 import type { DetailedChapter } from '~/features/chapters/types'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { h } from 'vue'
 import { VApp, VSlider } from 'vuetify/components'
 import Rail from './Rail.vue'
@@ -49,14 +49,13 @@ describe('readerOverlayRail', () => {
     expect(wrapper.text()).toContain('5')
   })
 
-  it('renders a readonly vertical reversed slider snapped to pages', async () => {
+  it('renders a vertical reversed slider snapped to pages', async () => {
     const wrapper = await mount(2)
     const slider = wrapper.findComponent(VSlider)
 
     expect(slider.exists()).toBe(true)
     expect(slider.props('direction')).toBe('vertical')
     expect(slider.props('reverse')).toBe(true)
-    expect(slider.props('readonly')).toBe(true)
     expect(slider.props('step')).toBe(1)
     expect(slider.props('min')).toBe(0)
     expect(slider.props('max')).toBe(4)
@@ -90,5 +89,24 @@ describe('readerOverlayRail', () => {
     const wrapper = await mount(4, chapter(), true)
 
     expect(wrapper.get('[data-test="rail-current"]').text()).toBe('5')
+  })
+
+  it('does not let a click on the rail bubble to the reader', async () => {
+    const onClick = vi.fn()
+    const wrapper = await mountSuspended({
+      render: () => h('div', { onClick }, [
+        h(VApp, () => [
+          h(Rail, {
+            'chapter': chapter(),
+            'page': 2,
+            'onUpdate:page': () => {},
+          }),
+        ]),
+      ]),
+    })
+
+    await wrapper.find('.position-fixed').trigger('click')
+
+    expect(onClick).not.toHaveBeenCalled()
   })
 })

--- a/web/app/features/reader/components/Overlay/Rail.vue
+++ b/web/app/features/reader/components/Overlay/Rail.vue
@@ -26,6 +26,7 @@ const currentLabel = computed(() => {
   <div
     class="position-fixed d-flex py-8"
     style="top: 6rem; bottom: 4.5rem; right: 1.5rem; z-index: 2;"
+    @click.stop
   >
     <div class="d-flex flex-column rounded-pill bg-surface border-thin pa-4 ga-2 h-100">
       <div data-test="rail-current" class="d-flex w-100 justify-center">
@@ -40,7 +41,6 @@ const currentLabel = computed(() => {
         :step="step"
         direction="vertical"
         reverse
-        readonly
         color="primary"
         track-color="secondary"
         show-ticks="always"

--- a/web/app/features/reader/components/Overlay/Rail.vue
+++ b/web/app/features/reader/components/Overlay/Rail.vue
@@ -1,0 +1,103 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+import type { DetailedChapter } from '~/features/chapters/types'
+
+const props = defineProps<{
+  chapter: DetailedChapter
+  doublePage?: boolean
+}>()
+
+const page = defineModel<number>('page', { default: 0 })
+
+const lastIndex = computed(() => Math.max(props.chapter.pageUrls.length - 1, 0))
+const step = computed(() => props.doublePage ? 2 : 1)
+const currentLabel = computed(() => {
+  const current = page.value + 1
+  const total = props.chapter.pageUrls.length
+  if (!props.doublePage || current >= total) {
+    return String(current)
+  }
+
+  return `${current}–${current + 1}`
+})
+</script>
+
+<template>
+  <div
+    class="position-fixed d-flex py-8"
+    style="top: 6rem; bottom: 4.5rem; right: 1.5rem; z-index: 2;"
+  >
+    <div class="d-flex flex-column rounded-pill bg-surface border-thin pa-4 ga-2 h-100">
+      <div data-test="rail-current" class="d-flex w-100 justify-center">
+        {{ currentLabel }}
+      </div>
+
+      <VSlider
+        v-model="page"
+        class="rail-slider flex-grow-1"
+        :min="0"
+        :max="lastIndex"
+        :step="step"
+        direction="vertical"
+        reverse
+        readonly
+        color="primary"
+        track-color="secondary"
+        show-ticks="always"
+        :tick-size="4"
+        :track-size="20"
+        :thumb-size="4"
+        hide-details
+      />
+
+      <div class="d-flex w-100 justify-center">
+        {{ chapter.pageUrls.length }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.rail-slider {
+  min-height: 0;
+  overflow: visible;
+}
+
+.rail-slider :deep(.v-slider.v-input--vertical) {
+  margin-block: 0;
+}
+
+.rail-slider :deep(.v-slider.v-input--vertical > .v-input__control) {
+  min-height: 0;
+  height: 100%;
+  overflow: visible;
+}
+
+.rail-slider :deep(.v-slider-track) {
+  border-radius: 9999px;
+}
+
+.rail-slider :deep(.v-slider-track__fill) {
+  border-radius: 9999px 9999px 0 0;
+}
+
+.rail-slider :deep(.v-slider-thumb__surface) {
+  width: 28px;
+  height: 4px;
+  border-radius: 2px;
+}
+
+.rail-slider :deep(.v-slider-thumb__surface::before),
+.rail-slider :deep(.v-slider-thumb__ripple) {
+  display: none;
+}
+
+.rail-slider :deep(.v-slider.v-input--vertical .v-slider-track__tick) {
+  opacity: 1;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  margin-inline-start: calc((var(--v-slider-track-size) + 2px) / 2);
+  transform: translate(-50%, 50%);
+}
+</style>

--- a/web/app/features/reader/components/Overlay/index.test.ts
+++ b/web/app/features/reader/components/Overlay/index.test.ts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { VueWrapper } from '@vue/test-utils'
+import type { DetailedChapter } from '~/features/chapters/types'
+import type { Comic } from '~/features/comics/types'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { VApp, VSlider } from 'vuetify/components'
+import { ASURA_SOURCE_NAME } from '~/constants'
+import Overlay from './index.vue'
+import Rail from './Rail.vue'
+
+const HeaderStub = defineComponent({
+  name: 'ReaderOverlayHeader',
+  props: {
+    comic: { type: Object, required: true },
+    chapter: { type: Object, required: true },
+  },
+  template: '<div data-test="header" />',
+})
+
+const FooterStub = defineComponent({
+  name: 'ReaderOverlayFooter',
+  props: {
+    comic: { type: Object, required: true },
+    chapter: { type: Object, required: true },
+  },
+  template: '<div data-test="footer" />',
+})
+
+function comic(): Comic {
+  return {
+    id: 'c1',
+    title: 'Solo Leveling',
+    slug: 'solo-leveling',
+    source: ASURA_SOURCE_NAME,
+    status: 'ongoing',
+    type: 'manhwa',
+    author: 'Chugong',
+    artist: 'Jang',
+    description: 'A hunter',
+    cover: '/cover',
+    genres: [],
+    altTitles: [],
+    chapterCount: 1,
+  }
+}
+
+function chapter(): DetailedChapter {
+  return {
+    id: 'ch-2',
+    comicId: 'c1',
+    publishedAt: new Date('2026-01-01'),
+    sourceChapterSlug: 'ch-2',
+    title: 'Two',
+    number: 2,
+    pagesNb: 3,
+    download: 100,
+    pageUrls: ['/p1', '/p2', '/p3'],
+  }
+}
+
+async function mount(isOpen = true, page = 1): Promise<VueWrapper> {
+  return mountSuspended({
+    render: () => h(VApp, () => [
+      h(Overlay, {
+        'comic': comic(),
+        'chapter': chapter(),
+        'modelValue': isOpen,
+        'page': page,
+        'onUpdate:modelValue': () => {},
+        'onUpdate:page': () => {},
+      }),
+    ]),
+  }, {
+    global: {
+      stubs: {
+        ReaderOverlayHeader: HeaderStub,
+        ReaderOverlayFooter: FooterStub,
+      },
+    },
+  })
+}
+
+describe('readerOverlay', () => {
+  it('shows the page rail with the current page when the overlay is open', async () => {
+    const wrapper = await mount(true, 1)
+
+    expect(wrapper.text()).toContain('2')
+    expect(wrapper.text()).toContain('3')
+    expect(wrapper.findComponent(VSlider).exists()).toBe(true)
+  })
+
+  it('hides the page rail when the overlay is closed', async () => {
+    const wrapper = await mount(false, 1)
+    const rail = wrapper.findComponent(Rail)
+
+    expect(rail.exists()).toBe(true)
+    expect((rail.element as HTMLElement).style.display).toBe('none')
+  })
+})

--- a/web/app/features/reader/components/Overlay/index.vue
+++ b/web/app/features/reader/components/Overlay/index.vue
@@ -6,9 +6,11 @@ import type { Comic } from '~/features/comics/types'
 defineProps<{
   comic: Comic
   chapter: DetailedChapter
+  doublePage?: boolean
 }>()
 
 const show = defineModel<boolean>({ required: true })
+const page = defineModel<number>('page', { required: true })
 </script>
 
 <template>
@@ -17,6 +19,15 @@ const show = defineModel<boolean>({ required: true })
       v-show="show"
       :comic="comic"
       :chapter="chapter"
+    />
+  </VFadeTransition>
+
+  <VFadeTransition>
+    <ReaderOverlayRail
+      v-show="show"
+      v-model:page="page"
+      :chapter="chapter"
+      :double-page="doublePage"
     />
   </VFadeTransition>
 

--- a/web/app/features/reader/components/index.test.ts
+++ b/web/app/features/reader/components/index.test.ts
@@ -18,6 +18,8 @@ const OverlayStub = defineComponent({
     comic: { type: Object, required: true },
     chapter: { type: Object, required: true },
     modelValue: { type: Boolean, required: true },
+    page: { type: Number, required: true },
+    doublePage: { type: Boolean, default: false },
   },
   template: '<div data-test="overlay" />',
 })

--- a/web/app/features/reader/components/index.vue
+++ b/web/app/features/reader/components/index.vue
@@ -34,8 +34,10 @@ const page = defineModel<number>('page', { required: true })
   <div class="h-screen w-screen position-relative">
     <ReaderOverlay
       v-model="showOverlay"
+      v-model:page="page"
       :comic
       :chapter
+      :double-page="settings.doublePage"
     />
 
     <div v-if="chapter.download !== 100" class="d-flex flex-column w-100 h-100 justify-center align-center ga-4">


### PR DESCRIPTION
## Summary

Page rail on the chapter reader overlay so you can see where you are in the current chapter and jump or scrub to a page (#100). This is the overlay page indicator called out in #73.

- `ReaderOverlayRail` on the right edge, between header and footer, in paged (`paged-rtl` / `paged-ltr`) and webtoon
- Shown only with the overlay; 1-based labels (`3 / 20`, `3–4 / 20` in double-page)
- Tap/scrub jumps to the matching stop; overlay stays open; the rail does not change chapter
- Paged: rail sits above the right tap-zone so a gesture on it never turns the page
- Webtoon: `scrollToIndex` for rail jumps; programmatic scroll does not hide the overlay
- Progress still goes through the existing `page` watcher

## Screenshots

### Desktop
<img width="2332" height="1365" alt="image" src="https://github.com/user-attachments/assets/196dc539-c3b1-4160-be5a-a9b11011284a" />
<img width="2331" height="1363" alt="image" src="https://github.com/user-attachments/assets/63b41e4a-fdb3-4bee-8721-3d6227440dbf" />
<img width="2319" height="1362" alt="image" src="https://github.com/user-attachments/assets/01788226-d54a-4b70-96aa-2b195dd28121" />


### Mobile
<img width="368" height="771" alt="image" src="https://github.com/user-attachments/assets/b69edb8c-82ff-4267-b68d-1b986178c3b3" />
<img width="368" height="792" alt="image" src="https://github.com/user-attachments/assets/9d22c893-ba87-4a75-896e-090e9d30c5b6" />
<img width="359" height="778" alt="image" src="https://github.com/user-attachments/assets/5ba69969-00c4-4b05-8008-219d84bf2f37" />

## Test plan

- [x] Overlay shown on a fully downloaded chapter → rail on the right, all three reading modes
- [x] Overlay hidden → no rail
- [x] Tap/scrub jumps to the matching page (or double-page pair); overlay stays open
- [x] Gesture on the rail never turns a paged page and never scrolls the webtoon strip
- [x] Label uses real 1-based pages (`3 / 20`, `3–4 / 20`)
- [x] Between-chapters card: rail stays at first or last stop; interior stop dismisses the card
- [x] `pnpm test`, `pnpm typecheck`, `pnpm lint`, `pnpm knip` pass

Closes #100