### PR TITLE
feat(readingprogress): bulk mark chapters as read API

### DIFF
--- a/api/cmd/uchiyomiserver/setup.go
+++ b/api/cmd/uchiyomiserver/setup.go
@@ -156,6 +156,7 @@ func setupApp(cfg *cfg) (*core.App, error) {
 
 	readingProgressSvc, err := readingprogress.NewService(readingprogress.Deps{
 		Repository: dbr.ReadingProgressRepository,
+		Transactor: dbr.Txor,
 		Library:    dbr.LibraryRepository,
 		Comics:     comicsExistsLookup{repo: dbr.ComicsRepository},
 		Chapters:   dbr.ChaptersRepository,

--- a/api/cmd/uchiyomiserver/setup_internal_test.go
+++ b/api/cmd/uchiyomiserver/setup_internal_test.go
@@ -105,6 +105,12 @@ func (stubReadingProgressService) Save(context.Context, readingprogress.SaveOpts
 	return readingprogress.Progress{}, nil
 }
 
+func (stubReadingProgressService) MarkRead(
+	context.Context, readingprogress.MarkReadOpts,
+) (readingprogress.ListResult, error) {
+	return readingprogress.ListResult{}, nil
+}
+
 type emptyOIDCProvidersRepository struct{}
 
 func (emptyOIDCProvidersRepository) GetByID(

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -450,6 +450,12 @@ func (fakeReadingProgressService) Save(context.Context, readingprogress.SaveOpts
 	return readingprogress.Progress{}, nil
 }
 
+func (fakeReadingProgressService) MarkRead(
+	context.Context, readingprogress.MarkReadOpts,
+) (readingprogress.ListResult, error) {
+	return readingprogress.ListResult{}, nil
+}
+
 func newTestCache[P any, T any](t *testing.T, name string, logger *slog.Logger) *fncache.Cache[P, T] {
 	t.Helper()
 

--- a/api/pkg/core/readingprogress/domain.go
+++ b/api/pkg/core/readingprogress/domain.go
@@ -51,6 +51,12 @@ type GetOpts struct {
 	ChapterID uuid.UUID
 }
 
+type MarkReadOpts struct {
+	ChapterIDs []uuid.UUID
+	UserID     uuid.UUID
+	ComicID    uuid.UUID
+}
+
 type UpsertOpts struct {
 	UpdatedAt time.Time
 	UserID    uuid.UUID
@@ -70,6 +76,7 @@ type ReadingProgressService interface {
 	List(context.Context, ListOpts) (ListResult, error)
 	MapByChapterIDs(context.Context, MapOpts) (map[uuid.UUID]Progress, error)
 	Save(context.Context, SaveOpts) (Progress, error)
+	MarkRead(context.Context, MarkReadOpts) (ListResult, error)
 }
 
 type LibraryMembership interface {
@@ -82,6 +89,7 @@ type ComicLookup interface {
 
 type ChapterLookup interface {
 	GetByID(context.Context, uuid.UUID) (*chapters.Chapter, error)
+	GetByIds(context.Context, []uuid.UUID) ([]chapters.Chapter, error)
 }
 
 func ClampPage(page, pagesNb int) int {

--- a/api/pkg/core/readingprogress/gateway/http/controller.go
+++ b/api/pkg/core/readingprogress/gateway/http/controller.go
@@ -93,6 +93,7 @@ func (c *Controller) InitRouter(r chi.Router) {
 	r.Group(func(r chi.Router) {
 		r.Use(c.cfg.Middlewares...)
 		r.Get(c.cfg.Endpoint+"/{id}/progress", c.get)
+		r.Post(c.cfg.Endpoint+"/{id}/progress", c.post)
 		r.Put(c.cfg.ChaptersEndpoint+"/{id}/progress", c.put)
 	})
 }
@@ -131,6 +132,62 @@ func (c *Controller) get(w http.ResponseWriter, r *http.Request) {
 		}
 
 		c.deps.Logger.Error("failed to list reading progress", "error", err)
+		httputils.WriteError(w, c.deps.Logger, http.StatusInternalServerError, "")
+
+		return
+	}
+
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, listFromDomain(result))
+}
+
+func (c *Controller) post(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user, ok := httpsession.UserFrom(ctx)
+	if !ok {
+		httputils.WriteError(w, c.deps.Logger, http.StatusUnauthorized, "")
+
+		return
+	}
+
+	comicID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "id must be a valid UUID")
+
+		return
+	}
+
+	req, err := httputils.DecodeJSON[markReadRequest](r)
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "invalid request body")
+
+		return
+	}
+
+	result, err := c.deps.Service.MarkRead(ctx, readingprogress.MarkReadOpts{
+		UserID:     user.ID,
+		ComicID:    comicID,
+		ChapterIDs: req.ChapterIDs,
+	})
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusNotFound, "")
+
+			return
+		}
+
+		if errors.Is(err, domain.ErrForbidden) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusForbidden, "comic not in library")
+
+			return
+		}
+
+		if errors.Is(err, readingprogress.ErrInvalid) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "invalid request body")
+
+			return
+		}
+
+		c.deps.Logger.Error("failed to mark reading progress", "error", err)
 		httputils.WriteError(w, c.deps.Logger, http.StatusInternalServerError, "")
 
 		return

--- a/api/pkg/core/readingprogress/gateway/http/controller_test.go
+++ b/api/pkg/core/readingprogress/gateway/http/controller_test.go
@@ -34,10 +34,13 @@ const (
 type stubService struct {
 	listErr    error
 	saveErr    error
+	markErr    error
 	listResult readingprogress.ListResult
+	markResult readingprogress.ListResult
 	saveResult readingprogress.Progress
-	lastList   readingprogress.ListOpts
+	lastMark   readingprogress.MarkReadOpts
 	lastSave   readingprogress.SaveOpts
+	lastList   readingprogress.ListOpts
 }
 
 func (s *stubService) List(_ context.Context, opts readingprogress.ListOpts) (readingprogress.ListResult, error) {
@@ -50,6 +53,14 @@ func (s *stubService) Save(_ context.Context, opts readingprogress.SaveOpts) (re
 	s.lastSave = opts
 
 	return s.saveResult, s.saveErr
+}
+
+func (s *stubService) MarkRead(
+	_ context.Context, opts readingprogress.MarkReadOpts,
+) (readingprogress.ListResult, error) {
+	s.lastMark = opts
+
+	return s.markResult, s.markErr
 }
 
 func (s *stubService) MapByChapterIDs(

--- a/api/pkg/core/readingprogress/gateway/http/controller_test.go
+++ b/api/pkg/core/readingprogress/gateway/http/controller_test.go
@@ -181,6 +181,20 @@ func putProgress(t *testing.T, r chi.Router, chapterID, body string, withCookie 
 	return rec
 }
 
+func postProgress(t *testing.T, r chi.Router, comicID, body string, withCookie bool) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, endpoint+"/"+comicID+"/progress", strings.NewReader(body))
+	if withCookie {
+		req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	}
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	return rec
+}
+
 func TestNewValidatesConfigAndDeps(t *testing.T) {
 	t.Parallel()
 
@@ -505,5 +519,190 @@ func TestPutUsesSessionUser(t *testing.T) {
 
 	if svc.lastSave.UserID != user.ID {
 		t.Errorf("lastSave.UserID = %s, want session user %s", svc.lastSave.UserID, user.ID)
+	}
+}
+
+func TestPostUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	r := newTestRouter(t, &stubService{}, authenticatorFor(t, user))
+
+	rec := postProgress(t, r, uuid.New().String(), `{"chapterIds":["`+uuid.New().String()+`"]}`, false)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusUnauthorized, rec.Body.String())
+	}
+}
+
+func TestPostOK(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	comicID := uuid.New()
+	ch1 := uuid.New()
+	ch2 := uuid.New()
+	continueChapter := uuid.New()
+
+	svc := &stubService{
+		markResult: readingprogress.ListResult{
+			Continue: &readingprogress.Continue{ChapterID: continueChapter, Page: 10},
+		},
+	}
+	r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+	body := `{"chapterIds":["` + ch1.String() + `","` + ch2.String() + `"]}`
+	rec := postProgress(t, r, comicID.String(), body, true)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	if svc.lastMark.UserID != user.ID {
+		t.Errorf("lastMark.UserID = %s, want %s", svc.lastMark.UserID, user.ID)
+	}
+
+	if svc.lastMark.ComicID != comicID {
+		t.Errorf("lastMark.ComicID = %s, want %s", svc.lastMark.ComicID, comicID)
+	}
+
+	if len(svc.lastMark.ChapterIDs) != 2 || svc.lastMark.ChapterIDs[0] != ch1 || svc.lastMark.ChapterIDs[1] != ch2 {
+		t.Errorf("lastMark.ChapterIDs = %v, want [%s, %s]", svc.lastMark.ChapterIDs, ch1, ch2)
+	}
+
+	var got continueJSON
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("body not decodable (%q): %v", rec.Body.String(), err)
+	}
+
+	if got.Continue == nil {
+		t.Fatal("continue is nil, want object")
+	}
+
+	if got.Continue.ChapterID != continueChapter.String() || got.Continue.Page != 10 {
+		t.Errorf("continue = %+v", got.Continue)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw body: %v", err)
+	}
+
+	if _, ok := raw["chapters"]; ok {
+		t.Error("body must not include chapters")
+	}
+
+	var continueRaw map[string]json.RawMessage
+	if err := json.Unmarshal(raw["continue"], &continueRaw); err != nil {
+		t.Fatalf("decode continue: %v", err)
+	}
+
+	if _, ok := continueRaw["updatedAt"]; ok {
+		t.Error("continue must not include updatedAt")
+	}
+}
+
+func TestPostInvalidComicID(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	r := newTestRouter(t, &stubService{}, authenticatorFor(t, user))
+
+	rec := postProgress(t, r, "not-a-uuid", `{"chapterIds":["`+uuid.New().String()+`"]}`, true)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestPostInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	r := newTestRouter(t, &stubService{}, authenticatorFor(t, user))
+
+	rec := postProgress(t, r, uuid.New().String(), `{`, true)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestPostMissingChapterIds(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	r := newTestRouter(t, &stubService{}, authenticatorFor(t, user))
+
+	rec := postProgress(t, r, uuid.New().String(), `{}`, true)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestPostEmptyChapterIds(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	r := newTestRouter(t, &stubService{}, authenticatorFor(t, user))
+
+	rec := postProgress(t, r, uuid.New().String(), `{"chapterIds":[]}`, true)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestPostForbidden(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	svc := &stubService{markErr: domain.ErrForbidden}
+	r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+	rec := postProgress(t, r, uuid.New().String(), `{"chapterIds":["`+uuid.New().String()+`"]}`, true)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusForbidden, rec.Body.String())
+	}
+
+	var got struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+
+	if got.Message != "comic not in library" {
+		t.Errorf("message = %q, want %q", got.Message, "comic not in library")
+	}
+}
+
+func TestPostNotFound(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	svc := &stubService{markErr: domain.ErrNotFound}
+	r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+	rec := postProgress(t, r, uuid.New().String(), `{"chapterIds":["`+uuid.New().String()+`"]}`, true)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+}
+
+func TestPostInvalid(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	svc := &stubService{markErr: readingprogress.ErrInvalid}
+	r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+	rec := postProgress(t, r, uuid.New().String(), `{"chapterIds":["`+uuid.New().String()+`"]}`, true)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
 	}
 }

--- a/api/pkg/core/readingprogress/gateway/http/dto.go
+++ b/api/pkg/core/readingprogress/gateway/http/dto.go
@@ -28,6 +28,10 @@ type saveRequest struct {
 	Page *int `json:"page" validate:"required"`
 }
 
+type markReadRequest struct {
+	ChapterIDs []uuid.UUID `json:"chapterIds" validate:"required,min=1,dive"`
+}
+
 func progressFromDomain(p readingprogress.Progress) progressResponse {
 	return progressResponse{
 		UpdatedAt: p.UpdatedAt,

--- a/api/pkg/core/readingprogress/service.go
+++ b/api/pkg/core/readingprogress/service.go
@@ -3,6 +3,7 @@
 package readingprogress
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -197,7 +198,149 @@ func (s *Service) MarkRead(ctx context.Context, opts MarkReadOpts) (ListResult, 
 		return ListResult{}, fmt.Errorf("%w: no eligible chapters", ErrInvalid)
 	}
 
-	return ListResult{}, fmt.Errorf("%w: not implemented", ErrInvalid)
+	err = s.deps.Transactor.WithinTx(ctx, transaction.TxOpts{}, func(ctx context.Context) error {
+		return s.markReadTx(ctx, opts, eligible)
+	})
+	if err != nil {
+		return ListResult{}, fmt.Errorf("s.deps.Transactor.WithinTx: %w", err)
+	}
+
+	return s.List(ctx, ListOpts{UserID: opts.UserID, ComicID: opts.ComicID})
+}
+
+func (s *Service) markReadTx(
+	ctx context.Context,
+	opts MarkReadOpts,
+	eligible []chapters.Chapter,
+) error {
+	latest, err := s.deps.Repository.GetLatestByUserAndComic(ctx, ListOpts{
+		UserID:  opts.UserID,
+		ComicID: opts.ComicID,
+	})
+	if err != nil {
+		return fmt.Errorf("s.deps.Repository.GetLatestByUserAndComic: %w", err)
+	}
+
+	var (
+		cChapter *chapters.Chapter
+		cMissing bool
+	)
+	if latest != nil {
+		cChapter, cMissing, err = s.resolveContinueChapter(ctx, latest.ChapterID)
+		if err != nil {
+			return err
+		}
+	}
+
+	eligibleIDs := make([]uuid.UUID, len(eligible))
+	for i, ch := range eligible {
+		eligibleIDs[i] = ch.ID
+	}
+
+	existingProgress, err := s.deps.Repository.ListByUserAndChapterIDs(ctx, MapOpts{
+		IDs:    eligibleIDs,
+		UserID: opts.UserID,
+	})
+	if err != nil {
+		return fmt.Errorf("s.deps.Repository.ListByUserAndChapterIDs: %w", err)
+	}
+
+	storedMap := make(map[uuid.UUID]int, len(existingProgress))
+	for _, p := range existingProgress {
+		storedMap[p.ChapterID] = p.Page
+	}
+
+	writtenAt := time.Now().UTC()
+	for _, ch := range eligible {
+		storedPage, ok := storedMap[ch.ID]
+		if !ok || storedPage != ch.PagesNb {
+			_, err := s.deps.Repository.Upsert(ctx, UpsertOpts{
+				UpdatedAt: writtenAt,
+				UserID:    opts.UserID,
+				ComicID:   opts.ComicID,
+				ChapterID: ch.ID,
+				Page:      ch.PagesNb,
+			})
+			if err != nil {
+				return fmt.Errorf("s.deps.Repository.Upsert: %w", err)
+			}
+		}
+	}
+
+	winnerID, winnerPage := continueWinner(eligible, latest, cChapter, cMissing)
+
+	retouchAt := time.Now().UTC()
+	if !retouchAt.After(writtenAt) {
+		retouchAt = writtenAt.Add(time.Nanosecond)
+	}
+
+	_, err = s.deps.Repository.Upsert(ctx, UpsertOpts{
+		UpdatedAt: retouchAt,
+		UserID:    opts.UserID,
+		ComicID:   opts.ComicID,
+		ChapterID: winnerID,
+		Page:      winnerPage,
+	})
+	if err != nil {
+		return fmt.Errorf("s.deps.Repository.Upsert: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Service) resolveContinueChapter(
+	ctx context.Context,
+	chapterID uuid.UUID,
+) (*chapters.Chapter, bool, error) {
+	ch, err := s.deps.Chapters.GetByID(ctx, chapterID)
+	if err == nil {
+		return ch, false, nil
+	}
+
+	if errors.Is(err, domain.ErrNotFound) {
+		return nil, true, nil
+	}
+
+	return nil, false, fmt.Errorf("s.deps.Chapters.GetByID: %w", err)
+}
+
+func continueWinner(
+	eligible []chapters.Chapter,
+	latest *Progress,
+	cChapter *chapters.Chapter,
+	cMissing bool,
+) (uuid.UUID, int) {
+	h := highestEligible(eligible)
+	if latest == nil || cMissing || cChapter == nil {
+		return h.ID, h.PagesNb
+	}
+
+	if h.Number > cChapter.Number {
+		return h.ID, h.PagesNb
+	}
+
+	for _, ch := range eligible {
+		if ch.ID == latest.ChapterID {
+			return latest.ChapterID, ch.PagesNb
+		}
+	}
+
+	return latest.ChapterID, latest.Page
+}
+
+func highestEligible(eligible []chapters.Chapter) chapters.Chapter {
+	best := eligible[0]
+	for _, ch := range eligible[1:] {
+		if ch.Number > best.Number {
+			best = ch
+		} else if ch.Number == best.Number {
+			if bytes.Compare(ch.ID[:], best.ID[:]) < 0 {
+				best = ch
+			}
+		}
+	}
+
+	return best
 }
 
 func uniqueIDs(ids []uuid.UUID) []uuid.UUID {

--- a/api/pkg/core/readingprogress/service.go
+++ b/api/pkg/core/readingprogress/service.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/transaction"
 )
@@ -163,10 +164,55 @@ func (s *Service) Save(ctx context.Context, opts SaveOpts) (Progress, error) {
 }
 
 func (s *Service) MarkRead(ctx context.Context, opts MarkReadOpts) (ListResult, error) {
-	_ = ctx
-	_ = opts
+	ids := uniqueIDs(opts.ChapterIDs)
+	if len(ids) == 0 {
+		return ListResult{}, fmt.Errorf("%w: chapterIds is required", ErrInvalid)
+	}
+
+	if err := s.requireLibrary(ctx, opts.UserID, opts.ComicID); err != nil {
+		return ListResult{}, err
+	}
+
+	found, err := s.deps.Chapters.GetByIds(ctx, ids)
+	if err != nil {
+		return ListResult{}, fmt.Errorf("s.deps.Chapters.GetByIds: %w", err)
+	}
+
+	if len(found) != len(ids) {
+		return ListResult{}, domain.ErrNotFound
+	}
+
+	eligible := make([]chapters.Chapter, 0, len(found))
+	for i := range found {
+		if found[i].ComicID != opts.ComicID {
+			return ListResult{}, domain.ErrNotFound
+		}
+
+		if found[i].PagesNb > 0 {
+			eligible = append(eligible, found[i])
+		}
+	}
+
+	if len(eligible) == 0 {
+		return ListResult{}, fmt.Errorf("%w: no eligible chapters", ErrInvalid)
+	}
 
 	return ListResult{}, fmt.Errorf("%w: not implemented", ErrInvalid)
+}
+
+func uniqueIDs(ids []uuid.UUID) []uuid.UUID {
+	seen := make(map[uuid.UUID]struct{}, len(ids))
+	out := make([]uuid.UUID, 0, len(ids))
+	for _, id := range ids {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+
+	return out
 }
 
 func (s *Service) requireLibrary(ctx context.Context, userID, comicID uuid.UUID) error {

--- a/api/pkg/core/readingprogress/service.go
+++ b/api/pkg/core/readingprogress/service.go
@@ -10,12 +10,14 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/transaction"
 )
 
 var _ ReadingProgressService = (*Service)(nil)
 
 type Deps struct {
 	Repository Repository
+	Transactor transaction.Transactor
 	Library    LibraryMembership
 	Comics     ComicLookup
 	Chapters   ChapterLookup
@@ -24,6 +26,10 @@ type Deps struct {
 func (deps *Deps) Validate() error {
 	if deps.Repository == nil {
 		return errors.New("repository is required")
+	}
+
+	if deps.Transactor == nil {
+		return errors.New("transactor is required")
 	}
 
 	if deps.Library == nil {
@@ -154,6 +160,13 @@ func (s *Service) Save(ctx context.Context, opts SaveOpts) (Progress, error) {
 	}
 
 	return saved, nil
+}
+
+func (s *Service) MarkRead(ctx context.Context, opts MarkReadOpts) (ListResult, error) {
+	_ = ctx
+	_ = opts
+
+	return ListResult{}, fmt.Errorf("%w: not implemented", ErrInvalid)
 }
 
 func (s *Service) requireLibrary(ctx context.Context, userID, comicID uuid.UUID) error {

--- a/api/pkg/core/readingprogress/service_test.go
+++ b/api/pkg/core/readingprogress/service_test.go
@@ -180,6 +180,34 @@ func (f *fakeChapters) GetByIds(_ context.Context, ids []uuid.UUID) ([]chapters.
 	return nil, nil
 }
 
+func ch(id, comicID uuid.UUID, number float64, pagesNb int) chapters.Chapter {
+	return chapters.Chapter{ID: id, ComicID: comicID, Number: number, PagesNb: pagesNb}
+}
+
+func markReadSvc(
+	t *testing.T,
+	repo *fakeRepo,
+	lib readingprogress.LibraryMembership,
+	comics readingprogress.ComicLookup,
+	chaps *fakeChapters,
+	tx *fakeTransactor,
+) *readingprogress.Service {
+	t.Helper()
+
+	svc, err := readingprogress.NewService(readingprogress.Deps{
+		Repository: repo,
+		Transactor: tx,
+		Library:    lib,
+		Comics:     comics,
+		Chapters:   chaps,
+	})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	return svc
+}
+
 func newService(
 	t *testing.T,
 	repo readingprogress.Repository,
@@ -506,5 +534,219 @@ func TestListForbidden(t *testing.T) {
 
 	if repo.listCalls != 0 {
 		t.Error("listed without membership")
+	}
+}
+
+func TestMarkReadEmptyChapterIDs(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		ids  []uuid.UUID
+	}{
+		{name: "nil", ids: nil},
+		{name: "empty slice", ids: []uuid.UUID{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := &fakeRepo{}
+			tx := &fakeTransactor{}
+			svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{}, tx)
+
+			_, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+				UserID:     uuid.New(),
+				ComicID:    uuid.New(),
+				ChapterIDs: tc.ids,
+			})
+			if !errors.Is(err, readingprogress.ErrInvalid) {
+				t.Errorf("err = %v, want ErrInvalid", err)
+			}
+			if tx.calls != 0 {
+				t.Errorf("tx.calls = %d, want 0", tx.calls)
+			}
+			if repo.upsertCalls != 0 {
+				t.Errorf("repo.upsertCalls = %d, want 0", repo.upsertCalls)
+			}
+		})
+	}
+}
+
+//nolint:dupl
+func TestMarkReadForbiddenWhenNotInLibrary(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chID := uuid.New()
+	repo := &fakeRepo{}
+	tx := &fakeTransactor{}
+	svc := markReadSvc(t, repo, &fakeLibrary{inLib: false}, &fakeComics{exists: true}, &fakeChapters{
+		byID: map[uuid.UUID]chapters.Chapter{
+			chID: ch(chID, comicID, 1.0, 10),
+		},
+	}, tx)
+
+	_, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+		UserID:     uuid.New(),
+		ComicID:    comicID,
+		ChapterIDs: []uuid.UUID{chID},
+	})
+	if !errors.Is(err, domain.ErrForbidden) {
+		t.Errorf("err = %v, want ErrForbidden", err)
+	}
+	if tx.calls != 0 {
+		t.Errorf("tx.calls = %d, want 0", tx.calls)
+	}
+	if repo.upsertCalls != 0 {
+		t.Errorf("repo.upsertCalls = %d, want 0", repo.upsertCalls)
+	}
+}
+
+//nolint:dupl
+func TestMarkReadNotFoundWhenComicMissing(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chID := uuid.New()
+	repo := &fakeRepo{}
+	tx := &fakeTransactor{}
+	svc := markReadSvc(t, repo, &fakeLibrary{inLib: false}, &fakeComics{exists: false}, &fakeChapters{
+		byID: map[uuid.UUID]chapters.Chapter{
+			chID: ch(chID, comicID, 2.5, 10),
+		},
+	}, tx)
+
+	_, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+		UserID:     uuid.New(),
+		ComicID:    comicID,
+		ChapterIDs: []uuid.UUID{chID},
+	})
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+	if tx.calls != 0 {
+		t.Errorf("tx.calls = %d, want 0", tx.calls)
+	}
+	if repo.upsertCalls != 0 {
+		t.Errorf("repo.upsertCalls = %d, want 0", repo.upsertCalls)
+	}
+}
+
+//nolint:dupl
+func TestMarkReadUnknownChapter(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	ch1 := uuid.New()
+	ch2 := uuid.New()
+	repo := &fakeRepo{}
+	tx := &fakeTransactor{}
+	svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{
+		byID: map[uuid.UUID]chapters.Chapter{
+			ch1: ch(ch1, comicID, 1.0, 10),
+		},
+	}, tx)
+
+	_, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+		UserID:     uuid.New(),
+		ComicID:    comicID,
+		ChapterIDs: []uuid.UUID{ch1, ch2},
+	})
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+	if tx.calls != 0 {
+		t.Errorf("tx.calls = %d, want 0", tx.calls)
+	}
+	if repo.upsertCalls != 0 {
+		t.Errorf("repo.upsertCalls = %d, want 0", repo.upsertCalls)
+	}
+}
+
+//nolint:dupl
+func TestMarkReadForeignComicChapter(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	otherComicID := uuid.New()
+	chID := uuid.New()
+	repo := &fakeRepo{}
+	tx := &fakeTransactor{}
+	svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{
+		byID: map[uuid.UUID]chapters.Chapter{
+			chID: ch(chID, otherComicID, 3.0, 10),
+		},
+	}, tx)
+
+	_, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+		UserID:     uuid.New(),
+		ComicID:    comicID,
+		ChapterIDs: []uuid.UUID{chID},
+	})
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+	if tx.calls != 0 {
+		t.Errorf("tx.calls = %d, want 0", tx.calls)
+	}
+	if repo.upsertCalls != 0 {
+		t.Errorf("repo.upsertCalls = %d, want 0", repo.upsertCalls)
+	}
+}
+
+//nolint:dupl
+func TestMarkReadOnlyZeroPagesNb(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chID := uuid.New()
+	repo := &fakeRepo{}
+	tx := &fakeTransactor{}
+	svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{
+		byID: map[uuid.UUID]chapters.Chapter{
+			chID: ch(chID, comicID, 4.0, 0),
+		},
+	}, tx)
+
+	_, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+		UserID:     uuid.New(),
+		ComicID:    comicID,
+		ChapterIDs: []uuid.UUID{chID},
+	})
+	if !errors.Is(err, readingprogress.ErrInvalid) {
+		t.Errorf("err = %v, want ErrInvalid", err)
+	}
+	if tx.calls != 0 {
+		t.Errorf("tx.calls = %d, want 0", tx.calls)
+	}
+	if repo.upsertCalls != 0 {
+		t.Errorf("repo.upsertCalls = %d, want 0", repo.upsertCalls)
+	}
+}
+
+func TestMarkReadDedupesBeforeLookup(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chID := uuid.New()
+	repo := &fakeRepo{}
+	tx := &fakeTransactor{}
+	chaps := &fakeChapters{
+		byID: map[uuid.UUID]chapters.Chapter{
+			chID: ch(chID, comicID, 5.0, 10),
+		},
+	}
+	svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, chaps, tx)
+
+	_, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+		UserID:     uuid.New(),
+		ComicID:    comicID,
+		ChapterIDs: []uuid.UUID{chID, chID},
+	})
+	if len(chaps.lastIDs) != 1 {
+		t.Fatalf("len(chaps.lastIDs) = %d, want 1", len(chaps.lastIDs))
+	}
+	if !errors.Is(err, readingprogress.ErrInvalid) {
+		t.Errorf("err = %v, want ErrInvalid", err)
 	}
 }

--- a/api/pkg/core/readingprogress/service_test.go
+++ b/api/pkg/core/readingprogress/service_test.go
@@ -12,20 +12,36 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/readingprogress"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/transaction"
 )
 
+type fakeTransactor struct {
+	err   error
+	calls int
+}
+
+func (f *fakeTransactor) WithinTx(ctx context.Context, _ transaction.TxOpts, fn func(context.Context) error) error {
+	f.calls++
+	if err := fn(ctx); err != nil {
+		return err
+	}
+
+	return f.err
+}
+
 type fakeRepo struct {
+	existing    *readingprogress.Progress
 	listErr     error
 	getErr      error
 	upsertErr   error
-	existing    *readingprogress.Progress
 	rows        []readingprogress.Progress
+	upserts     []readingprogress.UpsertOpts
 	lastUpsert  readingprogress.UpsertOpts
+	lastGet     readingprogress.GetOpts
+	listed      readingprogress.ListOpts
 	listCalls   int
 	getCalls    int
 	upsertCalls int
-	lastGet     readingprogress.GetOpts
-	listed      readingprogress.ListOpts
 }
 
 func (f *fakeRepo) GetLatestByUserAndComic(
@@ -72,6 +88,7 @@ func (f *fakeRepo) Get(_ context.Context, opts readingprogress.GetOpts) (*readin
 func (f *fakeRepo) Upsert(_ context.Context, opts readingprogress.UpsertOpts) (readingprogress.Progress, error) {
 	f.upsertCalls++
 	f.lastUpsert = opts
+	f.upserts = append(f.upserts, opts)
 
 	return readingprogress.Progress{
 		ChapterID: opts.ChapterID,
@@ -111,10 +128,13 @@ func (f *fakeComics) Exists(_ context.Context, id uuid.UUID) (bool, error) {
 }
 
 type fakeChapters struct {
-	getErr   error
-	chapter  *chapters.Chapter
-	lastID   uuid.UUID
-	getCalls int
+	byID        map[uuid.UUID]chapters.Chapter
+	chapter     *chapters.Chapter
+	getErr      error
+	getByIdsErr error
+	lastIDs     []uuid.UUID
+	lastID      uuid.UUID
+	getCalls    int
 }
 
 func (f *fakeChapters) GetByID(_ context.Context, id uuid.UUID) (*chapters.Chapter, error) {
@@ -124,7 +144,40 @@ func (f *fakeChapters) GetByID(_ context.Context, id uuid.UUID) (*chapters.Chapt
 		return nil, f.getErr
 	}
 
+	if f.byID != nil {
+		ch, ok := f.byID[id]
+		if !ok {
+			return nil, domain.ErrNotFound
+		}
+
+		return &ch, nil
+	}
+
 	return f.chapter, nil
+}
+
+func (f *fakeChapters) GetByIds(_ context.Context, ids []uuid.UUID) ([]chapters.Chapter, error) {
+	f.lastIDs = ids
+	if f.getByIdsErr != nil {
+		return nil, f.getByIdsErr
+	}
+
+	if f.byID != nil {
+		out := make([]chapters.Chapter, 0, len(ids))
+		for _, id := range ids {
+			if ch, ok := f.byID[id]; ok {
+				out = append(out, ch)
+			}
+		}
+
+		return out, nil
+	}
+
+	if f.chapter != nil {
+		return []chapters.Chapter{*f.chapter}, nil
+	}
+
+	return nil, nil
 }
 
 func newService(
@@ -138,6 +191,7 @@ func newService(
 
 	svc, err := readingprogress.NewService(readingprogress.Deps{
 		Repository: repo,
+		Transactor: &fakeTransactor{},
 		Library:    lib,
 		Comics:     comics,
 		Chapters:   ch,
@@ -155,6 +209,20 @@ func TestNewServiceValidatesDeps(t *testing.T) {
 	_, err := readingprogress.NewService(readingprogress.Deps{})
 	if err == nil {
 		t.Fatal("NewService with empty deps must fail")
+	}
+}
+
+func TestNewServiceRequiresTransactor(t *testing.T) {
+	t.Parallel()
+
+	_, err := readingprogress.NewService(readingprogress.Deps{
+		Repository: &fakeRepo{},
+		Library:    &fakeLibrary{inLib: true},
+		Comics:     &fakeComics{exists: true},
+		Chapters:   &fakeChapters{},
+	})
+	if err == nil {
+		t.Fatal("NewService without transactor must fail")
 	}
 }
 

--- a/api/pkg/core/readingprogress/service_test.go
+++ b/api/pkg/core/readingprogress/service_test.go
@@ -30,10 +30,12 @@ func (f *fakeTransactor) WithinTx(ctx context.Context, _ transaction.TxOpts, fn 
 }
 
 type fakeRepo struct {
+	latest      *readingprogress.Progress
 	existing    *readingprogress.Progress
 	listErr     error
 	getErr      error
 	upsertErr   error
+	stored      []readingprogress.Progress
 	rows        []readingprogress.Progress
 	upserts     []readingprogress.UpsertOpts
 	lastUpsert  readingprogress.UpsertOpts
@@ -54,6 +56,10 @@ func (f *fakeRepo) GetLatestByUserAndComic(
 		return nil, f.listErr
 	}
 
+	if f.latest != nil {
+		return f.latest, nil
+	}
+
 	if len(f.rows) == 0 {
 		return nil, nil
 	}
@@ -70,6 +76,10 @@ func (f *fakeRepo) ListByUserAndChapterIDs(
 	f.listCalls++
 	if f.listErr != nil {
 		return nil, f.listErr
+	}
+
+	if f.stored != nil {
+		return f.stored, nil
 	}
 
 	return f.rows, nil
@@ -89,12 +99,16 @@ func (f *fakeRepo) Upsert(_ context.Context, opts readingprogress.UpsertOpts) (r
 	f.upsertCalls++
 	f.lastUpsert = opts
 	f.upserts = append(f.upserts, opts)
-
-	return readingprogress.Progress{
+	out := readingprogress.Progress{
 		ChapterID: opts.ChapterID,
 		Page:      opts.Page,
 		UpdatedAt: opts.UpdatedAt,
-	}, f.upsertErr
+	}
+	f.latest = &out
+	row := out
+	f.rows = []readingprogress.Progress{row}
+
+	return out, f.upsertErr
 }
 
 type fakeLibrary struct {
@@ -746,7 +760,453 @@ func TestMarkReadDedupesBeforeLookup(t *testing.T) {
 	if len(chaps.lastIDs) != 1 {
 		t.Fatalf("len(chaps.lastIDs) = %d, want 1", len(chaps.lastIDs))
 	}
-	if !errors.Is(err, readingprogress.ErrInvalid) {
-		t.Errorf("err = %v, want ErrInvalid", err)
+	if err != nil {
+		t.Fatalf("MarkRead: %v", err)
+	}
+}
+
+func TestMarkReadFirstProgressContinueIsHighestNumber(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	comicID := uuid.New()
+	byID := make(map[uuid.UUID]chapters.Chapter, 10)
+	ids := make([]uuid.UUID, 10)
+	for i := 0; i < 10; i++ {
+		id := uuid.New()
+		ids[i] = id
+		byID[id] = ch(id, comicID, float64(i+1), 20)
+	}
+
+	repo := &fakeRepo{}
+	tx := &fakeTransactor{}
+	svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
+
+	got, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+		UserID:     userID,
+		ComicID:    comicID,
+		ChapterIDs: ids,
+	})
+	if err != nil {
+		t.Fatalf("MarkRead: %v", err)
+	}
+
+	if tx.calls != 1 {
+		t.Errorf("tx.calls = %d, want 1", tx.calls)
+	}
+	if repo.upsertCalls < 10 {
+		t.Errorf("repo.upsertCalls = %d, want >= 10", repo.upsertCalls)
+	}
+
+	seenEligible := make(map[uuid.UUID]bool, len(ids))
+	for _, up := range repo.upserts {
+		if up.Page == 20 {
+			seenEligible[up.ChapterID] = true
+		}
+	}
+	for _, id := range ids {
+		if !seenEligible[id] {
+			t.Errorf("chapter %v was not upserted with Page 20", id)
+		}
+	}
+
+	lastUpsert := repo.upserts[len(repo.upserts)-1]
+	wantWinnerID := ids[9]
+	if lastUpsert.ChapterID != wantWinnerID || lastUpsert.Page != 20 {
+		t.Errorf("last upsert = %+v, want chapter %v at page 20", lastUpsert, wantWinnerID)
+	}
+
+	if len(repo.upserts) > 1 && !lastUpsert.UpdatedAt.After(repo.upserts[0].UpdatedAt) {
+		t.Errorf(
+			"last upsert UpdatedAt %v not after first upsert UpdatedAt %v",
+			lastUpsert.UpdatedAt,
+			repo.upserts[0].UpdatedAt,
+		)
+	}
+
+	if got.Continue == nil || got.Continue.ChapterID != wantWinnerID || got.Continue.Page != 20 {
+		t.Errorf("got.Continue = %+v, want chapter %v at page 20", got.Continue, wantWinnerID)
+	}
+}
+
+func TestMarkReadKeepsEarlierContinuePage(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	comicID := uuid.New()
+	ch50ID := uuid.New()
+	ch50 := ch(ch50ID, comicID, 50.0, 20)
+
+	byID := make(map[uuid.UUID]chapters.Chapter, 41)
+	byID[ch50ID] = ch50
+
+	ids := make([]uuid.UUID, 40)
+	for i := 0; i < 40; i++ {
+		id := uuid.New()
+		ids[i] = id
+		byID[id] = ch(id, comicID, float64(i+1), 10)
+	}
+
+	repo := &fakeRepo{
+		latest: &readingprogress.Progress{
+			ChapterID: ch50ID,
+			Page:      3,
+			UpdatedAt: time.Unix(10, 0).UTC(),
+		},
+	}
+	tx := &fakeTransactor{}
+	svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
+
+	got, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+		UserID:     userID,
+		ComicID:    comicID,
+		ChapterIDs: ids,
+	})
+	if err != nil {
+		t.Fatalf("MarkRead: %v", err)
+	}
+
+	if len(repo.upserts) < 2 {
+		t.Fatalf("len(repo.upserts) = %d, want at least 2", len(repo.upserts))
+	}
+
+	for i, up := range repo.upserts[:len(repo.upserts)-1] {
+		if up.ChapterID == ch50ID {
+			t.Errorf("upsert[%d] has ch50, want only in last upsert", i)
+		}
+		if up.Page != 10 {
+			t.Errorf("upsert[%d] Page = %d, want 10", i, up.Page)
+		}
+	}
+
+	lastUpsert := repo.upserts[len(repo.upserts)-1]
+	if lastUpsert.ChapterID != ch50ID || lastUpsert.Page != 3 {
+		t.Errorf("last upsert = %+v, want ch50 at page 3", lastUpsert)
+	}
+	if !lastUpsert.UpdatedAt.After(repo.upserts[0].UpdatedAt) {
+		t.Errorf("last upsert UpdatedAt not after first upsert UpdatedAt")
+	}
+
+	if got.Continue == nil || got.Continue.ChapterID != ch50ID || got.Continue.Page != 3 {
+		t.Errorf("got.Continue = %+v, want ch50 at page 3", got.Continue)
+	}
+}
+
+func TestMarkReadKeepsCompletedLaterContinue(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	comicID := uuid.New()
+	ch100ID := uuid.New()
+	ch100 := ch(ch100ID, comicID, 100.0, 50)
+
+	byID := make(map[uuid.UUID]chapters.Chapter, 11)
+	byID[ch100ID] = ch100
+
+	ids := make([]uuid.UUID, 10)
+	for i := 0; i < 10; i++ {
+		id := uuid.New()
+		ids[i] = id
+		byID[id] = ch(id, comicID, float64(i+1), 20)
+	}
+
+	repo := &fakeRepo{
+		latest: &readingprogress.Progress{
+			ChapterID: ch100ID,
+			Page:      50,
+			UpdatedAt: time.Unix(10, 0).UTC(),
+		},
+	}
+	tx := &fakeTransactor{}
+	svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
+
+	got, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+		UserID:     userID,
+		ComicID:    comicID,
+		ChapterIDs: ids,
+	})
+	if err != nil {
+		t.Fatalf("MarkRead: %v", err)
+	}
+
+	for i, up := range repo.upserts[:len(repo.upserts)-1] {
+		if up.ChapterID == ch100ID {
+			t.Errorf("non-final upsert[%d] rewrote ch100", i)
+		}
+	}
+
+	lastUpsert := repo.upserts[len(repo.upserts)-1]
+	if lastUpsert.ChapterID != ch100ID || lastUpsert.Page != 50 {
+		t.Errorf("last upsert = %+v, want ch100 at page 50", lastUpsert)
+	}
+	if got.Continue == nil || got.Continue.ChapterID != ch100ID || got.Continue.Page != 50 {
+		t.Errorf("got.Continue = %+v, want ch100 at page 50", got.Continue)
+	}
+}
+
+func TestMarkReadMovesContinueForward(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	comicID := uuid.New()
+	byID := make(map[uuid.UUID]chapters.Chapter, 50)
+	ids := make([]uuid.UUID, 50)
+	for i := 0; i < 50; i++ {
+		id := uuid.New()
+		ids[i] = id
+		byID[id] = ch(id, comicID, float64(i+1), 15)
+	}
+
+	ch5ID := ids[4]
+	ch50ID := ids[49]
+
+	repo := &fakeRepo{
+		latest: &readingprogress.Progress{
+			ChapterID: ch5ID,
+			Page:      2,
+			UpdatedAt: time.Unix(10, 0).UTC(),
+		},
+	}
+	tx := &fakeTransactor{}
+	svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
+
+	got, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+		UserID:     userID,
+		ComicID:    comicID,
+		ChapterIDs: ids,
+	})
+	if err != nil {
+		t.Fatalf("MarkRead: %v", err)
+	}
+
+	foundCh5Upsert := false
+	for _, up := range repo.upserts[:len(repo.upserts)-1] {
+		if up.ChapterID == ch5ID && up.Page == 15 {
+			foundCh5Upsert = true
+		}
+	}
+	if !foundCh5Upsert {
+		t.Errorf("ch5 was not upserted to page 15 in loop")
+	}
+
+	lastUpsert := repo.upserts[len(repo.upserts)-1]
+	if lastUpsert.ChapterID != ch50ID || lastUpsert.Page != 15 {
+		t.Errorf("last upsert = %+v, want ch50 at page 15", lastUpsert)
+	}
+	if got.Continue == nil || got.Continue.ChapterID != ch50ID || got.Continue.Page != 15 {
+		t.Errorf("got.Continue = %+v, want ch50 at page 15", got.Continue)
+	}
+}
+
+func TestMarkReadSkipsZeroPagesNbAmongEligible(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	comicID := uuid.New()
+	ch1ID := uuid.New()
+	ch2ID := uuid.New()
+	ch3ID := uuid.New()
+
+	byID := map[uuid.UUID]chapters.Chapter{
+		ch1ID: ch(ch1ID, comicID, 1.0, 0),
+		ch2ID: ch(ch2ID, comicID, 2.0, 10),
+		ch3ID: ch(ch3ID, comicID, 3.0, 10),
+	}
+
+	repo := &fakeRepo{}
+	tx := &fakeTransactor{}
+	svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
+
+	got, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+		UserID:     userID,
+		ComicID:    comicID,
+		ChapterIDs: []uuid.UUID{ch1ID, ch2ID, ch3ID},
+	})
+	if err != nil {
+		t.Fatalf("MarkRead: %v", err)
+	}
+
+	for _, up := range repo.upserts {
+		if up.ChapterID == ch1ID {
+			t.Errorf("ch1 (PagesNb: 0) was upserted")
+		}
+	}
+
+	lastUpsert := repo.upserts[len(repo.upserts)-1]
+	if lastUpsert.ChapterID != ch3ID || lastUpsert.Page != 10 {
+		t.Errorf("last upsert = %+v, want ch3 at page 10", lastUpsert)
+	}
+	if got.Continue == nil || got.Continue.ChapterID != ch3ID || got.Continue.Page != 10 {
+		t.Errorf("got.Continue = %+v, want ch3 at page 10", got.Continue)
+	}
+}
+
+func TestMarkReadDuplicateIDsOneWritePerChapter(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	comicID := uuid.New()
+	ch1ID := uuid.New()
+
+	byID := map[uuid.UUID]chapters.Chapter{
+		ch1ID: ch(ch1ID, comicID, 1.0, 8),
+	}
+
+	repo := &fakeRepo{}
+	tx := &fakeTransactor{}
+	svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
+
+	_, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+		UserID:     userID,
+		ComicID:    comicID,
+		ChapterIDs: []uuid.UUID{ch1ID, ch1ID},
+	})
+	if err != nil {
+		t.Fatalf("MarkRead: %v", err)
+	}
+
+	ch1Upserts := 0
+	for _, up := range repo.upserts {
+		if up.ChapterID == ch1ID {
+			ch1Upserts++
+		}
+	}
+	if ch1Upserts > 2 {
+		t.Errorf("ch1 upserts = %d, want <= 2", ch1Upserts)
+	}
+}
+
+func TestMarkReadMissingContinueChapterTreatsAsNone(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	comicID := uuid.New()
+	missingID := uuid.New()
+	ch3ID := uuid.New()
+	ch7ID := uuid.New()
+
+	byID := map[uuid.UUID]chapters.Chapter{
+		ch3ID: ch(ch3ID, comicID, 3.0, 12),
+		ch7ID: ch(ch7ID, comicID, 7.0, 12),
+	}
+
+	repo := &fakeRepo{
+		latest: &readingprogress.Progress{
+			ChapterID: missingID,
+			Page:      5,
+			UpdatedAt: time.Unix(10, 0).UTC(),
+		},
+	}
+	tx := &fakeTransactor{}
+	svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
+
+	got, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+		UserID:     userID,
+		ComicID:    comicID,
+		ChapterIDs: []uuid.UUID{ch3ID, ch7ID},
+	})
+	if err != nil {
+		t.Fatalf("MarkRead: %v", err)
+	}
+
+	for _, up := range repo.upserts {
+		if up.ChapterID == missingID {
+			t.Errorf("missing continue chapter %v was upserted", missingID)
+		}
+	}
+
+	lastUpsert := repo.upserts[len(repo.upserts)-1]
+	if lastUpsert.ChapterID != ch7ID || lastUpsert.Page != 12 {
+		t.Errorf("last upsert = %+v, want ch7 at page 12", lastUpsert)
+	}
+	if got.Continue == nil || got.Continue.ChapterID != ch7ID || got.Continue.Page != 12 {
+		t.Errorf("got.Continue = %+v, want ch7 at page 12", got.Continue)
+	}
+}
+
+func TestMarkReadTxErrorNoListSideEffect(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chID := uuid.New()
+	byID := map[uuid.UUID]chapters.Chapter{
+		chID: ch(chID, comicID, 1.0, 10),
+	}
+
+	t.Run("upsert error inside tx", func(t *testing.T) {
+		t.Parallel()
+
+		upsertErr := errors.New("db error")
+		repo := &fakeRepo{upsertErr: upsertErr}
+		tx := &fakeTransactor{}
+		svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
+
+		_, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+			UserID:     uuid.New(),
+			ComicID:    comicID,
+			ChapterIDs: []uuid.UUID{chID},
+		})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !errors.Is(err, upsertErr) {
+			t.Errorf("err = %v, want wrapped %v", err, upsertErr)
+		}
+	})
+
+	t.Run("withinTx returns error", func(t *testing.T) {
+		t.Parallel()
+
+		txErr := errors.New("tx commit failed")
+		repo := &fakeRepo{}
+		tx := &fakeTransactor{err: txErr}
+		svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
+
+		_, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+			UserID:     uuid.New(),
+			ComicID:    comicID,
+			ChapterIDs: []uuid.UUID{chID},
+		})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !errors.Is(err, txErr) {
+			t.Errorf("err = %v, want wrapped %v", err, txErr)
+		}
+	})
+}
+
+func TestMarkReadTieBreakByUUID(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	comicID := uuid.New()
+	id1 := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	id2 := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+
+	byID := map[uuid.UUID]chapters.Chapter{
+		id1: ch(id1, comicID, 1.0, 10),
+		id2: ch(id2, comicID, 1.0, 10),
+	}
+
+	repo := &fakeRepo{}
+	tx := &fakeTransactor{}
+	svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
+
+	got, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+		UserID:     userID,
+		ComicID:    comicID,
+		ChapterIDs: []uuid.UUID{id2, id1},
+	})
+	if err != nil {
+		t.Fatalf("MarkRead: %v", err)
+	}
+
+	lastUpsert := repo.upserts[len(repo.upserts)-1]
+	if lastUpsert.ChapterID != id1 {
+		t.Errorf("winner = %v, want %v (smallest UUID)", lastUpsert.ChapterID, id1)
+	}
+	if got.Continue == nil || got.Continue.ChapterID != id1 {
+		t.Errorf("got.Continue = %+v, want chapter %v", got.Continue, id1)
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `POST /api/me/comics/{id}/progress` endpoint to bulk mark a list of chapters as read for a comic.
- Implements `MarkRead` service method transactional progress updates and intelligent continue chapter resolution.
- Validates chapter IDs, ensures library membership, filters out 0-page chapters, and handles deduplication.
- Closes #95

## Test plan
- [x] Unit tests for `readingprogress.Service.MarkRead` covering validation, transaction handling, upserts, and continue chapter computation.
- [x] Unit tests for HTTP controller `POST /api/me/comics/{id}/progress` testing authentication, validation errors, error handling, and response payloads.
- [x] Full API test suite passes (`go test ./...`).
- [x] Pre-push hooks passed (linting, build, and tests).