### PR TITLE
feat(comics): select multiple chapters on library comic page (#96)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ logs
 .env.*
 !.env.example
 
+
+.pnpm-store
+
 .DS_Store
 .idea
 *.suo

--- a/api/cmd/uchiyomiserver/setup_internal_test.go
+++ b/api/cmd/uchiyomiserver/setup_internal_test.go
@@ -105,10 +105,16 @@ func (stubReadingProgressService) Save(context.Context, readingprogress.SaveOpts
 	return readingprogress.Progress{}, nil
 }
 
-func (stubReadingProgressService) MarkRead(
-	context.Context, readingprogress.MarkReadOpts,
+func (stubReadingProgressService) SetRead(
+	context.Context, readingprogress.SetReadOpts,
 ) (readingprogress.ListResult, error) {
 	return readingprogress.ListResult{}, nil
+}
+
+func (stubReadingProgressService) Delete(
+	context.Context, readingprogress.DeleteOpts,
+) error {
+	return nil
 }
 
 type emptyOIDCProvidersRepository struct{}

--- a/api/pkg/core/comics/domain.go
+++ b/api/pkg/core/comics/domain.go
@@ -87,6 +87,12 @@ type RefreshComicOpts struct {
 	ID     uuid.UUID
 }
 
+type RetryChaptersOpts struct {
+	ChapterIDs []uuid.UUID
+	UserID     uuid.UUID
+	ComicID    uuid.UUID
+}
+
 type ComicsService interface {
 	Create(context.Context, CreateOpts) (*Comic, error)
 	GetByID(context.Context, GetByIDOpts) (*Comic, error)
@@ -94,6 +100,7 @@ type ComicsService interface {
 	Delete(context.Context, DeleteOpts) error
 	RefreshChapterLists(context.Context) error
 	RefreshComic(context.Context, RefreshComicOpts) (*Comic, error)
+	RetryChapters(context.Context, RetryChaptersOpts) error
 	ServeCover(ctx context.Context, opts GetByIDOpts) (diskPath, contentType string, err error)
 }
 

--- a/api/pkg/core/comics/gateway/http/controller.go
+++ b/api/pkg/core/comics/gateway/http/controller.go
@@ -91,6 +91,7 @@ func (c *Controller) InitRouter(r chi.Router) {
 		r.Post("/", c.create)
 		r.Get("/", c.getMany)
 		r.Post("/{id}/refresh", c.refreshByID)
+		r.Post("/{id}/retry", c.retryChapters)
 		r.Get("/{id}/cover", c.serveCover)
 		r.Get("/{id}", c.getByID)
 		r.Delete("/{id}", c.deleteByID)
@@ -444,4 +445,61 @@ func (c *Controller) serveCover(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", contentType)
 	http.ServeContent(w, r, diskPath, time.Time{}, f)
+}
+
+func (c *Controller) retryChapters(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user, ok := httpsession.UserFrom(ctx)
+	if !ok {
+		c.deps.Logger.Error("user not found in context")
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+
+		return
+	}
+
+	comicID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "id must be a valid UUID")
+
+		return
+	}
+
+	req, err := httputils.DecodeJSON[retryChaptersRequest](r)
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "invalid request body")
+
+		return
+	}
+
+	if len(req.ChapterIDs) == 0 {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "chapterIds must not be empty")
+
+		return
+	}
+
+	err = c.deps.ComicsService.RetryChapters(ctx, comics.RetryChaptersOpts{
+		ComicID:    comicID,
+		UserID:     user.ID,
+		ChapterIDs: req.ChapterIDs,
+	})
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusNotFound, "comic not found")
+
+			return
+		}
+
+		if errors.Is(err, domain.ErrForbidden) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusForbidden, "comic not in library")
+
+			return
+		}
+
+		c.deps.Logger.Error("failed to retry chapters download", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusAccepted, "")
 }

--- a/api/pkg/core/comics/gateway/http/controller_test.go
+++ b/api/pkg/core/comics/gateway/http/controller_test.go
@@ -44,6 +44,7 @@ type stubComicsService struct {
 	deleteErr          error
 	serveCoverErr      error
 	refreshComicErr    error
+	retryChaptersErr   error
 	createResult       *comics.Comic
 	getByIDResult      *comics.Comic
 	refreshComicResult *comics.Comic
@@ -51,6 +52,7 @@ type stubComicsService struct {
 	serveCoverType     string
 	getManyResult      comics.Page
 	lastGetMany        comics.GetManyOpts
+	lastRetryChapters  comics.RetryChaptersOpts
 	serveCoverCalls    int
 	lastServeCoverID   uuid.UUID
 }
@@ -81,8 +83,10 @@ func (s *stubComicsService) RefreshComic(_ context.Context, _ comics.RefreshComi
 	return s.refreshComicResult, s.refreshComicErr
 }
 
-func (s *stubComicsService) RetryChapters(_ context.Context, _ comics.RetryChaptersOpts) error {
-	return nil
+func (s *stubComicsService) RetryChapters(_ context.Context, opts comics.RetryChaptersOpts) error {
+	s.lastRetryChapters = opts
+
+	return s.retryChaptersErr
 }
 
 func (s *stubComicsService) ServeCover(_ context.Context, opts comics.GetByIDOpts) (string, string, error) {
@@ -727,5 +731,123 @@ func TestRefreshInternalError(t *testing.T) {
 
 	if rec.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestRetryChaptersRequiresAuthentication(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	r := newTestRouter(t, &stubComicsService{}, nil)
+
+	body := strings.NewReader(`{"chapterIds":["` + uuid.New().String() + `"]}`)
+	req := httptest.NewRequest(http.MethodPost, comicsEndpoint+"/"+comicID.String()+"/retry", body)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestRetryChaptersInvalidComicID(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	r := newTestRouter(t, &stubComicsService{}, authenticatorFor(t, user))
+
+	body := strings.NewReader(`{"chapterIds":["` + uuid.New().String() + `"]}`)
+	req := httptest.NewRequest(http.MethodPost, comicsEndpoint+"/invalid-uuid/retry", body)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestRetryChaptersEmptyChapterIDs(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	r := newTestRouter(t, &stubComicsService{}, authenticatorFor(t, user))
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		comicsEndpoint+"/"+uuid.New().String()+"/retry",
+		strings.NewReader(`{"chapterIds":[]}`),
+	)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestRetryChaptersNotFound(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	comicID := uuid.New()
+	r := newTestRouter(t, &stubComicsService{
+		retryChaptersErr: fmt.Errorf("s.deps.ComicsRepository.FindByID: %w", domain.ErrNotFound),
+	}, authenticatorFor(t, user))
+
+	body := strings.NewReader(`{"chapterIds":["` + uuid.New().String() + `"]}`)
+	req := httptest.NewRequest(http.MethodPost, comicsEndpoint+"/"+comicID.String()+"/retry", body)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestRetryChaptersForbidden(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	comicID := uuid.New()
+	r := newTestRouter(t, &stubComicsService{
+		retryChaptersErr: domain.ErrForbidden,
+	}, authenticatorFor(t, user))
+
+	body := strings.NewReader(`{"chapterIds":["` + uuid.New().String() + `"]}`)
+	req := httptest.NewRequest(http.MethodPost, comicsEndpoint+"/"+comicID.String()+"/retry", body)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
+func TestRetryChaptersAccepted(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	comicID := uuid.New()
+	chapterID := uuid.New()
+	svc := &stubComicsService{}
+	r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+	body := strings.NewReader(`{"chapterIds":["` + chapterID.String() + `"]}`)
+	req := httptest.NewRequest(http.MethodPost, comicsEndpoint+"/"+comicID.String()+"/retry", body)
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusAccepted)
+	}
+
+	last := svc.lastRetryChapters
+	if last.ComicID != comicID || last.UserID != user.ID || len(last.ChapterIDs) != 1 || last.ChapterIDs[0] != chapterID {
+		t.Errorf("unexpected lastRetryChapters: %+v", last)
 	}
 }

--- a/api/pkg/core/comics/gateway/http/controller_test.go
+++ b/api/pkg/core/comics/gateway/http/controller_test.go
@@ -81,6 +81,10 @@ func (s *stubComicsService) RefreshComic(_ context.Context, _ comics.RefreshComi
 	return s.refreshComicResult, s.refreshComicErr
 }
 
+func (s *stubComicsService) RetryChapters(_ context.Context, _ comics.RetryChaptersOpts) error {
+	return nil
+}
+
 func (s *stubComicsService) ServeCover(_ context.Context, opts comics.GetByIDOpts) (string, string, error) {
 	s.serveCoverCalls++
 	s.lastServeCoverID = opts.ID

--- a/api/pkg/core/comics/gateway/http/dto.go
+++ b/api/pkg/core/comics/gateway/http/dto.go
@@ -89,3 +89,7 @@ func comicResponseFromDomain(comic *comics.Comic) comicResponse {
 		AltTitles:    comic.AltTitles,
 	}
 }
+
+type retryChaptersRequest struct {
+	ChapterIDs []uuid.UUID `json:"chapterIds"`
+}

--- a/api/pkg/core/comics/refresh/app_test.go
+++ b/api/pkg/core/comics/refresh/app_test.go
@@ -42,6 +42,10 @@ func (f *fakeComicsService) RefreshComic(context.Context, comics.RefreshComicOpt
 	panic("RefreshComic must not be called")
 }
 
+func (f *fakeComicsService) RetryChapters(context.Context, comics.RetryChaptersOpts) error {
+	panic("RetryChapters must not be called")
+}
+
 func (f *fakeComicsService) RefreshChapterLists(ctx context.Context) error {
 	f.mu.Lock()
 	f.refreshCalls++

--- a/api/pkg/core/comics/service.go
+++ b/api/pkg/core/comics/service.go
@@ -299,3 +299,57 @@ func (s *Service) Delete(ctx context.Context, opts DeleteOpts) error {
 
 	return nil
 }
+
+func (s *Service) RetryChapters(ctx context.Context, opts RetryChaptersOpts) error {
+	if len(opts.ChapterIDs) == 0 {
+		return errors.New("opts.ChapterIDs must not be empty")
+	}
+
+	comic, err := s.deps.ComicsRepository.FindByID(ctx, opts.ComicID)
+	if err != nil {
+		return fmt.Errorf("s.deps.ComicsRepository.FindByID: %w", err)
+	}
+
+	if comic == nil {
+		return domain.ErrNotFound
+	}
+
+	inLibrary, err := s.deps.LibraryRepository.ExistsByUserAndComic(ctx, opts.UserID, opts.ComicID)
+	if err != nil {
+		return fmt.Errorf("s.deps.LibraryRepository.ExistsByUserAndComic: %w", err)
+	}
+
+	if !inLibrary {
+		return domain.ErrForbidden
+	}
+
+	chapterList, err := s.deps.ChaptersService.ListByComicID(ctx, opts.ComicID)
+	if err != nil {
+		return fmt.Errorf("s.deps.ChaptersService.ListByComicID: %w", err)
+	}
+
+	requestedMap := make(map[uuid.UUID]struct{}, len(opts.ChapterIDs))
+	for _, id := range opts.ChapterIDs {
+		requestedMap[id] = struct{}{}
+	}
+
+	for _, chapter := range chapterList {
+		if _, requested := requestedMap[chapter.ID]; !requested {
+			continue
+		}
+
+		if chapter.Download >= 100 {
+			continue
+		}
+
+		err = s.deps.ChaptersService.RetryDownload(ctx, chapters.RetryDownloadOpts{
+			UserID:    opts.UserID,
+			ChapterID: chapter.ID,
+		})
+		if err != nil && !errors.Is(err, domain.ErrConflict) {
+			return fmt.Errorf("s.deps.ChaptersService.RetryDownload: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/api/pkg/core/comics/service_test.go
+++ b/api/pkg/core/comics/service_test.go
@@ -279,6 +279,7 @@ type fakeChaptersService struct {
 	lastCleanupChapters      []chapters.Chapter
 	listByComicIDResult      []chapters.Chapter
 	createAllResult          []chapters.Chapter
+	retryDownloadCalls       []chapters.RetryDownloadOpts
 	createAllCalls           int
 	listByComicIDCalls       int
 	enqueueDownloadableCalls int
@@ -360,7 +361,9 @@ func (f *fakeChaptersService) CleanupComic(_ context.Context, comicID uuid.UUID,
 	return f.cleanupComicErr
 }
 
-func (f *fakeChaptersService) RetryDownload(context.Context, chapters.RetryDownloadOpts) error {
+func (f *fakeChaptersService) RetryDownload(_ context.Context, opts chapters.RetryDownloadOpts) error {
+	f.retryDownloadCalls = append(f.retryDownloadCalls, opts)
+
 	return nil
 }
 
@@ -1159,5 +1162,95 @@ func TestServeCoverReturnsLocalPath(t *testing.T) {
 
 	if coverStore.serveCalls != 1 {
 		t.Errorf("ServeLocal called %d times, want 1", coverStore.serveCalls)
+	}
+}
+
+func TestServiceRetryChaptersNotFound(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	userID := uuid.New()
+
+	deps := validServiceDeps()
+	deps.ComicsRepository = &fakeComicsRepository{findByIDErr: domain.ErrNotFound}
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	err = svc.RetryChapters(context.Background(), comics.RetryChaptersOpts{
+		ComicID:    comicID,
+		UserID:     userID,
+		ChapterIDs: []uuid.UUID{uuid.New()},
+	})
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("RetryChapters = %v, want domain.ErrNotFound", err)
+	}
+}
+
+func TestServiceRetryChaptersForbiddenWhenNotInLibrary(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	userID := uuid.New()
+
+	deps := validServiceDeps()
+	deps.ComicsRepository = &fakeComicsRepository{findByIDResult: &comics.Comic{ID: comicID}}
+	deps.LibraryRepository = &fakeLibraryRepository{inLibrary: false}
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	err = svc.RetryChapters(context.Background(), comics.RetryChaptersOpts{
+		ComicID:    comicID,
+		UserID:     userID,
+		ChapterIDs: []uuid.UUID{uuid.New()},
+	})
+	if !errors.Is(err, domain.ErrForbidden) {
+		t.Fatalf("RetryChapters = %v, want domain.ErrForbidden", err)
+	}
+}
+
+func TestServiceRetryChaptersSuccess(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	userID := uuid.New()
+	ch1ID := uuid.New()
+	ch2ID := uuid.New()
+	ch3CompletedID := uuid.New()
+
+	fakeChapters := &fakeChaptersService{
+		listByComicIDResult: []chapters.Chapter{
+			{ID: ch1ID, ComicID: comicID, Download: -1},
+			{ID: ch2ID, ComicID: comicID, Download: 50},
+			{ID: ch3CompletedID, ComicID: comicID, Download: 100},
+		},
+	}
+
+	deps := validServiceDeps()
+	deps.ComicsRepository = &fakeComicsRepository{findByIDResult: &comics.Comic{ID: comicID}}
+	deps.LibraryRepository = &fakeLibraryRepository{inLibrary: true}
+	deps.ChaptersService = fakeChapters
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	err = svc.RetryChapters(context.Background(), comics.RetryChaptersOpts{
+		ComicID:    comicID,
+		UserID:     userID,
+		ChapterIDs: []uuid.UUID{ch1ID, ch2ID, ch3CompletedID},
+	})
+	if err != nil {
+		t.Fatalf("RetryChapters: %v", err)
+	}
+
+	if len(fakeChapters.retryDownloadCalls) != 2 {
+		t.Fatalf("expected 2 retry calls (excluding 100%%), got %d", len(fakeChapters.retryDownloadCalls))
 	}
 }

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -360,6 +360,10 @@ func (fakeComicsService) RefreshComic(context.Context, comics.RefreshComicOpts) 
 	return nil, errors.New(notImplemented)
 }
 
+func (fakeComicsService) RetryChapters(context.Context, comics.RetryChaptersOpts) error {
+	return errors.New(notImplemented)
+}
+
 func (fakeComicsService) ServeCover(context.Context, comics.GetByIDOpts) (string, string, error) {
 	return "", "", errors.New(notImplemented)
 }

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -450,10 +450,16 @@ func (fakeReadingProgressService) Save(context.Context, readingprogress.SaveOpts
 	return readingprogress.Progress{}, nil
 }
 
-func (fakeReadingProgressService) MarkRead(
-	context.Context, readingprogress.MarkReadOpts,
+func (fakeReadingProgressService) SetRead(
+	context.Context, readingprogress.SetReadOpts,
 ) (readingprogress.ListResult, error) {
 	return readingprogress.ListResult{}, nil
+}
+
+func (fakeReadingProgressService) Delete(
+	context.Context, readingprogress.DeleteOpts,
+) error {
+	return nil
 }
 
 func newTestCache[P any, T any](t *testing.T, name string, logger *slog.Logger) *fncache.Cache[P, T] {

--- a/api/pkg/core/readingprogress/domain.go
+++ b/api/pkg/core/readingprogress/domain.go
@@ -51,10 +51,16 @@ type GetOpts struct {
 	ChapterID uuid.UUID
 }
 
-type MarkReadOpts struct {
+type DeleteOpts struct {
+	UserID    uuid.UUID
+	ChapterID uuid.UUID
+}
+
+type SetReadOpts struct {
 	ChapterIDs []uuid.UUID
 	UserID     uuid.UUID
 	ComicID    uuid.UUID
+	Read       bool
 }
 
 type UpsertOpts struct {
@@ -66,8 +72,8 @@ type UpsertOpts struct {
 }
 
 type DeleteProgressOpts struct {
-	UserID     uuid.UUID
 	ChapterIDs []uuid.UUID
+	UserID     uuid.UUID
 }
 
 type Repository interface {
@@ -82,7 +88,8 @@ type ReadingProgressService interface {
 	List(context.Context, ListOpts) (ListResult, error)
 	MapByChapterIDs(context.Context, MapOpts) (map[uuid.UUID]Progress, error)
 	Save(context.Context, SaveOpts) (Progress, error)
-	MarkRead(context.Context, MarkReadOpts) (ListResult, error)
+	SetRead(context.Context, SetReadOpts) (ListResult, error)
+	Delete(context.Context, DeleteOpts) error
 }
 
 type LibraryMembership interface {

--- a/api/pkg/core/readingprogress/domain.go
+++ b/api/pkg/core/readingprogress/domain.go
@@ -78,6 +78,7 @@ type DeleteProgressOpts struct {
 
 type Repository interface {
 	GetLatestByUserAndComic(context.Context, ListOpts) (*Progress, error)
+	ListByUserAndComic(context.Context, ListOpts) ([]Progress, error)
 	ListByUserAndChapterIDs(context.Context, MapOpts) ([]Progress, error)
 	Get(context.Context, GetOpts) (*Progress, error)
 	Upsert(context.Context, UpsertOpts) (Progress, error)
@@ -103,6 +104,7 @@ type ComicLookup interface {
 type ChapterLookup interface {
 	GetByID(context.Context, uuid.UUID) (*chapters.Chapter, error)
 	GetByIds(context.Context, []uuid.UUID) ([]chapters.Chapter, error)
+	ListByComicID(context.Context, uuid.UUID) ([]chapters.Chapter, error)
 }
 
 func ClampPage(page, pagesNb int) int {

--- a/api/pkg/core/readingprogress/domain.go
+++ b/api/pkg/core/readingprogress/domain.go
@@ -65,11 +65,17 @@ type UpsertOpts struct {
 	Page      int
 }
 
+type DeleteProgressOpts struct {
+	UserID     uuid.UUID
+	ChapterIDs []uuid.UUID
+}
+
 type Repository interface {
 	GetLatestByUserAndComic(context.Context, ListOpts) (*Progress, error)
 	ListByUserAndChapterIDs(context.Context, MapOpts) ([]Progress, error)
 	Get(context.Context, GetOpts) (*Progress, error)
 	Upsert(context.Context, UpsertOpts) (Progress, error)
+	DeleteByUserAndChapterIDs(context.Context, DeleteProgressOpts) error
 }
 
 type ReadingProgressService interface {

--- a/api/pkg/core/readingprogress/gateway/http/controller.go
+++ b/api/pkg/core/readingprogress/gateway/http/controller.go
@@ -95,6 +95,7 @@ func (c *Controller) InitRouter(r chi.Router) {
 		r.Get(c.cfg.Endpoint+"/{id}/progress", c.get)
 		r.Post(c.cfg.Endpoint+"/{id}/progress", c.post)
 		r.Put(c.cfg.ChaptersEndpoint+"/{id}/progress", c.put)
+		r.Delete(c.cfg.ChaptersEndpoint+"/{id}/progress", c.delete)
 	})
 }
 
@@ -156,7 +157,7 @@ func (c *Controller) post(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	req, err := httputils.DecodeJSON[markReadRequest](r)
+	req, err := httputils.DecodeJSON[setReadRequest](r)
 	if err != nil {
 		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "invalid request body")
 
@@ -167,7 +168,7 @@ func (c *Controller) post(w http.ResponseWriter, r *http.Request) {
 		UserID:     user.ID,
 		ComicID:    comicID,
 		ChapterIDs: req.ChapterIDs,
-		Read:       true,
+		Read:       *req.Read,
 	})
 	if err != nil {
 		if errors.Is(err, domain.ErrNotFound) {
@@ -188,7 +189,7 @@ func (c *Controller) post(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		c.deps.Logger.Error("failed to mark reading progress", "error", err)
+		c.deps.Logger.Error("failed to set reading progress", "error", err)
 		httputils.WriteError(w, c.deps.Logger, http.StatusInternalServerError, "")
 
 		return
@@ -257,4 +258,52 @@ func (c *Controller) put(w http.ResponseWriter, r *http.Request) {
 	}
 
 	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, progressFromDomain(saved))
+}
+
+func (c *Controller) delete(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user, ok := httpsession.UserFrom(ctx)
+	if !ok {
+		httputils.WriteError(w, c.deps.Logger, http.StatusUnauthorized, "")
+
+		return
+	}
+
+	chapterID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "id must be a valid UUID")
+
+		return
+	}
+
+	err = c.deps.Service.Delete(ctx, readingprogress.DeleteOpts{
+		UserID:    user.ID,
+		ChapterID: chapterID,
+	})
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusNotFound, "")
+
+			return
+		}
+
+		if errors.Is(err, domain.ErrForbidden) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusForbidden, "comic not in library")
+
+			return
+		}
+
+		if errors.Is(err, readingprogress.ErrInvalid) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "invalid request body")
+
+			return
+		}
+
+		c.deps.Logger.Error("failed to delete reading progress", "error", err)
+		httputils.WriteError(w, c.deps.Logger, http.StatusInternalServerError, "")
+
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/api/pkg/core/readingprogress/gateway/http/controller.go
+++ b/api/pkg/core/readingprogress/gateway/http/controller.go
@@ -163,10 +163,11 @@ func (c *Controller) post(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := c.deps.Service.MarkRead(ctx, readingprogress.MarkReadOpts{
+	result, err := c.deps.Service.SetRead(ctx, readingprogress.SetReadOpts{
 		UserID:     user.ID,
 		ComicID:    comicID,
 		ChapterIDs: req.ChapterIDs,
+		Read:       true,
 	})
 	if err != nil {
 		if errors.Is(err, domain.ErrNotFound) {

--- a/api/pkg/core/readingprogress/gateway/http/controller_test.go
+++ b/api/pkg/core/readingprogress/gateway/http/controller_test.go
@@ -24,11 +24,12 @@ import (
 )
 
 const (
-	endpoint         = "/comics"
-	chaptersEndpoint = "/chapters"
-	cookieName       = "uchiyomi_session"
-	testToken        = "letoken"
-	testUsername     = "alice"
+	endpoint             = "/comics"
+	chaptersEndpoint     = "/chapters"
+	cookieName           = "uchiyomi_session"
+	testToken            = "letoken"
+	testUsername         = "alice"
+	errComicNotInLibrary = "comic not in library"
 )
 
 type stubService struct {
@@ -193,6 +194,20 @@ func postProgress(t *testing.T, r chi.Router, comicID, body string, withCookie b
 	t.Helper()
 
 	req := httptest.NewRequest(http.MethodPost, endpoint+"/"+comicID+"/progress", strings.NewReader(body))
+	if withCookie {
+		req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	}
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	return rec
+}
+
+func deleteProgress(t *testing.T, r chi.Router, chapterID string, withCookie bool) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodDelete, chaptersEndpoint+"/"+chapterID+"/progress", nil)
 	if withCookie {
 		req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
 	}
@@ -489,8 +504,8 @@ func TestPutForbidden(t *testing.T) {
 		t.Fatalf("decode error body: %v", err)
 	}
 
-	if got.Message != "comic not in library" {
-		t.Errorf("message = %q, want %q", got.Message, "comic not in library")
+	if got.Message != errComicNotInLibrary {
+		t.Errorf("message = %q, want %q", got.Message, errComicNotInLibrary)
 	}
 }
 
@@ -536,14 +551,14 @@ func TestPostUnauthorized(t *testing.T) {
 	user := testUser()
 	r := newTestRouter(t, &stubService{}, authenticatorFor(t, user))
 
-	rec := postProgress(t, r, uuid.New().String(), `{"chapterIds":["`+uuid.New().String()+`"]}`, false)
+	rec := postProgress(t, r, uuid.New().String(), `{"chapterIds":["`+uuid.New().String()+`"],"read":true}`, false)
 
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusUnauthorized, rec.Body.String())
 	}
 }
 
-func TestPostOK(t *testing.T) {
+func TestPostOK_ReadTrue(t *testing.T) {
 	t.Parallel()
 
 	user := testUser()
@@ -559,7 +574,7 @@ func TestPostOK(t *testing.T) {
 	}
 	r := newTestRouter(t, svc, authenticatorFor(t, user))
 
-	body := `{"chapterIds":["` + ch1.String() + `","` + ch2.String() + `"]}`
+	body := `{"chapterIds":["` + ch1.String() + `","` + ch2.String() + `"],"read":true}`
 	rec := postProgress(t, r, comicID.String(), body, true)
 
 	if rec.Code != http.StatusOK {
@@ -572,6 +587,10 @@ func TestPostOK(t *testing.T) {
 
 	if svc.lastMark.ComicID != comicID {
 		t.Errorf("lastMark.ComicID = %s, want %s", svc.lastMark.ComicID, comicID)
+	}
+
+	if !svc.lastMark.Read {
+		t.Errorf("lastMark.Read = false, want true")
 	}
 
 	if len(svc.lastMark.ChapterIDs) != 2 || svc.lastMark.ChapterIDs[0] != ch1 || svc.lastMark.ChapterIDs[1] != ch2 {
@@ -610,13 +629,79 @@ func TestPostOK(t *testing.T) {
 	}
 }
 
+func TestPostOK_ReadFalse(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	comicID := uuid.New()
+	ch1 := uuid.New()
+	ch2 := uuid.New()
+	continueChapter := uuid.New()
+
+	svc := &stubService{
+		markResult: readingprogress.ListResult{
+			Continue: &readingprogress.Continue{ChapterID: continueChapter, Page: 10},
+		},
+	}
+	r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+	body := `{"chapterIds":["` + ch1.String() + `","` + ch2.String() + `"],"read":false}`
+	rec := postProgress(t, r, comicID.String(), body, true)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	if svc.lastMark.UserID != user.ID {
+		t.Errorf("lastMark.UserID = %s, want %s", svc.lastMark.UserID, user.ID)
+	}
+
+	if svc.lastMark.ComicID != comicID {
+		t.Errorf("lastMark.ComicID = %s, want %s", svc.lastMark.ComicID, comicID)
+	}
+
+	if svc.lastMark.Read {
+		t.Errorf("lastMark.Read = true, want false")
+	}
+
+	if len(svc.lastMark.ChapterIDs) != 2 || svc.lastMark.ChapterIDs[0] != ch1 || svc.lastMark.ChapterIDs[1] != ch2 {
+		t.Errorf("lastMark.ChapterIDs = %v, want [%s, %s]", svc.lastMark.ChapterIDs, ch1, ch2)
+	}
+
+	var got continueJSON
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("body not decodable (%q): %v", rec.Body.String(), err)
+	}
+
+	if got.Continue == nil {
+		t.Fatal("continue is nil, want object")
+	}
+
+	if got.Continue.ChapterID != continueChapter.String() || got.Continue.Page != 10 {
+		t.Errorf("continue = %+v", got.Continue)
+	}
+}
+
+func TestPostMissingReadField(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	r := newTestRouter(t, &stubService{}, authenticatorFor(t, user))
+
+	rec := postProgress(t, r, uuid.New().String(), `{"chapterIds":["`+uuid.New().String()+`"]}`, true)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
 func TestPostInvalidComicID(t *testing.T) {
 	t.Parallel()
 
 	user := testUser()
 	r := newTestRouter(t, &stubService{}, authenticatorFor(t, user))
 
-	rec := postProgress(t, r, "not-a-uuid", `{"chapterIds":["`+uuid.New().String()+`"]}`, true)
+	rec := postProgress(t, r, "not-a-uuid", `{"chapterIds":["`+uuid.New().String()+`"],"read":true}`, true)
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
@@ -642,7 +727,7 @@ func TestPostMissingChapterIds(t *testing.T) {
 	user := testUser()
 	r := newTestRouter(t, &stubService{}, authenticatorFor(t, user))
 
-	rec := postProgress(t, r, uuid.New().String(), `{}`, true)
+	rec := postProgress(t, r, uuid.New().String(), `{"read":true}`, true)
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
@@ -655,7 +740,7 @@ func TestPostEmptyChapterIds(t *testing.T) {
 	user := testUser()
 	r := newTestRouter(t, &stubService{}, authenticatorFor(t, user))
 
-	rec := postProgress(t, r, uuid.New().String(), `{"chapterIds":[]}`, true)
+	rec := postProgress(t, r, uuid.New().String(), `{"chapterIds":[],"read":true}`, true)
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
@@ -669,7 +754,7 @@ func TestPostForbidden(t *testing.T) {
 	svc := &stubService{markErr: domain.ErrForbidden}
 	r := newTestRouter(t, svc, authenticatorFor(t, user))
 
-	rec := postProgress(t, r, uuid.New().String(), `{"chapterIds":["`+uuid.New().String()+`"]}`, true)
+	rec := postProgress(t, r, uuid.New().String(), `{"chapterIds":["`+uuid.New().String()+`"],"read":true}`, true)
 
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusForbidden, rec.Body.String())
@@ -682,8 +767,8 @@ func TestPostForbidden(t *testing.T) {
 		t.Fatalf("decode error body: %v", err)
 	}
 
-	if got.Message != "comic not in library" {
-		t.Errorf("message = %q, want %q", got.Message, "comic not in library")
+	if got.Message != errComicNotInLibrary {
+		t.Errorf("message = %q, want %q", got.Message, errComicNotInLibrary)
 	}
 }
 
@@ -694,7 +779,7 @@ func TestPostNotFound(t *testing.T) {
 	svc := &stubService{markErr: domain.ErrNotFound}
 	r := newTestRouter(t, svc, authenticatorFor(t, user))
 
-	rec := postProgress(t, r, uuid.New().String(), `{"chapterIds":["`+uuid.New().String()+`"]}`, true)
+	rec := postProgress(t, r, uuid.New().String(), `{"chapterIds":["`+uuid.New().String()+`"],"read":true}`, true)
 
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusNotFound, rec.Body.String())
@@ -708,9 +793,132 @@ func TestPostInvalid(t *testing.T) {
 	svc := &stubService{markErr: readingprogress.ErrInvalid}
 	r := newTestRouter(t, svc, authenticatorFor(t, user))
 
-	rec := postProgress(t, r, uuid.New().String(), `{"chapterIds":["`+uuid.New().String()+`"]}`, true)
+	rec := postProgress(t, r, uuid.New().String(), `{"chapterIds":["`+uuid.New().String()+`"],"read":true}`, true)
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestDeleteUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	r := newTestRouter(t, &stubService{}, authenticatorFor(t, user))
+
+	rec := deleteProgress(t, r, uuid.New().String(), false)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusUnauthorized, rec.Body.String())
+	}
+}
+
+func TestDeleteInvalidChapterID(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	r := newTestRouter(t, &stubService{}, authenticatorFor(t, user))
+
+	rec := deleteProgress(t, r, "not-a-uuid", true)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestDeleteNotFound(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	svc := &stubService{deleteErr: domain.ErrNotFound}
+	r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+	rec := deleteProgress(t, r, uuid.New().String(), true)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+}
+
+func TestDeleteForbidden(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	svc := &stubService{deleteErr: domain.ErrForbidden}
+	r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+	rec := deleteProgress(t, r, uuid.New().String(), true)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusForbidden, rec.Body.String())
+	}
+
+	var got struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+
+	if got.Message != errComicNotInLibrary {
+		t.Errorf("message = %q, want %q", got.Message, errComicNotInLibrary)
+	}
+}
+
+func TestDeleteInvalid(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	svc := &stubService{deleteErr: readingprogress.ErrInvalid}
+	r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+	rec := deleteProgress(t, r, uuid.New().String(), true)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestDeleteOK(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	chapterID := uuid.New()
+
+	svc := &stubService{}
+	r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+	rec := deleteProgress(t, r, chapterID.String(), true)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusNoContent, rec.Body.String())
+	}
+
+	if svc.lastDelete.UserID != user.ID {
+		t.Errorf("lastDelete.UserID = %s, want %s", svc.lastDelete.UserID, user.ID)
+	}
+
+	if svc.lastDelete.ChapterID != chapterID {
+		t.Errorf("lastDelete.ChapterID = %s, want %s", svc.lastDelete.ChapterID, chapterID)
+	}
+}
+
+func TestDeleteUsesSessionUser(t *testing.T) {
+	t.Parallel()
+
+	user := testUser()
+	chapterID := uuid.New()
+
+	svc := &stubService{}
+	r := newTestRouter(t, svc, authenticatorFor(t, user))
+
+	rec := deleteProgress(t, r, chapterID.String(), true)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusNoContent, rec.Body.String())
+	}
+
+	if svc.lastDelete.UserID != user.ID {
+		t.Errorf("lastDelete.UserID = %s, want session user %s", svc.lastDelete.UserID, user.ID)
 	}
 }

--- a/api/pkg/core/readingprogress/gateway/http/controller_test.go
+++ b/api/pkg/core/readingprogress/gateway/http/controller_test.go
@@ -35,12 +35,14 @@ type stubService struct {
 	listErr    error
 	saveErr    error
 	markErr    error
+	deleteErr  error
 	listResult readingprogress.ListResult
 	markResult readingprogress.ListResult
 	saveResult readingprogress.Progress
-	lastMark   readingprogress.MarkReadOpts
+	lastMark   readingprogress.SetReadOpts
 	lastSave   readingprogress.SaveOpts
 	lastList   readingprogress.ListOpts
+	lastDelete readingprogress.DeleteOpts
 }
 
 func (s *stubService) List(_ context.Context, opts readingprogress.ListOpts) (readingprogress.ListResult, error) {
@@ -55,12 +57,18 @@ func (s *stubService) Save(_ context.Context, opts readingprogress.SaveOpts) (re
 	return s.saveResult, s.saveErr
 }
 
-func (s *stubService) MarkRead(
-	_ context.Context, opts readingprogress.MarkReadOpts,
+func (s *stubService) SetRead(
+	_ context.Context, opts readingprogress.SetReadOpts,
 ) (readingprogress.ListResult, error) {
 	s.lastMark = opts
 
 	return s.markResult, s.markErr
+}
+
+func (s *stubService) Delete(_ context.Context, opts readingprogress.DeleteOpts) error {
+	s.lastDelete = opts
+
+	return s.deleteErr
 }
 
 func (s *stubService) MapByChapterIDs(

--- a/api/pkg/core/readingprogress/gateway/http/dto.go
+++ b/api/pkg/core/readingprogress/gateway/http/dto.go
@@ -28,7 +28,8 @@ type saveRequest struct {
 	Page *int `json:"page" validate:"required"`
 }
 
-type markReadRequest struct {
+type setReadRequest struct {
+	Read       *bool       `json:"read" validate:"required"`
 	ChapterIDs []uuid.UUID `json:"chapterIds" validate:"required,min=1,dive"`
 }
 

--- a/api/pkg/core/readingprogress/repository/pg/repository.go
+++ b/api/pkg/core/readingprogress/repository/pg/repository.go
@@ -72,6 +72,25 @@ func (r *PGReadingProgressRepository) GetLatestByUserAndComic(
 	return &ret, nil
 }
 
+func (r *PGReadingProgressRepository) ListByUserAndComic(
+	ctx context.Context, opts readingprogress.ListOpts,
+) ([]readingprogress.Progress, error) {
+	models, err := r.db(ctx).
+		Joins(clause.JoinTarget{Association: libraryEntryAssoc}, nil).
+		Where(`"LibraryEntry".user_id = ? AND "LibraryEntry".comic_id = ?`, opts.UserID, opts.ComicID).
+		Find(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("r.db(ctx).Find: %w", err)
+	}
+
+	ret := make([]readingprogress.Progress, 0, len(models))
+	for i := range models {
+		ret = append(ret, models[i].Domain())
+	}
+
+	return ret, nil
+}
+
 func (r *PGReadingProgressRepository) ListByUserAndChapterIDs(
 	ctx context.Context, opts readingprogress.MapOpts,
 ) ([]readingprogress.Progress, error) {

--- a/api/pkg/core/readingprogress/repository/pg/repository.go
+++ b/api/pkg/core/readingprogress/repository/pg/repository.go
@@ -150,3 +150,25 @@ func (r *PGReadingProgressRepository) Upsert(
 
 	return model.Domain(), nil
 }
+
+func (r *PGReadingProgressRepository) DeleteByUserAndChapterIDs(
+	ctx context.Context, opts readingprogress.DeleteProgressOpts,
+) error {
+	if len(opts.ChapterIDs) == 0 {
+		return nil
+	}
+
+	subQuery := r.deps.DB.WithContext(ctx).
+		Table("library_entries").
+		Select("id").
+		Where("user_id = ?", opts.UserID)
+
+	err := pgtx.From(ctx, r.deps.DB).WithContext(ctx).
+		Where("chapter_id IN ? AND library_entry_id IN (?)", opts.ChapterIDs, subQuery).
+		Delete(&pgmodels.ReadingProgress{}).Error
+	if err != nil {
+		return fmt.Errorf("pgtx.From(ctx, r.deps.DB).Delete: %w", err)
+	}
+
+	return nil
+}

--- a/api/pkg/core/readingprogress/repository/pg/repository_test.go
+++ b/api/pkg/core/readingprogress/repository/pg/repository_test.go
@@ -121,6 +121,47 @@ func TestGetLatestOrdersByUpdatedAtDesc(t *testing.T) {
 	}
 }
 
+func TestListByUserAndComicJoinsLibraryEntry(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newReadingProgressRepo(t)
+
+	userID := uuid.New()
+	comicID := uuid.New()
+	chapter1 := uuid.New()
+	chapter2 := uuid.New()
+	updatedAt := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	query := `JOIN "library_entries" "LibraryEntry".*WHERE "LibraryEntry"\.(user_id|"user_id") = \$1` +
+		` AND "LibraryEntry"\.(comic_id|"comic_id") = \$2`
+	mock.ExpectQuery(query).
+		WithArgs(userID, comicID).
+		WillReturnRows(
+			sqlmock.NewRows(readingProgressSelectColumns()).
+				AddRow(uuid.New(), uuid.New(), chapter1, 5, updatedAt).
+				AddRow(uuid.New(), uuid.New(), chapter2, 10, updatedAt),
+		)
+
+	got, err := r.ListByUserAndComic(context.Background(), readingprogress.ListOpts{
+		UserID:  userID,
+		ComicID: comicID,
+	})
+	if err != nil {
+		t.Fatalf("ListByUserAndComic: %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2", len(got))
+	}
+
+	if got[0].ChapterID != chapter1 || got[0].Page != 5 {
+		t.Errorf("got[0] = %+v", got[0])
+	}
+	if got[1].ChapterID != chapter2 || got[1].Page != 10 {
+		t.Errorf("got[1] = %+v", got[1])
+	}
+}
+
 func TestListByUserAndChapterIDsEmptySkipsQuery(t *testing.T) {
 	t.Parallel()
 

--- a/api/pkg/core/readingprogress/repository/pg/repository_test.go
+++ b/api/pkg/core/readingprogress/repository/pg/repository_test.go
@@ -298,3 +298,43 @@ func TestUpsertConflictUpdates(t *testing.T) {
 		t.Errorf("Upsert() = %+v, want %+v", got, want)
 	}
 }
+
+func TestDeleteByUserAndChapterIDs(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newReadingProgressRepo(t)
+	userID := uuid.New()
+	ch1 := uuid.New()
+	ch2 := uuid.New()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(
+		`DELETE FROM "reading_progress" WHERE chapter_id IN \(\$1,\$2\) AND `+
+			`library_entry_id IN \(SELECT (id|"id") FROM "library_entries" WHERE user_id = \$3\)`,
+	).
+		WithArgs(ch1, ch2, userID).
+		WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectCommit()
+
+	err := r.DeleteByUserAndChapterIDs(context.Background(), readingprogress.DeleteProgressOpts{
+		UserID:     userID,
+		ChapterIDs: []uuid.UUID{ch1, ch2},
+	})
+	if err != nil {
+		t.Fatalf("DeleteByUserAndChapterIDs: %v", err)
+	}
+}
+
+func TestDeleteByUserAndChapterIDsEmpty(t *testing.T) {
+	t.Parallel()
+
+	r, _ := newReadingProgressRepo(t)
+
+	err := r.DeleteByUserAndChapterIDs(context.Background(), readingprogress.DeleteProgressOpts{
+		UserID:     uuid.New(),
+		ChapterIDs: []uuid.UUID{},
+	})
+	if err != nil {
+		t.Fatalf("DeleteByUserAndChapterIDs with empty IDs should return nil, got: %v", err)
+	}
+}

--- a/api/pkg/core/readingprogress/service.go
+++ b/api/pkg/core/readingprogress/service.go
@@ -164,7 +164,7 @@ func (s *Service) Save(ctx context.Context, opts SaveOpts) (Progress, error) {
 	return saved, nil
 }
 
-func (s *Service) MarkRead(ctx context.Context, opts MarkReadOpts) (ListResult, error) {
+func (s *Service) SetRead(ctx context.Context, opts SetReadOpts) (ListResult, error) {
 	ids := uniqueIDs(opts.ChapterIDs)
 	if len(ids) == 0 {
 		return ListResult{}, fmt.Errorf("%w: chapterIds is required", ErrInvalid)
@@ -198,24 +198,64 @@ func (s *Service) MarkRead(ctx context.Context, opts MarkReadOpts) (ListResult, 
 		return ListResult{}, fmt.Errorf("%w: no eligible chapters", ErrInvalid)
 	}
 
-	err = s.deps.Transactor.WithinTx(ctx, transaction.TxOpts{}, func(ctx context.Context) error {
-		return s.markReadTx(ctx, opts, eligible)
-	})
-	if err != nil {
-		return ListResult{}, fmt.Errorf("s.deps.Transactor.WithinTx: %w", err)
+	eligibleIDs := make([]uuid.UUID, len(eligible))
+	for i, ch := range eligible {
+		eligibleIDs[i] = ch.ID
+	}
+
+	if opts.Read {
+		err = s.deps.Transactor.WithinTx(ctx, transaction.TxOpts{}, func(ctx context.Context) error {
+			return s.markReadTx(ctx, opts.UserID, opts.ComicID, eligible)
+		})
+		if err != nil {
+			return ListResult{}, fmt.Errorf("s.deps.Transactor.WithinTx: %w", err)
+		}
+	} else {
+		err = s.deps.Repository.DeleteByUserAndChapterIDs(ctx, DeleteProgressOpts{
+			UserID:     opts.UserID,
+			ChapterIDs: eligibleIDs,
+		})
+		if err != nil {
+			return ListResult{}, fmt.Errorf("s.deps.Repository.DeleteByUserAndChapterIDs: %w", err)
+		}
 	}
 
 	return s.List(ctx, ListOpts{UserID: opts.UserID, ComicID: opts.ComicID})
 }
 
+func (s *Service) Delete(ctx context.Context, opts DeleteOpts) error {
+	chapter, err := s.deps.Chapters.GetByID(ctx, opts.ChapterID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return domain.ErrNotFound
+		}
+
+		return fmt.Errorf("s.deps.Chapters.GetByID: %w", err)
+	}
+
+	if err = s.requireLibrary(ctx, opts.UserID, chapter.ComicID); err != nil {
+		return err
+	}
+
+	err = s.deps.Repository.DeleteByUserAndChapterIDs(ctx, DeleteProgressOpts{
+		UserID:     opts.UserID,
+		ChapterIDs: []uuid.UUID{opts.ChapterID},
+	})
+	if err != nil {
+		return fmt.Errorf("s.deps.Repository.DeleteByUserAndChapterIDs: %w", err)
+	}
+
+	return nil
+}
+
 func (s *Service) markReadTx(
 	ctx context.Context,
-	opts MarkReadOpts,
+	userID, comicID uuid.UUID,
 	eligible []chapters.Chapter,
 ) error {
 	latest, err := s.deps.Repository.GetLatestByUserAndComic(ctx, ListOpts{
-		UserID:  opts.UserID,
-		ComicID: opts.ComicID,
+		UserID:  userID,
+		ComicID: comicID,
 	})
 	if err != nil {
 		return fmt.Errorf("s.deps.Repository.GetLatestByUserAndComic: %w", err)
@@ -239,7 +279,7 @@ func (s *Service) markReadTx(
 
 	existingProgress, err := s.deps.Repository.ListByUserAndChapterIDs(ctx, MapOpts{
 		IDs:    eligibleIDs,
-		UserID: opts.UserID,
+		UserID: userID,
 	})
 	if err != nil {
 		return fmt.Errorf("s.deps.Repository.ListByUserAndChapterIDs: %w", err)
@@ -256,8 +296,8 @@ func (s *Service) markReadTx(
 		if !ok || storedPage != ch.PagesNb {
 			_, err := s.deps.Repository.Upsert(ctx, UpsertOpts{
 				UpdatedAt: writtenAt,
-				UserID:    opts.UserID,
-				ComicID:   opts.ComicID,
+				UserID:    userID,
+				ComicID:   comicID,
 				ChapterID: ch.ID,
 				Page:      ch.PagesNb,
 			})
@@ -276,8 +316,8 @@ func (s *Service) markReadTx(
 
 	_, err = s.deps.Repository.Upsert(ctx, UpsertOpts{
 		UpdatedAt: retouchAt,
-		UserID:    opts.UserID,
-		ComicID:   opts.ComicID,
+		UserID:    userID,
+		ComicID:   comicID,
 		ChapterID: winnerID,
 		Page:      winnerPage,
 	})

--- a/api/pkg/core/readingprogress/service.go
+++ b/api/pkg/core/readingprogress/service.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/google/uuid"
@@ -66,30 +67,71 @@ func (s *Service) List(ctx context.Context, opts ListOpts) (ListResult, error) {
 		return ListResult{}, err
 	}
 
-	row, err := s.deps.Repository.GetLatestByUserAndComic(ctx, opts)
+	chList, err := s.deps.Chapters.ListByComicID(ctx, opts.ComicID)
 	if err != nil {
-		return ListResult{}, fmt.Errorf("s.deps.Repository.GetLatestByUserAndComic: %w", err)
+		return ListResult{}, fmt.Errorf("s.deps.Chapters.ListByComicID: %w", err)
 	}
 
-	if row == nil {
+	if len(chList) == 0 {
 		return ListResult{}, nil
 	}
 
-	chapter, err := s.deps.Chapters.GetByID(ctx, row.ChapterID)
+	progresses, err := s.deps.Repository.ListByUserAndComic(ctx, opts)
 	if err != nil {
-		if errors.Is(err, domain.ErrNotFound) {
-			return ListResult{
-				Continue: &Continue{ChapterID: row.ChapterID, Page: row.Page},
-			}, nil
+		return ListResult{}, fmt.Errorf("s.deps.Repository.ListByUserAndComic: %w", err)
+	}
+
+	if len(progresses) == 0 {
+		return ListResult{}, nil
+	}
+
+	sort.SliceStable(chList, func(i, j int) bool {
+		if chList[i].Number != chList[j].Number {
+			return chList[i].Number < chList[j].Number
 		}
 
-		return ListResult{}, fmt.Errorf("s.deps.Chapters.GetByID: %w", err)
+		return bytes.Compare(chList[i].ID[:], chList[j].ID[:]) < 0
+	})
+
+	progMap := make(map[uuid.UUID]int, len(progresses))
+	for _, p := range progresses {
+		progMap[p.ChapterID] = p.Page
+	}
+
+	highestIdx := -1
+	for i := range chList {
+		page, ok := progMap[chList[i].ID]
+		if !ok {
+			continue
+		}
+
+		clamped := ClampPage(page, chList[i].PagesNb)
+		if clamped > 1 || (chList[i].PagesNb > 0 && clamped >= chList[i].PagesNb) {
+			highestIdx = i
+		}
+	}
+
+	if highestIdx == -1 {
+		return ListResult{}, nil
+	}
+
+	target := chList[highestIdx]
+	targetPage := ClampPage(progMap[target.ID], target.PagesNb)
+	if target.PagesNb > 0 && targetPage >= target.PagesNb && highestIdx+1 < len(chList) {
+		next := chList[highestIdx+1]
+
+		return ListResult{
+			Continue: &Continue{
+				ChapterID: next.ID,
+				Page:      1,
+			},
+		}, nil
 	}
 
 	return ListResult{
 		Continue: &Continue{
-			ChapterID: row.ChapterID,
-			Page:      ClampPage(row.Page, chapter.PagesNb),
+			ChapterID: target.ID,
+			Page:      targetPage,
 		},
 	}, nil
 }
@@ -253,25 +295,6 @@ func (s *Service) markReadTx(
 	userID, comicID uuid.UUID,
 	eligible []chapters.Chapter,
 ) error {
-	latest, err := s.deps.Repository.GetLatestByUserAndComic(ctx, ListOpts{
-		UserID:  userID,
-		ComicID: comicID,
-	})
-	if err != nil {
-		return fmt.Errorf("s.deps.Repository.GetLatestByUserAndComic: %w", err)
-	}
-
-	var (
-		cChapter *chapters.Chapter
-		cMissing bool
-	)
-	if latest != nil {
-		cChapter, cMissing, err = s.resolveContinueChapter(ctx, latest.ChapterID)
-		if err != nil {
-			return err
-		}
-	}
-
 	eligibleIDs := make([]uuid.UUID, len(eligible))
 	for i, ch := range eligible {
 		eligibleIDs[i] = ch.ID
@@ -307,80 +330,7 @@ func (s *Service) markReadTx(
 		}
 	}
 
-	winnerID, winnerPage := continueWinner(eligible, latest, cChapter, cMissing)
-
-	retouchAt := time.Now().UTC()
-	if !retouchAt.After(writtenAt) {
-		retouchAt = writtenAt.Add(time.Nanosecond)
-	}
-
-	_, err = s.deps.Repository.Upsert(ctx, UpsertOpts{
-		UpdatedAt: retouchAt,
-		UserID:    userID,
-		ComicID:   comicID,
-		ChapterID: winnerID,
-		Page:      winnerPage,
-	})
-	if err != nil {
-		return fmt.Errorf("s.deps.Repository.Upsert: %w", err)
-	}
-
 	return nil
-}
-
-func (s *Service) resolveContinueChapter(
-	ctx context.Context,
-	chapterID uuid.UUID,
-) (*chapters.Chapter, bool, error) {
-	ch, err := s.deps.Chapters.GetByID(ctx, chapterID)
-	if err == nil {
-		return ch, false, nil
-	}
-
-	if errors.Is(err, domain.ErrNotFound) {
-		return nil, true, nil
-	}
-
-	return nil, false, fmt.Errorf("s.deps.Chapters.GetByID: %w", err)
-}
-
-func continueWinner(
-	eligible []chapters.Chapter,
-	latest *Progress,
-	cChapter *chapters.Chapter,
-	cMissing bool,
-) (uuid.UUID, int) {
-	h := highestEligible(eligible)
-	if latest == nil || cMissing || cChapter == nil {
-		return h.ID, h.PagesNb
-	}
-
-	if h.Number > cChapter.Number {
-		return h.ID, h.PagesNb
-	}
-
-	for _, ch := range eligible {
-		if ch.ID == latest.ChapterID {
-			return latest.ChapterID, ch.PagesNb
-		}
-	}
-
-	return latest.ChapterID, latest.Page
-}
-
-func highestEligible(eligible []chapters.Chapter) chapters.Chapter {
-	best := eligible[0]
-	for _, ch := range eligible[1:] {
-		if ch.Number > best.Number {
-			best = ch
-		} else if ch.Number == best.Number {
-			if bytes.Compare(ch.ID[:], best.ID[:]) < 0 {
-				best = ch
-			}
-		}
-	}
-
-	return best
 }
 
 func uniqueIDs(ids []uuid.UUID) []uuid.UUID {

--- a/api/pkg/core/readingprogress/service_test.go
+++ b/api/pkg/core/readingprogress/service_test.go
@@ -73,6 +73,23 @@ func (f *fakeRepo) GetLatestByUserAndComic(
 	return &row, nil
 }
 
+func (f *fakeRepo) ListByUserAndComic(
+	_ context.Context,
+	opts readingprogress.ListOpts,
+) ([]readingprogress.Progress, error) {
+	f.listCalls++
+	f.listed = opts
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+
+	if f.stored != nil {
+		return f.stored, nil
+	}
+
+	return f.rows, nil
+}
+
 func (f *fakeRepo) ListByUserAndChapterIDs(
 	_ context.Context,
 	_ readingprogress.MapOpts,
@@ -109,8 +126,19 @@ func (f *fakeRepo) Upsert(_ context.Context, opts readingprogress.UpsertOpts) (r
 		UpdatedAt: opts.UpdatedAt,
 	}
 	f.latest = &out
-	row := out
-	f.rows = []readingprogress.Progress{row}
+
+	updated := false
+	for i := range f.rows {
+		if f.rows[i].ChapterID == opts.ChapterID {
+			f.rows[i] = out
+			updated = true
+
+			break
+		}
+	}
+	if !updated {
+		f.rows = append(f.rows, out)
+	}
 
 	return out, f.upsertErr
 }
@@ -121,6 +149,18 @@ func (f *fakeRepo) DeleteByUserAndChapterIDs(
 ) error {
 	f.deleteCalls++
 	f.lastDelete = opts
+
+	delMap := make(map[uuid.UUID]bool, len(opts.ChapterIDs))
+	for _, id := range opts.ChapterIDs {
+		delMap[id] = true
+	}
+	remaining := make([]readingprogress.Progress, 0, len(f.rows))
+	for _, r := range f.rows {
+		if !delMap[r.ChapterID] {
+			remaining = append(remaining, r)
+		}
+	}
+	f.rows = remaining
 
 	return f.deleteErr
 }
@@ -156,13 +196,46 @@ func (f *fakeComics) Exists(_ context.Context, id uuid.UUID) (bool, error) {
 }
 
 type fakeChapters struct {
-	byID        map[uuid.UUID]chapters.Chapter
-	chapter     *chapters.Chapter
-	getErr      error
-	getByIdsErr error
-	lastIDs     []uuid.UUID
-	lastID      uuid.UUID
-	getCalls    int
+	byID           map[uuid.UUID]chapters.Chapter
+	chapter        *chapters.Chapter
+	list           []chapters.Chapter
+	getErr         error
+	getByIdsErr    error
+	listByComicErr error
+	lastIDs        []uuid.UUID
+	lastID         uuid.UUID
+	lastComicID    uuid.UUID
+	getCalls       int
+	listCalls      int
+}
+
+func (f *fakeChapters) ListByComicID(_ context.Context, comicID uuid.UUID) ([]chapters.Chapter, error) {
+	f.listCalls++
+	f.lastComicID = comicID
+	if f.listByComicErr != nil {
+		return nil, f.listByComicErr
+	}
+
+	if f.list != nil {
+		return f.list, nil
+	}
+
+	if f.byID != nil {
+		out := make([]chapters.Chapter, 0, len(f.byID))
+		for _, c := range f.byID {
+			if c.ComicID == comicID {
+				out = append(out, c)
+			}
+		}
+
+		return out, nil
+	}
+
+	if f.chapter != nil {
+		return []chapters.Chapter{*f.chapter}, nil
+	}
+
+	return nil, nil
 }
 
 func (f *fakeChapters) GetByID(_ context.Context, id uuid.UUID) (*chapters.Chapter, error) {
@@ -505,8 +578,13 @@ func TestListEmptyContinueNull(t *testing.T) {
 
 	userID := uuid.New()
 	comicID := uuid.New()
+	ch1 := uuid.New()
 	repo := &fakeRepo{rows: nil}
-	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{}, &fakeChapters{})
+	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{}, &fakeChapters{
+		list: []chapters.Chapter{
+			{ID: ch1, ComicID: comicID, Number: 1, PagesNb: 20},
+		},
+	})
 
 	got, err := svc.List(context.Background(), readingprogress.ListOpts{UserID: userID, ComicID: comicID})
 	if err != nil {
@@ -522,26 +600,255 @@ func TestListEmptyContinueNull(t *testing.T) {
 	}
 }
 
-func TestListClampsWithoutWrite(t *testing.T) {
+func TestListIgnoredPageOneNotLast(t *testing.T) {
 	t.Parallel()
 
-	chID := uuid.New()
-	repo := &fakeRepo{rows: []readingprogress.Progress{{
-		ChapterID: chID,
-		Page:      18,
-		UpdatedAt: time.Unix(2, 0).UTC(),
-	}}}
+	comicID := uuid.New()
+	ch1 := uuid.New()
+	repo := &fakeRepo{rows: []readingprogress.Progress{
+		{ChapterID: ch1, Page: 1},
+	}}
 	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{}, &fakeChapters{
-		chapter: &chapters.Chapter{ID: chID, PagesNb: 12, Download: 50},
+		list: []chapters.Chapter{
+			{ID: ch1, ComicID: comicID, Number: 1, PagesNb: 20},
+		},
 	})
 
-	got, err := svc.List(context.Background(), readingprogress.ListOpts{UserID: uuid.New(), ComicID: uuid.New()})
+	got, err := svc.List(context.Background(), readingprogress.ListOpts{UserID: uuid.New(), ComicID: comicID})
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
 
-	if got.Continue == nil || got.Continue.Page != 12 || got.Continue.ChapterID != chID {
-		t.Errorf("continue = %+v", got.Continue)
+	if got.Continue != nil {
+		t.Errorf("continue = %+v, want nil", got.Continue)
+	}
+}
+
+//nolint:dupl
+func TestListSinglePageChapterCompleteAdvances(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	ch1 := uuid.New()
+	ch2 := uuid.New()
+	repo := &fakeRepo{rows: []readingprogress.Progress{
+		{ChapterID: ch1, Page: 1},
+	}}
+	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{}, &fakeChapters{
+		list: []chapters.Chapter{
+			{ID: ch1, ComicID: comicID, Number: 1, PagesNb: 1},
+			{ID: ch2, ComicID: comicID, Number: 2, PagesNb: 20},
+		},
+	})
+
+	got, err := svc.List(context.Background(), readingprogress.ListOpts{UserID: uuid.New(), ComicID: comicID})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if got.Continue == nil || got.Continue.ChapterID != ch2 || got.Continue.Page != 1 {
+		t.Errorf("continue = %+v, want chapter %s page 1", got.Continue, ch2)
+	}
+}
+
+//nolint:dupl
+func TestListPartiallyReadChapter(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	ch1 := uuid.New()
+	ch2 := uuid.New()
+	repo := &fakeRepo{rows: []readingprogress.Progress{
+		{ChapterID: ch1, Page: 10},
+	}}
+	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{}, &fakeChapters{
+		list: []chapters.Chapter{
+			{ID: ch1, ComicID: comicID, Number: 1, PagesNb: 20},
+			{ID: ch2, ComicID: comicID, Number: 2, PagesNb: 20},
+		},
+	})
+
+	got, err := svc.List(context.Background(), readingprogress.ListOpts{UserID: uuid.New(), ComicID: comicID})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if got.Continue == nil || got.Continue.ChapterID != ch1 || got.Continue.Page != 10 {
+		t.Errorf("continue = %+v, want chapter %s page 10", got.Continue, ch1)
+	}
+}
+
+//nolint:dupl
+func TestListCompletedChapterAdvancesToNext(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	ch1 := uuid.New()
+	ch2 := uuid.New()
+	repo := &fakeRepo{rows: []readingprogress.Progress{
+		{ChapterID: ch1, Page: 20},
+	}}
+	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{}, &fakeChapters{
+		list: []chapters.Chapter{
+			{ID: ch1, ComicID: comicID, Number: 1, PagesNb: 20},
+			{ID: ch2, ComicID: comicID, Number: 2, PagesNb: 20},
+		},
+	})
+
+	got, err := svc.List(context.Background(), readingprogress.ListOpts{UserID: uuid.New(), ComicID: comicID})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if got.Continue == nil || got.Continue.ChapterID != ch2 || got.Continue.Page != 1 {
+		t.Errorf("continue = %+v, want chapter %s page 1", got.Continue, ch2)
+	}
+}
+
+//nolint:dupl
+func TestListHighestChapterWithProgressSelected(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	ch1 := uuid.New()
+	ch2 := uuid.New()
+	ch3 := uuid.New()
+	repo := &fakeRepo{rows: []readingprogress.Progress{
+		{ChapterID: ch1, Page: 20},
+		{ChapterID: ch2, Page: 5},
+	}}
+	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{}, &fakeChapters{
+		list: []chapters.Chapter{
+			{ID: ch1, ComicID: comicID, Number: 1, PagesNb: 20},
+			{ID: ch2, ComicID: comicID, Number: 2, PagesNb: 20},
+			{ID: ch3, ComicID: comicID, Number: 3, PagesNb: 20},
+		},
+	})
+
+	got, err := svc.List(context.Background(), readingprogress.ListOpts{UserID: uuid.New(), ComicID: comicID})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if got.Continue == nil || got.Continue.ChapterID != ch2 || got.Continue.Page != 5 {
+		t.Errorf("continue = %+v, want chapter %s page 5", got.Continue, ch2)
+	}
+}
+
+//nolint:dupl
+func TestListHighestChapterCompletedAdvances(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	ch1 := uuid.New()
+	ch2 := uuid.New()
+	ch3 := uuid.New()
+	repo := &fakeRepo{rows: []readingprogress.Progress{
+		{ChapterID: ch1, Page: 20},
+		{ChapterID: ch2, Page: 20},
+	}}
+	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{}, &fakeChapters{
+		list: []chapters.Chapter{
+			{ID: ch1, ComicID: comicID, Number: 1, PagesNb: 20},
+			{ID: ch2, ComicID: comicID, Number: 2, PagesNb: 20},
+			{ID: ch3, ComicID: comicID, Number: 3, PagesNb: 20},
+		},
+	})
+
+	got, err := svc.List(context.Background(), readingprogress.ListOpts{UserID: uuid.New(), ComicID: comicID})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if got.Continue == nil || got.Continue.ChapterID != ch3 || got.Continue.Page != 1 {
+		t.Errorf("continue = %+v, want chapter %s page 1", got.Continue, ch3)
+	}
+}
+
+//nolint:dupl
+func TestListLastChapterCompletedReturnsLastChapter(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	ch1 := uuid.New()
+	ch2 := uuid.New()
+	repo := &fakeRepo{rows: []readingprogress.Progress{
+		{ChapterID: ch1, Page: 20},
+		{ChapterID: ch2, Page: 20},
+	}}
+	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{}, &fakeChapters{
+		list: []chapters.Chapter{
+			{ID: ch1, ComicID: comicID, Number: 1, PagesNb: 20},
+			{ID: ch2, ComicID: comicID, Number: 2, PagesNb: 20},
+		},
+	})
+
+	got, err := svc.List(context.Background(), readingprogress.ListOpts{UserID: uuid.New(), ComicID: comicID})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if got.Continue == nil || got.Continue.ChapterID != ch2 || got.Continue.Page != 20 {
+		t.Errorf("continue = %+v, want chapter %s page 20", got.Continue, ch2)
+	}
+}
+
+//nolint:dupl
+func TestListAccidentalPageOneOnLaterChapterIgnored(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	ch1 := uuid.New()
+	ch2 := uuid.New()
+	ch3 := uuid.New()
+	repo := &fakeRepo{rows: []readingprogress.Progress{
+		{ChapterID: ch1, Page: 20},
+		{ChapterID: ch3, Page: 1},
+	}}
+	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{}, &fakeChapters{
+		list: []chapters.Chapter{
+			{ID: ch1, ComicID: comicID, Number: 1, PagesNb: 20},
+			{ID: ch2, ComicID: comicID, Number: 2, PagesNb: 20},
+			{ID: ch3, ComicID: comicID, Number: 3, PagesNb: 20},
+		},
+	})
+
+	got, err := svc.List(context.Background(), readingprogress.ListOpts{UserID: uuid.New(), ComicID: comicID})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if got.Continue == nil || got.Continue.ChapterID != ch2 || got.Continue.Page != 1 {
+		t.Errorf("continue = %+v, want chapter %s page 1", got.Continue, ch2)
+	}
+}
+
+//nolint:dupl
+func TestListClampsPageToPagesNb(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	ch1 := uuid.New()
+	ch2 := uuid.New()
+	repo := &fakeRepo{rows: []readingprogress.Progress{{
+		ChapterID: ch1,
+		Page:      25,
+		UpdatedAt: time.Unix(2, 0).UTC(),
+	}}}
+	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{}, &fakeChapters{
+		list: []chapters.Chapter{
+			{ID: ch1, ComicID: comicID, Number: 1, PagesNb: 20},
+			{ID: ch2, ComicID: comicID, Number: 2, PagesNb: 20},
+		},
+	})
+
+	got, err := svc.List(context.Background(), readingprogress.ListOpts{UserID: uuid.New(), ComicID: comicID})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if got.Continue == nil || got.Continue.ChapterID != ch2 || got.Continue.Page != 1 {
+		t.Errorf("continue = %+v, want chapter %s page 1", got.Continue, ch2)
 	}
 
 	if repo.upsertCalls != 0 {
@@ -838,20 +1145,7 @@ func TestSetReadFirstProgressContinueIsHighestNumber(t *testing.T) {
 		}
 	}
 
-	lastUpsert := repo.upserts[len(repo.upserts)-1]
 	wantWinnerID := ids[9]
-	if lastUpsert.ChapterID != wantWinnerID || lastUpsert.Page != 20 {
-		t.Errorf("last upsert = %+v, want chapter %v at page 20", lastUpsert, wantWinnerID)
-	}
-
-	if len(repo.upserts) > 1 && !lastUpsert.UpdatedAt.After(repo.upserts[0].UpdatedAt) {
-		t.Errorf(
-			"last upsert UpdatedAt %v not after first upsert UpdatedAt %v",
-			lastUpsert.UpdatedAt,
-			repo.upserts[0].UpdatedAt,
-		)
-	}
-
 	if got.Continue == nil || got.Continue.ChapterID != wantWinnerID || got.Continue.Page != 20 {
 		t.Errorf("got.Continue = %+v, want chapter %v at page 20", got.Continue, wantWinnerID)
 	}
@@ -876,10 +1170,12 @@ func TestSetReadKeepsEarlierContinuePage(t *testing.T) {
 	}
 
 	repo := &fakeRepo{
-		latest: &readingprogress.Progress{
-			ChapterID: ch50ID,
-			Page:      3,
-			UpdatedAt: time.Unix(10, 0).UTC(),
+		rows: []readingprogress.Progress{
+			{
+				ChapterID: ch50ID,
+				Page:      3,
+				UpdatedAt: time.Unix(10, 0).UTC(),
+			},
 		},
 	}
 	tx := &fakeTransactor{}
@@ -895,25 +1191,17 @@ func TestSetReadKeepsEarlierContinuePage(t *testing.T) {
 		t.Fatalf("SetRead: %v", err)
 	}
 
-	if len(repo.upserts) < 2 {
-		t.Fatalf("len(repo.upserts) = %d, want at least 2", len(repo.upserts))
+	if len(repo.upserts) != 40 {
+		t.Fatalf("len(repo.upserts) = %d, want 40", len(repo.upserts))
 	}
 
-	for i, up := range repo.upserts[:len(repo.upserts)-1] {
+	for i, up := range repo.upserts {
 		if up.ChapterID == ch50ID {
-			t.Errorf("upsert[%d] has ch50, want only in last upsert", i)
+			t.Errorf("upsert[%d] has ch50, want ch50 untouched", i)
 		}
 		if up.Page != 10 {
 			t.Errorf("upsert[%d] Page = %d, want 10", i, up.Page)
 		}
-	}
-
-	lastUpsert := repo.upserts[len(repo.upserts)-1]
-	if lastUpsert.ChapterID != ch50ID || lastUpsert.Page != 3 {
-		t.Errorf("last upsert = %+v, want ch50 at page 3", lastUpsert)
-	}
-	if !lastUpsert.UpdatedAt.After(repo.upserts[0].UpdatedAt) {
-		t.Errorf("last upsert UpdatedAt not after first upsert UpdatedAt")
 	}
 
 	if got.Continue == nil || got.Continue.ChapterID != ch50ID || got.Continue.Page != 3 {
@@ -940,10 +1228,12 @@ func TestSetReadKeepsCompletedLaterContinue(t *testing.T) {
 	}
 
 	repo := &fakeRepo{
-		latest: &readingprogress.Progress{
-			ChapterID: ch100ID,
-			Page:      50,
-			UpdatedAt: time.Unix(10, 0).UTC(),
+		rows: []readingprogress.Progress{
+			{
+				ChapterID: ch100ID,
+				Page:      50,
+				UpdatedAt: time.Unix(10, 0).UTC(),
+			},
 		},
 	}
 	tx := &fakeTransactor{}
@@ -959,16 +1249,12 @@ func TestSetReadKeepsCompletedLaterContinue(t *testing.T) {
 		t.Fatalf("SetRead: %v", err)
 	}
 
-	for i, up := range repo.upserts[:len(repo.upserts)-1] {
+	for i, up := range repo.upserts {
 		if up.ChapterID == ch100ID {
-			t.Errorf("non-final upsert[%d] rewrote ch100", i)
+			t.Errorf("upsert[%d] rewrote ch100, want untouched", i)
 		}
 	}
 
-	lastUpsert := repo.upserts[len(repo.upserts)-1]
-	if lastUpsert.ChapterID != ch100ID || lastUpsert.Page != 50 {
-		t.Errorf("last upsert = %+v, want ch100 at page 50", lastUpsert)
-	}
 	if got.Continue == nil || got.Continue.ChapterID != ch100ID || got.Continue.Page != 50 {
 		t.Errorf("got.Continue = %+v, want ch100 at page 50", got.Continue)
 	}
@@ -1011,7 +1297,7 @@ func TestSetReadMovesContinueForward(t *testing.T) {
 	}
 
 	foundCh5Upsert := false
-	for _, up := range repo.upserts[:len(repo.upserts)-1] {
+	for _, up := range repo.upserts {
 		if up.ChapterID == ch5ID && up.Page == 15 {
 			foundCh5Upsert = true
 		}
@@ -1020,10 +1306,6 @@ func TestSetReadMovesContinueForward(t *testing.T) {
 		t.Errorf("ch5 was not upserted to page 15 in loop")
 	}
 
-	lastUpsert := repo.upserts[len(repo.upserts)-1]
-	if lastUpsert.ChapterID != ch50ID || lastUpsert.Page != 15 {
-		t.Errorf("last upsert = %+v, want ch50 at page 15", lastUpsert)
-	}
 	if got.Continue == nil || got.Continue.ChapterID != ch50ID || got.Continue.Page != 15 {
 		t.Errorf("got.Continue = %+v, want ch50 at page 15", got.Continue)
 	}
@@ -1064,10 +1346,6 @@ func TestSetReadSkipsZeroPagesNbAmongEligible(t *testing.T) {
 		}
 	}
 
-	lastUpsert := repo.upserts[len(repo.upserts)-1]
-	if lastUpsert.ChapterID != ch3ID || lastUpsert.Page != 10 {
-		t.Errorf("last upsert = %+v, want ch3 at page 10", lastUpsert)
-	}
 	if got.Continue == nil || got.Continue.ChapterID != ch3ID || got.Continue.Page != 10 {
 		t.Errorf("got.Continue = %+v, want ch3 at page 10", got.Continue)
 	}
@@ -1104,8 +1382,8 @@ func TestSetReadDuplicateIDsOneWritePerChapter(t *testing.T) {
 			ch1Upserts++
 		}
 	}
-	if ch1Upserts > 2 {
-		t.Errorf("ch1 upserts = %d, want <= 2", ch1Upserts)
+	if ch1Upserts != 1 {
+		t.Errorf("ch1 upserts = %d, want 1", ch1Upserts)
 	}
 }
 
@@ -1124,10 +1402,12 @@ func TestSetReadMissingContinueChapterTreatsAsNone(t *testing.T) {
 	}
 
 	repo := &fakeRepo{
-		latest: &readingprogress.Progress{
-			ChapterID: missingID,
-			Page:      5,
-			UpdatedAt: time.Unix(10, 0).UTC(),
+		rows: []readingprogress.Progress{
+			{
+				ChapterID: missingID,
+				Page:      5,
+				UpdatedAt: time.Unix(10, 0).UTC(),
+			},
 		},
 	}
 	tx := &fakeTransactor{}
@@ -1149,10 +1429,6 @@ func TestSetReadMissingContinueChapterTreatsAsNone(t *testing.T) {
 		}
 	}
 
-	lastUpsert := repo.upserts[len(repo.upserts)-1]
-	if lastUpsert.ChapterID != ch7ID || lastUpsert.Page != 12 {
-		t.Errorf("last upsert = %+v, want ch7 at page 12", lastUpsert)
-	}
 	if got.Continue == nil || got.Continue.ChapterID != ch7ID || got.Continue.Page != 12 {
 		t.Errorf("got.Continue = %+v, want ch7 at page 12", got.Continue)
 	}
@@ -1239,12 +1515,11 @@ func TestSetReadTieBreakByUUID(t *testing.T) {
 		t.Fatalf("SetRead: %v", err)
 	}
 
-	lastUpsert := repo.upserts[len(repo.upserts)-1]
-	if lastUpsert.ChapterID != id1 {
-		t.Errorf("winner = %v, want %v (smallest UUID)", lastUpsert.ChapterID, id1)
+	if len(repo.upserts) != 2 {
+		t.Fatalf("len(repo.upserts) = %d, want 2", len(repo.upserts))
 	}
-	if got.Continue == nil || got.Continue.ChapterID != id1 {
-		t.Errorf("got.Continue = %+v, want chapter %v", got.Continue, id1)
+	if got.Continue == nil || got.Continue.ChapterID != id2 || got.Continue.Page != 10 {
+		t.Errorf("got.Continue = %+v, want chapter %v at page 10", got.Continue, id2)
 	}
 }
 

--- a/api/pkg/core/readingprogress/service_test.go
+++ b/api/pkg/core/readingprogress/service_test.go
@@ -29,21 +29,25 @@ func (f *fakeTransactor) WithinTx(ctx context.Context, _ transaction.TxOpts, fn 
 	return f.err
 }
 
+//nolint:govet // fieldalignment on a test fake is not worth the unreadable field order
 type fakeRepo struct {
 	latest      *readingprogress.Progress
 	existing    *readingprogress.Progress
 	listErr     error
 	getErr      error
 	upsertErr   error
+	deleteErr   error
 	stored      []readingprogress.Progress
 	rows        []readingprogress.Progress
 	upserts     []readingprogress.UpsertOpts
 	lastUpsert  readingprogress.UpsertOpts
 	lastGet     readingprogress.GetOpts
+	lastDelete  readingprogress.DeleteProgressOpts
 	listed      readingprogress.ListOpts
 	listCalls   int
 	getCalls    int
 	upsertCalls int
+	deleteCalls int
 }
 
 func (f *fakeRepo) GetLatestByUserAndComic(
@@ -109,6 +113,16 @@ func (f *fakeRepo) Upsert(_ context.Context, opts readingprogress.UpsertOpts) (r
 	f.rows = []readingprogress.Progress{row}
 
 	return out, f.upsertErr
+}
+
+func (f *fakeRepo) DeleteByUserAndChapterIDs(
+	_ context.Context,
+	opts readingprogress.DeleteProgressOpts,
+) error {
+	f.deleteCalls++
+	f.lastDelete = opts
+
+	return f.deleteErr
 }
 
 type fakeLibrary struct {
@@ -198,7 +212,7 @@ func ch(id, comicID uuid.UUID, number float64, pagesNb int) chapters.Chapter {
 	return chapters.Chapter{ID: id, ComicID: comicID, Number: number, PagesNb: pagesNb}
 }
 
-func markReadSvc(
+func setReadSvc(
 	t *testing.T,
 	repo *fakeRepo,
 	lib readingprogress.LibraryMembership,
@@ -551,27 +565,31 @@ func TestListForbidden(t *testing.T) {
 	}
 }
 
-func TestMarkReadEmptyChapterIDs(t *testing.T) {
+func TestSetReadEmptyChapterIDs(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
 		name string
 		ids  []uuid.UUID
+		read bool
 	}{
-		{name: "nil", ids: nil},
-		{name: "empty slice", ids: []uuid.UUID{}},
+		{name: "nil read true", ids: nil, read: true},
+		{name: "empty slice read true", ids: []uuid.UUID{}, read: true},
+		{name: "nil read false", ids: nil, read: false},
+		{name: "empty slice read false", ids: []uuid.UUID{}, read: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			repo := &fakeRepo{}
 			tx := &fakeTransactor{}
-			svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{}, tx)
+			svc := setReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{}, tx)
 
-			_, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+			_, err := svc.SetRead(context.Background(), readingprogress.SetReadOpts{
 				UserID:     uuid.New(),
 				ComicID:    uuid.New(),
 				ChapterIDs: tc.ids,
+				Read:       tc.read,
 			})
 			if !errors.Is(err, readingprogress.ErrInvalid) {
 				t.Errorf("err = %v, want ErrInvalid", err)
@@ -582,28 +600,32 @@ func TestMarkReadEmptyChapterIDs(t *testing.T) {
 			if repo.upsertCalls != 0 {
 				t.Errorf("repo.upsertCalls = %d, want 0", repo.upsertCalls)
 			}
+			if repo.deleteCalls != 0 {
+				t.Errorf("repo.deleteCalls = %d, want 0", repo.deleteCalls)
+			}
 		})
 	}
 }
 
 //nolint:dupl
-func TestMarkReadForbiddenWhenNotInLibrary(t *testing.T) {
+func TestSetReadForbiddenWhenNotInLibrary(t *testing.T) {
 	t.Parallel()
 
 	comicID := uuid.New()
 	chID := uuid.New()
 	repo := &fakeRepo{}
 	tx := &fakeTransactor{}
-	svc := markReadSvc(t, repo, &fakeLibrary{inLib: false}, &fakeComics{exists: true}, &fakeChapters{
+	svc := setReadSvc(t, repo, &fakeLibrary{inLib: false}, &fakeComics{exists: true}, &fakeChapters{
 		byID: map[uuid.UUID]chapters.Chapter{
 			chID: ch(chID, comicID, 1.0, 10),
 		},
 	}, tx)
 
-	_, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+	_, err := svc.SetRead(context.Background(), readingprogress.SetReadOpts{
 		UserID:     uuid.New(),
 		ComicID:    comicID,
 		ChapterIDs: []uuid.UUID{chID},
+		Read:       true,
 	})
 	if !errors.Is(err, domain.ErrForbidden) {
 		t.Errorf("err = %v, want ErrForbidden", err)
@@ -617,23 +639,24 @@ func TestMarkReadForbiddenWhenNotInLibrary(t *testing.T) {
 }
 
 //nolint:dupl
-func TestMarkReadNotFoundWhenComicMissing(t *testing.T) {
+func TestSetReadNotFoundWhenComicMissing(t *testing.T) {
 	t.Parallel()
 
 	comicID := uuid.New()
 	chID := uuid.New()
 	repo := &fakeRepo{}
 	tx := &fakeTransactor{}
-	svc := markReadSvc(t, repo, &fakeLibrary{inLib: false}, &fakeComics{exists: false}, &fakeChapters{
+	svc := setReadSvc(t, repo, &fakeLibrary{inLib: false}, &fakeComics{exists: false}, &fakeChapters{
 		byID: map[uuid.UUID]chapters.Chapter{
 			chID: ch(chID, comicID, 2.5, 10),
 		},
 	}, tx)
 
-	_, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+	_, err := svc.SetRead(context.Background(), readingprogress.SetReadOpts{
 		UserID:     uuid.New(),
 		ComicID:    comicID,
 		ChapterIDs: []uuid.UUID{chID},
+		Read:       true,
 	})
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Errorf("err = %v, want ErrNotFound", err)
@@ -647,7 +670,7 @@ func TestMarkReadNotFoundWhenComicMissing(t *testing.T) {
 }
 
 //nolint:dupl
-func TestMarkReadUnknownChapter(t *testing.T) {
+func TestSetReadUnknownChapter(t *testing.T) {
 	t.Parallel()
 
 	comicID := uuid.New()
@@ -655,16 +678,17 @@ func TestMarkReadUnknownChapter(t *testing.T) {
 	ch2 := uuid.New()
 	repo := &fakeRepo{}
 	tx := &fakeTransactor{}
-	svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{
+	svc := setReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{
 		byID: map[uuid.UUID]chapters.Chapter{
 			ch1: ch(ch1, comicID, 1.0, 10),
 		},
 	}, tx)
 
-	_, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+	_, err := svc.SetRead(context.Background(), readingprogress.SetReadOpts{
 		UserID:     uuid.New(),
 		ComicID:    comicID,
 		ChapterIDs: []uuid.UUID{ch1, ch2},
+		Read:       true,
 	})
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Errorf("err = %v, want ErrNotFound", err)
@@ -678,7 +702,7 @@ func TestMarkReadUnknownChapter(t *testing.T) {
 }
 
 //nolint:dupl
-func TestMarkReadForeignComicChapter(t *testing.T) {
+func TestSetReadForeignComicChapter(t *testing.T) {
 	t.Parallel()
 
 	comicID := uuid.New()
@@ -686,16 +710,17 @@ func TestMarkReadForeignComicChapter(t *testing.T) {
 	chID := uuid.New()
 	repo := &fakeRepo{}
 	tx := &fakeTransactor{}
-	svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{
+	svc := setReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{
 		byID: map[uuid.UUID]chapters.Chapter{
 			chID: ch(chID, otherComicID, 3.0, 10),
 		},
 	}, tx)
 
-	_, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+	_, err := svc.SetRead(context.Background(), readingprogress.SetReadOpts{
 		UserID:     uuid.New(),
 		ComicID:    comicID,
 		ChapterIDs: []uuid.UUID{chID},
+		Read:       true,
 	})
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Errorf("err = %v, want ErrNotFound", err)
@@ -709,23 +734,24 @@ func TestMarkReadForeignComicChapter(t *testing.T) {
 }
 
 //nolint:dupl
-func TestMarkReadOnlyZeroPagesNb(t *testing.T) {
+func TestSetReadOnlyZeroPagesNb(t *testing.T) {
 	t.Parallel()
 
 	comicID := uuid.New()
 	chID := uuid.New()
 	repo := &fakeRepo{}
 	tx := &fakeTransactor{}
-	svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{
+	svc := setReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{
 		byID: map[uuid.UUID]chapters.Chapter{
 			chID: ch(chID, comicID, 4.0, 0),
 		},
 	}, tx)
 
-	_, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+	_, err := svc.SetRead(context.Background(), readingprogress.SetReadOpts{
 		UserID:     uuid.New(),
 		ComicID:    comicID,
 		ChapterIDs: []uuid.UUID{chID},
+		Read:       true,
 	})
 	if !errors.Is(err, readingprogress.ErrInvalid) {
 		t.Errorf("err = %v, want ErrInvalid", err)
@@ -738,7 +764,7 @@ func TestMarkReadOnlyZeroPagesNb(t *testing.T) {
 	}
 }
 
-func TestMarkReadDedupesBeforeLookup(t *testing.T) {
+func TestSetReadDedupesBeforeLookup(t *testing.T) {
 	t.Parallel()
 
 	comicID := uuid.New()
@@ -750,22 +776,23 @@ func TestMarkReadDedupesBeforeLookup(t *testing.T) {
 			chID: ch(chID, comicID, 5.0, 10),
 		},
 	}
-	svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, chaps, tx)
+	svc := setReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, chaps, tx)
 
-	_, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+	_, err := svc.SetRead(context.Background(), readingprogress.SetReadOpts{
 		UserID:     uuid.New(),
 		ComicID:    comicID,
 		ChapterIDs: []uuid.UUID{chID, chID},
+		Read:       true,
 	})
 	if len(chaps.lastIDs) != 1 {
 		t.Fatalf("len(chaps.lastIDs) = %d, want 1", len(chaps.lastIDs))
 	}
 	if err != nil {
-		t.Fatalf("MarkRead: %v", err)
+		t.Fatalf("SetRead: %v", err)
 	}
 }
 
-func TestMarkReadFirstProgressContinueIsHighestNumber(t *testing.T) {
+func TestSetReadFirstProgressContinueIsHighestNumber(t *testing.T) {
 	t.Parallel()
 
 	userID := uuid.New()
@@ -780,15 +807,16 @@ func TestMarkReadFirstProgressContinueIsHighestNumber(t *testing.T) {
 
 	repo := &fakeRepo{}
 	tx := &fakeTransactor{}
-	svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
+	svc := setReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
 
-	got, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+	got, err := svc.SetRead(context.Background(), readingprogress.SetReadOpts{
 		UserID:     userID,
 		ComicID:    comicID,
 		ChapterIDs: ids,
+		Read:       true,
 	})
 	if err != nil {
-		t.Fatalf("MarkRead: %v", err)
+		t.Fatalf("SetRead: %v", err)
 	}
 
 	if tx.calls != 1 {
@@ -829,7 +857,7 @@ func TestMarkReadFirstProgressContinueIsHighestNumber(t *testing.T) {
 	}
 }
 
-func TestMarkReadKeepsEarlierContinuePage(t *testing.T) {
+func TestSetReadKeepsEarlierContinuePage(t *testing.T) {
 	t.Parallel()
 
 	userID := uuid.New()
@@ -855,15 +883,16 @@ func TestMarkReadKeepsEarlierContinuePage(t *testing.T) {
 		},
 	}
 	tx := &fakeTransactor{}
-	svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
+	svc := setReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
 
-	got, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+	got, err := svc.SetRead(context.Background(), readingprogress.SetReadOpts{
 		UserID:     userID,
 		ComicID:    comicID,
 		ChapterIDs: ids,
+		Read:       true,
 	})
 	if err != nil {
-		t.Fatalf("MarkRead: %v", err)
+		t.Fatalf("SetRead: %v", err)
 	}
 
 	if len(repo.upserts) < 2 {
@@ -892,7 +921,7 @@ func TestMarkReadKeepsEarlierContinuePage(t *testing.T) {
 	}
 }
 
-func TestMarkReadKeepsCompletedLaterContinue(t *testing.T) {
+func TestSetReadKeepsCompletedLaterContinue(t *testing.T) {
 	t.Parallel()
 
 	userID := uuid.New()
@@ -918,15 +947,16 @@ func TestMarkReadKeepsCompletedLaterContinue(t *testing.T) {
 		},
 	}
 	tx := &fakeTransactor{}
-	svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
+	svc := setReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
 
-	got, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+	got, err := svc.SetRead(context.Background(), readingprogress.SetReadOpts{
 		UserID:     userID,
 		ComicID:    comicID,
 		ChapterIDs: ids,
+		Read:       true,
 	})
 	if err != nil {
-		t.Fatalf("MarkRead: %v", err)
+		t.Fatalf("SetRead: %v", err)
 	}
 
 	for i, up := range repo.upserts[:len(repo.upserts)-1] {
@@ -944,7 +974,7 @@ func TestMarkReadKeepsCompletedLaterContinue(t *testing.T) {
 	}
 }
 
-func TestMarkReadMovesContinueForward(t *testing.T) {
+func TestSetReadMovesContinueForward(t *testing.T) {
 	t.Parallel()
 
 	userID := uuid.New()
@@ -968,15 +998,16 @@ func TestMarkReadMovesContinueForward(t *testing.T) {
 		},
 	}
 	tx := &fakeTransactor{}
-	svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
+	svc := setReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
 
-	got, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+	got, err := svc.SetRead(context.Background(), readingprogress.SetReadOpts{
 		UserID:     userID,
 		ComicID:    comicID,
 		ChapterIDs: ids,
+		Read:       true,
 	})
 	if err != nil {
-		t.Fatalf("MarkRead: %v", err)
+		t.Fatalf("SetRead: %v", err)
 	}
 
 	foundCh5Upsert := false
@@ -998,7 +1029,7 @@ func TestMarkReadMovesContinueForward(t *testing.T) {
 	}
 }
 
-func TestMarkReadSkipsZeroPagesNbAmongEligible(t *testing.T) {
+func TestSetReadSkipsZeroPagesNbAmongEligible(t *testing.T) {
 	t.Parallel()
 
 	userID := uuid.New()
@@ -1015,15 +1046,16 @@ func TestMarkReadSkipsZeroPagesNbAmongEligible(t *testing.T) {
 
 	repo := &fakeRepo{}
 	tx := &fakeTransactor{}
-	svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
+	svc := setReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
 
-	got, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+	got, err := svc.SetRead(context.Background(), readingprogress.SetReadOpts{
 		UserID:     userID,
 		ComicID:    comicID,
 		ChapterIDs: []uuid.UUID{ch1ID, ch2ID, ch3ID},
+		Read:       true,
 	})
 	if err != nil {
-		t.Fatalf("MarkRead: %v", err)
+		t.Fatalf("SetRead: %v", err)
 	}
 
 	for _, up := range repo.upserts {
@@ -1041,7 +1073,7 @@ func TestMarkReadSkipsZeroPagesNbAmongEligible(t *testing.T) {
 	}
 }
 
-func TestMarkReadDuplicateIDsOneWritePerChapter(t *testing.T) {
+func TestSetReadDuplicateIDsOneWritePerChapter(t *testing.T) {
 	t.Parallel()
 
 	userID := uuid.New()
@@ -1054,15 +1086,16 @@ func TestMarkReadDuplicateIDsOneWritePerChapter(t *testing.T) {
 
 	repo := &fakeRepo{}
 	tx := &fakeTransactor{}
-	svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
+	svc := setReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
 
-	_, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+	_, err := svc.SetRead(context.Background(), readingprogress.SetReadOpts{
 		UserID:     userID,
 		ComicID:    comicID,
 		ChapterIDs: []uuid.UUID{ch1ID, ch1ID},
+		Read:       true,
 	})
 	if err != nil {
-		t.Fatalf("MarkRead: %v", err)
+		t.Fatalf("SetRead: %v", err)
 	}
 
 	ch1Upserts := 0
@@ -1076,7 +1109,7 @@ func TestMarkReadDuplicateIDsOneWritePerChapter(t *testing.T) {
 	}
 }
 
-func TestMarkReadMissingContinueChapterTreatsAsNone(t *testing.T) {
+func TestSetReadMissingContinueChapterTreatsAsNone(t *testing.T) {
 	t.Parallel()
 
 	userID := uuid.New()
@@ -1098,15 +1131,16 @@ func TestMarkReadMissingContinueChapterTreatsAsNone(t *testing.T) {
 		},
 	}
 	tx := &fakeTransactor{}
-	svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
+	svc := setReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
 
-	got, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+	got, err := svc.SetRead(context.Background(), readingprogress.SetReadOpts{
 		UserID:     userID,
 		ComicID:    comicID,
 		ChapterIDs: []uuid.UUID{ch3ID, ch7ID},
+		Read:       true,
 	})
 	if err != nil {
-		t.Fatalf("MarkRead: %v", err)
+		t.Fatalf("SetRead: %v", err)
 	}
 
 	for _, up := range repo.upserts {
@@ -1124,7 +1158,7 @@ func TestMarkReadMissingContinueChapterTreatsAsNone(t *testing.T) {
 	}
 }
 
-func TestMarkReadTxErrorNoListSideEffect(t *testing.T) {
+func TestSetReadTxErrorNoListSideEffect(t *testing.T) {
 	t.Parallel()
 
 	comicID := uuid.New()
@@ -1139,12 +1173,13 @@ func TestMarkReadTxErrorNoListSideEffect(t *testing.T) {
 		upsertErr := errors.New("db error")
 		repo := &fakeRepo{upsertErr: upsertErr}
 		tx := &fakeTransactor{}
-		svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
+		svc := setReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
 
-		_, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+		_, err := svc.SetRead(context.Background(), readingprogress.SetReadOpts{
 			UserID:     uuid.New(),
 			ComicID:    comicID,
 			ChapterIDs: []uuid.UUID{chID},
+			Read:       true,
 		})
 		if err == nil {
 			t.Fatal("expected error")
@@ -1160,12 +1195,13 @@ func TestMarkReadTxErrorNoListSideEffect(t *testing.T) {
 		txErr := errors.New("tx commit failed")
 		repo := &fakeRepo{}
 		tx := &fakeTransactor{err: txErr}
-		svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
+		svc := setReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
 
-		_, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+		_, err := svc.SetRead(context.Background(), readingprogress.SetReadOpts{
 			UserID:     uuid.New(),
 			ComicID:    comicID,
 			ChapterIDs: []uuid.UUID{chID},
+			Read:       true,
 		})
 		if err == nil {
 			t.Fatal("expected error")
@@ -1176,7 +1212,7 @@ func TestMarkReadTxErrorNoListSideEffect(t *testing.T) {
 	})
 }
 
-func TestMarkReadTieBreakByUUID(t *testing.T) {
+func TestSetReadTieBreakByUUID(t *testing.T) {
 	t.Parallel()
 
 	userID := uuid.New()
@@ -1191,15 +1227,16 @@ func TestMarkReadTieBreakByUUID(t *testing.T) {
 
 	repo := &fakeRepo{}
 	tx := &fakeTransactor{}
-	svc := markReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
+	svc := setReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
 
-	got, err := svc.MarkRead(context.Background(), readingprogress.MarkReadOpts{
+	got, err := svc.SetRead(context.Background(), readingprogress.SetReadOpts{
 		UserID:     userID,
 		ComicID:    comicID,
 		ChapterIDs: []uuid.UUID{id2, id1},
+		Read:       true,
 	})
 	if err != nil {
-		t.Fatalf("MarkRead: %v", err)
+		t.Fatalf("SetRead: %v", err)
 	}
 
 	lastUpsert := repo.upserts[len(repo.upserts)-1]
@@ -1208,5 +1245,265 @@ func TestMarkReadTieBreakByUUID(t *testing.T) {
 	}
 	if got.Continue == nil || got.Continue.ChapterID != id1 {
 		t.Errorf("got.Continue = %+v, want chapter %v", got.Continue, id1)
+	}
+}
+
+func TestSetReadFalseSuccess(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	comicID := uuid.New()
+	ch1 := uuid.New()
+	ch2 := uuid.New()
+
+	byID := map[uuid.UUID]chapters.Chapter{
+		ch1: ch(ch1, comicID, 1.0, 10),
+		ch2: ch(ch2, comicID, 2.0, 15),
+	}
+
+	repo := &fakeRepo{}
+	tx := &fakeTransactor{}
+	svc := setReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
+
+	got, err := svc.SetRead(context.Background(), readingprogress.SetReadOpts{
+		UserID:     userID,
+		ComicID:    comicID,
+		ChapterIDs: []uuid.UUID{ch1, ch2},
+		Read:       false,
+	})
+	if err != nil {
+		t.Fatalf("SetRead(Read: false): %v", err)
+	}
+
+	if tx.calls != 0 {
+		t.Errorf("tx.calls = %d, want 0", tx.calls)
+	}
+	if repo.upsertCalls != 0 {
+		t.Errorf("repo.upsertCalls = %d, want 0", repo.upsertCalls)
+	}
+	if repo.deleteCalls != 1 {
+		t.Errorf("repo.deleteCalls = %d, want 1", repo.deleteCalls)
+	}
+	if repo.lastDelete.UserID != userID {
+		t.Errorf("repo.lastDelete.UserID = %v, want %v", repo.lastDelete.UserID, userID)
+	}
+	if len(repo.lastDelete.ChapterIDs) != 2 ||
+		repo.lastDelete.ChapterIDs[0] != ch1 ||
+		repo.lastDelete.ChapterIDs[1] != ch2 {
+		t.Errorf("repo.lastDelete.ChapterIDs = %v, want [%v, %v]", repo.lastDelete.ChapterIDs, ch1, ch2)
+	}
+	if got.Continue != nil {
+		t.Errorf("got.Continue = %+v, want nil", got.Continue)
+	}
+}
+
+func TestSetReadFalseSkipsZeroPagesNb(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	comicID := uuid.New()
+	ch1 := uuid.New()
+	ch2 := uuid.New()
+
+	byID := map[uuid.UUID]chapters.Chapter{
+		ch1: ch(ch1, comicID, 1.0, 0),
+		ch2: ch(ch2, comicID, 2.0, 15),
+	}
+
+	repo := &fakeRepo{}
+	tx := &fakeTransactor{}
+	svc := setReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
+
+	_, err := svc.SetRead(context.Background(), readingprogress.SetReadOpts{
+		UserID:     userID,
+		ComicID:    comicID,
+		ChapterIDs: []uuid.UUID{ch1, ch2},
+		Read:       false,
+	})
+	if err != nil {
+		t.Fatalf("SetRead: %v", err)
+	}
+
+	if repo.deleteCalls != 1 {
+		t.Errorf("repo.deleteCalls = %d, want 1", repo.deleteCalls)
+	}
+	if len(repo.lastDelete.ChapterIDs) != 1 || repo.lastDelete.ChapterIDs[0] != ch2 {
+		t.Errorf("repo.lastDelete.ChapterIDs = %v, want [%v]", repo.lastDelete.ChapterIDs, ch2)
+	}
+}
+
+func TestSetReadFalseDeleteError(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chID := uuid.New()
+	byID := map[uuid.UUID]chapters.Chapter{
+		chID: ch(chID, comicID, 1.0, 10),
+	}
+
+	delErr := errors.New("delete failed")
+	repo := &fakeRepo{deleteErr: delErr}
+	tx := &fakeTransactor{}
+	svc := setReadSvc(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{byID: byID}, tx)
+
+	_, err := svc.SetRead(context.Background(), readingprogress.SetReadOpts{
+		UserID:     uuid.New(),
+		ComicID:    comicID,
+		ChapterIDs: []uuid.UUID{chID},
+		Read:       false,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, delErr) {
+		t.Errorf("err = %v, want wrapped %v", err, delErr)
+	}
+}
+
+func TestDeleteChapterNotFound(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{}
+	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{
+		byID: map[uuid.UUID]chapters.Chapter{},
+	})
+
+	err := svc.Delete(context.Background(), readingprogress.DeleteOpts{
+		UserID:    uuid.New(),
+		ChapterID: uuid.New(),
+	})
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+	if repo.deleteCalls != 0 {
+		t.Errorf("repo.deleteCalls = %d, want 0", repo.deleteCalls)
+	}
+}
+
+func TestDeleteChapterLookupError(t *testing.T) {
+	t.Parallel()
+
+	lookupErr := errors.New("chapter lookup error")
+	repo := &fakeRepo{}
+	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{
+		getErr: lookupErr,
+	})
+
+	err := svc.Delete(context.Background(), readingprogress.DeleteOpts{
+		UserID:    uuid.New(),
+		ChapterID: uuid.New(),
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, lookupErr) {
+		t.Errorf("err = %v, want wrapped %v", err, lookupErr)
+	}
+	if repo.deleteCalls != 0 {
+		t.Errorf("repo.deleteCalls = %d, want 0", repo.deleteCalls)
+	}
+}
+
+func TestDeleteForbiddenWhenNotInLibrary(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chID := uuid.New()
+	repo := &fakeRepo{}
+	svc := newService(t, repo, &fakeLibrary{inLib: false}, &fakeComics{exists: true}, &fakeChapters{
+		byID: map[uuid.UUID]chapters.Chapter{
+			chID: ch(chID, comicID, 1.0, 10),
+		},
+	})
+
+	err := svc.Delete(context.Background(), readingprogress.DeleteOpts{
+		UserID:    uuid.New(),
+		ChapterID: chID,
+	})
+	if !errors.Is(err, domain.ErrForbidden) {
+		t.Errorf("err = %v, want ErrForbidden", err)
+	}
+	if repo.deleteCalls != 0 {
+		t.Errorf("repo.deleteCalls = %d, want 0", repo.deleteCalls)
+	}
+}
+
+func TestDeleteNotFoundWhenComicMissing(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chID := uuid.New()
+	repo := &fakeRepo{}
+	svc := newService(t, repo, &fakeLibrary{inLib: false}, &fakeComics{exists: false}, &fakeChapters{
+		byID: map[uuid.UUID]chapters.Chapter{
+			chID: ch(chID, comicID, 1.0, 10),
+		},
+	})
+
+	err := svc.Delete(context.Background(), readingprogress.DeleteOpts{
+		UserID:    uuid.New(),
+		ChapterID: chID,
+	})
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+	if repo.deleteCalls != 0 {
+		t.Errorf("repo.deleteCalls = %d, want 0", repo.deleteCalls)
+	}
+}
+
+func TestDeleteSuccess(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	comicID := uuid.New()
+	chID := uuid.New()
+	repo := &fakeRepo{}
+	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{
+		byID: map[uuid.UUID]chapters.Chapter{
+			chID: ch(chID, comicID, 1.0, 10),
+		},
+	})
+
+	err := svc.Delete(context.Background(), readingprogress.DeleteOpts{
+		UserID:    userID,
+		ChapterID: chID,
+	})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if repo.deleteCalls != 1 {
+		t.Errorf("repo.deleteCalls = %d, want 1", repo.deleteCalls)
+	}
+	if repo.lastDelete.UserID != userID {
+		t.Errorf("repo.lastDelete.UserID = %v, want %v", repo.lastDelete.UserID, userID)
+	}
+	if len(repo.lastDelete.ChapterIDs) != 1 || repo.lastDelete.ChapterIDs[0] != chID {
+		t.Errorf("repo.lastDelete.ChapterIDs = %v, want [%v]", repo.lastDelete.ChapterIDs, chID)
+	}
+}
+
+func TestDeleteRepoError(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chID := uuid.New()
+	delErr := errors.New("delete error")
+	repo := &fakeRepo{deleteErr: delErr}
+	svc := newService(t, repo, &fakeLibrary{inLib: true}, &fakeComics{exists: true}, &fakeChapters{
+		byID: map[uuid.UUID]chapters.Chapter{
+			chID: ch(chID, comicID, 1.0, 10),
+		},
+	})
+
+	err := svc.Delete(context.Background(), readingprogress.DeleteOpts{
+		UserID:    uuid.New(),
+		ChapterID: chID,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, delErr) {
+		t.Errorf("err = %v, want wrapped %v", err, delErr)
 	}
 }

--- a/web/app/features/asura/composables/asura-chapters.composable.test.ts
+++ b/web/app/features/asura/composables/asura-chapters.composable.test.ts
@@ -34,6 +34,7 @@ function createChaptersApiStub(): ChaptersApi {
     getByComicId: vi.fn(),
     getById: vi.fn(),
     saveProgress: vi.fn(),
+    deleteProgress: vi.fn(),
   }
 }
 

--- a/web/app/features/chapters/composables/chapters.api.test.ts
+++ b/web/app/features/chapters/composables/chapters.api.test.ts
@@ -185,3 +185,22 @@ describe('createChaptersApi().retryDownload', () => {
     expect(res.success === false && res.error.status).toBe(409)
   })
 })
+
+describe('createChaptersApi().deleteProgress', () => {
+  it('sends DELETE to /:id/progress', async () => {
+    call.mockResolvedValue(undefined)
+
+    const res = await createChaptersApi().deleteProgress('ch-1')
+
+    expect(call).toHaveBeenCalledWith('/ch-1/progress', { method: 'DELETE' })
+    expect(res).toEqual({ success: true, data: undefined })
+  })
+
+  it('surfaces a failure with its status', async () => {
+    call.mockRejectedValue({ statusCode: 500, data: {} })
+
+    const res = await createChaptersApi().deleteProgress('ch-1')
+
+    expect(res.success === false && res.error.status).toBe(500)
+  })
+})

--- a/web/app/features/chapters/composables/chapters.api.test.ts
+++ b/web/app/features/chapters/composables/chapters.api.test.ts
@@ -15,14 +15,55 @@ beforeEach(() => {
 })
 
 describe('createChaptersApi().getByComicId', () => {
-  it('lists chapters for the comic', async () => {
-    const chapters = [{ id: 'ch-1', comicId: 'c1', number: 1 }]
+  it('lists chapters for the comic and deserializes dates', async () => {
+    const publishedAt = '2026-01-01T00:00:00.000Z'
+    const chapters = [{
+      id: 'ch-1',
+      comicId: 'c1',
+      number: 1,
+      publishedAt,
+      earlyAccessUntil: '0001-01-01T00:00:00Z',
+    }]
     call.mockResolvedValue(chapters)
 
     const res = await createChaptersApi().getByComicId('c1')
 
     expect(call).toHaveBeenCalledWith('/', { params: { comicId: 'c1' } })
-    expect(res).toEqual({ success: true, data: chapters })
+    expect(res).toEqual({
+      success: true,
+      data: [{
+        id: 'ch-1',
+        comicId: 'c1',
+        number: 1,
+        publishedAt: new Date(publishedAt),
+      }],
+    })
+  })
+
+  it('keeps valid earlyAccessUntil as Date', async () => {
+    const publishedAt = '2026-01-01T00:00:00.000Z'
+    const earlyAccessUntil = '2026-02-01T00:00:00.000Z'
+    const chapters = [{
+      id: 'ch-1',
+      comicId: 'c1',
+      number: 1,
+      publishedAt,
+      earlyAccessUntil,
+    }]
+    call.mockResolvedValue(chapters)
+
+    const res = await createChaptersApi().getByComicId('c1')
+
+    expect(res).toEqual({
+      success: true,
+      data: [{
+        id: 'ch-1',
+        comicId: 'c1',
+        number: 1,
+        publishedAt: new Date(publishedAt),
+        earlyAccessUntil: new Date(earlyAccessUntil),
+      }],
+    })
   })
 
   it('surfaces a 404 with its status', async () => {
@@ -36,13 +77,22 @@ describe('createChaptersApi().getByComicId', () => {
 
 describe('createChaptersApi().getByIds', () => {
   it('posts the chapter ids', async () => {
-    const chapters = [{ id: 'ch-1', comicId: 'c1', number: 1 }]
+    const publishedAt = '2026-01-01T00:00:00.000Z'
+    const chapters = [{ id: 'ch-1', comicId: 'c1', number: 1, publishedAt }]
     call.mockResolvedValue(chapters)
 
     const res = await createChaptersApi().getByIds(['ch-1', 'ch-2'])
 
     expect(call).toHaveBeenCalledWith('/list', { method: 'POST', body: { ids: ['ch-1', 'ch-2'] } })
-    expect(res).toEqual({ success: true, data: chapters })
+    expect(res).toEqual({
+      success: true,
+      data: [{
+        id: 'ch-1',
+        comicId: 'c1',
+        number: 1,
+        publishedAt: new Date(publishedAt),
+      }],
+    })
   })
 
   it('surfaces a failure with its status', async () => {
@@ -56,6 +106,7 @@ describe('createChaptersApi().getByIds', () => {
 
 describe('createChaptersApi().getById', () => {
   it('returns the chapter with next and previous neighbors', async () => {
+    const publishedAt = '2026-01-01T00:00:00.000Z'
     const next = { id: 'ch-3', title: 'Three', number: 3 }
     const previous = { id: 'ch-1', title: 'One', number: 1 }
     call.mockResolvedValue({
@@ -63,6 +114,7 @@ describe('createChaptersApi().getById', () => {
       comicId: 'c1',
       number: 2,
       title: 'Two',
+      publishedAt,
       pageUrls: ['/api/chapters/ch-2/pages/1'],
       next,
       previous,
@@ -78,6 +130,7 @@ describe('createChaptersApi().getById', () => {
         comicId: 'c1',
         number: 2,
         title: 'Two',
+        publishedAt: new Date(publishedAt),
         pageUrls: ['/api/chapters/ch-2/pages/1'],
         next,
         previous,

--- a/web/app/features/chapters/composables/chapters.api.ts
+++ b/web/app/features/chapters/composables/chapters.api.ts
@@ -1,6 +1,7 @@
 import type { Chapter, ChapterProgress, DetailedChapter, SaveChapterProgressRequest } from '../types'
 import type { ApiResponse } from '~/utils/api'
 import { ApiError, initApi } from '~/utils/api'
+import { parseOptionalDate } from '~/utils/date.utils'
 
 export interface ChaptersApi {
   retryDownload: (chapterId: string) => Promise<ApiResponse<void>>
@@ -8,11 +9,16 @@ export interface ChaptersApi {
   getByComicId: (comicId: string) => Promise<ApiResponse<Chapter[]>>
   getById: (id: string) => Promise<ApiResponse<DetailedChapter>>
   saveProgress: (req: SaveChapterProgressRequest) => Promise<ApiResponse<ChapterProgress>>
+  deleteProgress: (id: string) => Promise<ApiResponse<void>>
 }
 
-function chapterFromHTTP({ progress, ...chapter }: Chapter): Chapter {
+function chapterFromHTTP({ progress, earlyAccessUntil, publishedAt, ...chapter }: Chapter): Chapter {
+  const until = parseOptionalDate(earlyAccessUntil)
+
   return {
     ...chapter,
+    publishedAt: new Date(publishedAt),
+    ...(until && { earlyAccessUntil: until }),
     progress: progress
       ? {
           updatedAt: new Date(progress.updatedAt),
@@ -89,11 +95,22 @@ export function createChaptersApi(): ChaptersApi {
     }
   }
 
+  async function deleteProgress(id: string): Promise<ApiResponse<void>> {
+    try {
+      await api<void>(`/${id}/progress`, { method: 'DELETE' })
+
+      return { success: true, data: undefined }
+    } catch (error) {
+      return { success: false, error: ApiError.fromFetchError(error) }
+    }
+  }
+
   return {
     retryDownload,
     getByIds,
     getByComicId,
     getById,
     saveProgress,
+    deleteProgress,
   }
 }

--- a/web/app/features/comics/components/Chapters/Actions.test.ts
+++ b/web/app/features/comics/components/Chapters/Actions.test.ts
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { VueWrapper } from '@vue/test-utils'
+import type { Chapter } from '~/features/chapters/types'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, ref } from 'vue'
+import { VApp, VListItem } from 'vuetify/components'
+import { useToast } from '~/composables/toast.composable'
+import Actions from './Actions.vue'
+
+const { setChaptersProgress, retryChaptersDownload } = vi.hoisted(() => ({
+  setChaptersProgress: vi.fn(),
+  retryChaptersDownload: vi.fn(),
+}))
+
+function comicsApiStub(): {
+  setChaptersProgress: typeof setChaptersProgress
+  retryChaptersDownload: typeof retryChaptersDownload
+} {
+  return {
+    setChaptersProgress,
+    retryChaptersDownload,
+  }
+}
+
+mockNuxtImport('createComicsApi', () => comicsApiStub)
+
+const MenuStub = defineComponent({
+  name: 'VMenu',
+  inheritAttrs: false,
+  setup(_, { slots }) {
+    return () => slots.default?.()
+  },
+})
+
+function chapter(overrides: Partial<Chapter> = {}): Chapter {
+  return {
+    id: 'ch-1',
+    comicId: 'c1',
+    title: 'Chapter 1',
+    number: 1,
+    publishedAt: new Date('2026-08-18T12:00:00.000Z'),
+    sourceChapterSlug: '1',
+    pagesNb: 20,
+    download: 100,
+    ...overrides,
+  }
+}
+
+async function mount(initialChapters: Chapter[]): Promise<{
+  wrapper: VueWrapper
+  chaptersRef: ReturnType<typeof ref<Chapter[]>>
+  onRefetchChapters: ReturnType<typeof vi.fn>
+}> {
+  const chaptersRef = ref<Chapter[]>([...initialChapters])
+  const onRefetchChapters = vi.fn()
+
+  const wrapper = await mountSuspended({
+    render: () => h(VApp, () => [h(Actions, {
+      'comicId': 'c1',
+      'modelValue': chaptersRef.value,
+      'onUpdate:modelValue': (val: Chapter[]) => {
+        chaptersRef.value = val
+      },
+      'onRefetchChapters': onRefetchChapters,
+    })]),
+  }, {
+    global: {
+      stubs: { VMenu: MenuStub },
+    },
+  })
+
+  return { wrapper, chaptersRef, onRefetchChapters }
+}
+
+beforeEach(() => {
+  useToast().messages.value.length = 0
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  setChaptersProgress.mockReset()
+  retryChaptersDownload.mockReset()
+  setChaptersProgress.mockResolvedValue({ success: true, data: undefined })
+  retryChaptersDownload.mockResolvedValue({ success: true, data: undefined })
+})
+
+describe('comicsChaptersActions', () => {
+  it('disables actions when corresponding chapters are empty', async () => {
+    const { wrapper } = await mount([
+      chapter({ id: 'ch-1', pagesNb: 20, progress: { page: 20, updatedAt: new Date() }, download: 100 }),
+    ])
+
+    const items = wrapper.findAllComponents(VListItem)
+    expect(items).toHaveLength(3)
+
+    // retryable: disabled because no download === -1
+    expect(items[0]!.props('disabled')).toBe(true)
+    // setRead: disabled because all chapters are already read
+    expect(items[1]!.props('disabled')).toBe(true)
+    // setUnread: enabled because ch-1 is read
+    expect(items[2]!.props('disabled')).toBe(false)
+  })
+
+  it('triggers retryDownload on action click, clears chapters model and emits refetchChapters(false)', async () => {
+    const { wrapper, chaptersRef, onRefetchChapters } = await mount([
+      chapter({ id: 'ch-1', download: -1 }),
+      chapter({ id: 'ch-2', download: 100 }),
+    ])
+
+    const items = wrapper.findAllComponents(VListItem)
+    expect(items[0]!.props('disabled')).toBe(false)
+
+    await items[0]!.trigger('click')
+
+    expect(retryChaptersDownload).toHaveBeenCalledWith('c1', ['ch-1'])
+    expect(chaptersRef.value).toEqual([])
+    expect(onRefetchChapters).toHaveBeenCalledWith(false)
+  })
+
+  it('triggers setRead on action click, clears chapters model and emits refetchChapters(true)', async () => {
+    const { wrapper, chaptersRef, onRefetchChapters } = await mount([
+      chapter({ id: 'ch-1', pagesNb: 20, progress: undefined }),
+      chapter({ id: 'ch-2', pagesNb: 20, progress: { page: 20, updatedAt: new Date() } }),
+    ])
+
+    const items = wrapper.findAllComponents(VListItem)
+    expect(items[1]!.props('disabled')).toBe(false)
+
+    await items[1]!.trigger('click')
+
+    expect(setChaptersProgress).toHaveBeenCalledWith({
+      comicId: 'c1',
+      chapterIds: ['ch-1'],
+      read: true,
+    })
+    expect(chaptersRef.value).toEqual([])
+    expect(onRefetchChapters).toHaveBeenCalledWith(true)
+  })
+
+  it('triggers setUnread on action click, clears chapters model and emits refetchChapters(true)', async () => {
+    const { wrapper, chaptersRef, onRefetchChapters } = await mount([
+      chapter({ id: 'ch-1', pagesNb: 20, progress: undefined }),
+      chapter({ id: 'ch-2', pagesNb: 20, progress: { page: 20, updatedAt: new Date() } }),
+    ])
+
+    const items = wrapper.findAllComponents(VListItem)
+    expect(items[2]!.props('disabled')).toBe(false)
+
+    await items[2]!.trigger('click')
+
+    expect(setChaptersProgress).toHaveBeenCalledWith({
+      comicId: 'c1',
+      chapterIds: ['ch-2'],
+      read: false,
+    })
+    expect(chaptersRef.value).toEqual([])
+    expect(onRefetchChapters).toHaveBeenCalledWith(true)
+  })
+
+  it('displays a toast error when setChaptersProgress fails', async () => {
+    setChaptersProgress.mockResolvedValue({
+      success: false,
+      error: { status: 500, message: 'Server error' },
+    })
+
+    const { wrapper } = await mount([
+      chapter({ id: 'ch-1', pagesNb: 20, progress: undefined }),
+    ])
+
+    const items = wrapper.findAllComponents(VListItem)
+    await items[1]!.trigger('click')
+
+    expect(useToast().messages.value).toEqual([{ text: 'Unknown error', color: 'error' }])
+  })
+})

--- a/web/app/features/comics/components/Chapters/Actions.vue
+++ b/web/app/features/comics/components/Chapters/Actions.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import type { Chapter } from '~/features/chapters/types'
+
+const props = defineProps<{ comicId: string }>()
+const emit = defineEmits<{ refetchChapters: [updateConitnue: boolean] }>()
+const chapters = defineModel<Chapter[]>({ required: true })
+
+const comicsApi = createComicsApi()
+const { t } = useI18n()
+const toast = useToast()
+
+const readChaptersIds = computed(() => {
+  const ids: string[] = []
+  for (const chapter of chapters.value) {
+    if (chapter.pagesNb === chapter.progress?.page) {
+      ids.push(chapter.id)
+    }
+  }
+
+  return ids
+})
+
+const unreadChaptersIds = computed(() => {
+  const ids: string[] = []
+  for (const chapter of chapters.value) {
+    if (chapter.pagesNb !== chapter.progress?.page) {
+      ids.push(chapter.id)
+    }
+  }
+
+  return ids
+})
+
+const retryableDownloadChaptersIds = computed(() => {
+  const ids: string[] = []
+  for (const chapter of chapters.value) {
+    if (chapter.download === -1) {
+      ids.push(chapter.id)
+    }
+  }
+
+  return ids
+})
+
+const showMenu = ref(false)
+const loading = ref(false)
+
+async function setProgress(chaptersIds: string[], read: boolean): Promise<void> {
+  const response = await comicsApi.setChaptersProgress({
+    comicId: props.comicId,
+    chapterIds: chaptersIds,
+    read,
+  })
+
+  if (!response.success) {
+    console.error('comicsApi.setChaptersProgress', response.error)
+    toast.error(t('error.unknown'))
+  }
+}
+
+async function doAction(action: 'retryDownload' | 'setRead' | 'setUnread'): Promise<void> {
+  loading.value = true
+
+  if (action !== 'retryDownload') {
+    await setProgress(
+      action === 'setRead' ? unreadChaptersIds.value : readChaptersIds.value,
+      action === 'setRead',
+    )
+  }
+
+  loading.value = false
+
+  chapters.value = []
+
+  emit('refetchChapters', action !== 'retryDownload')
+}
+</script>
+
+<template>
+  <VBtn
+    prepend-icon="fa6-solid:gear"
+    color="surfaceVariant"
+    :loading
+  >
+    {{ $t('common.actions') }}
+    <VMenu
+      v-model="showMenu"
+      activator="parent"
+      location="bottom center"
+      offset="8"
+      close-on-content-click
+    >
+      <VList
+        density="compact"
+        style="border-radius: 12px;"
+        class="border-thin"
+      >
+        <VListItem
+          :title="$t('comic.chapter.download.retryMany', { count: retryableDownloadChaptersIds.length })"
+          :disabled="retryableDownloadChaptersIds.length === 0"
+          prepend-icon="fa6-solid:exclamation"
+          density="compact"
+          @click="doAction('retryDownload')"
+        />
+        <VListItem
+          :title="$t('comic.chapter.setReadMany', { count: unreadChaptersIds.length })"
+          :disabled="unreadChaptersIds.length === 0"
+          prepend-icon="fa6-solid:check"
+          density="compact"
+          @click="doAction('setRead')"
+        />
+
+        <VListItem
+          :title="$t('comic.chapter.setUnreadMany', { count: readChaptersIds.length })"
+          :disabled="readChaptersIds.length === 0"
+          prepend-icon="fa6-solid:eye-low-vision"
+          density="compact"
+          @click="doAction('setUnread')"
+        />
+      </VList>
+    </VMenu>
+  </VBtn>
+</template>

--- a/web/app/features/comics/components/Chapters/Actions.vue
+++ b/web/app/features/comics/components/Chapters/Actions.vue
@@ -58,14 +58,27 @@ async function setProgress(chaptersIds: string[], read: boolean): Promise<void> 
   }
 }
 
+async function retryDownload(): Promise<void> {
+  const response = await comicsApi.retryChaptersDownload(props.comicId, retryableDownloadChaptersIds.value)
+  if (!response.success) {
+    console.error('comicsApi.retryChaptersDownload', response.error)
+    toast.error(t('error.unknown'))
+  }
+}
+
 async function doAction(action: 'retryDownload' | 'setRead' | 'setUnread'): Promise<void> {
   loading.value = true
 
-  if (action !== 'retryDownload') {
-    await setProgress(
-      action === 'setRead' ? unreadChaptersIds.value : readChaptersIds.value,
-      action === 'setRead',
-    )
+  switch (action) {
+    case 'retryDownload':
+      await retryDownload()
+      break
+    case 'setRead':
+      await setProgress(unreadChaptersIds.value, true)
+      break
+    case 'setUnread':
+      await setProgress(readChaptersIds.value, false)
+      break
   }
 
   loading.value = false
@@ -74,6 +87,34 @@ async function doAction(action: 'retryDownload' | 'setRead' | 'setUnread'): Prom
 
   emit('refetchChapters', action !== 'retryDownload')
 }
+
+interface ListItem {
+  disabled: boolean
+  title: string
+  prependIcon: string
+  onClick: () => void
+}
+
+const items = computed((): ListItem[] => [
+  {
+    title: t('comic.chapter.download.retryMany', { count: retryableDownloadChaptersIds.value.length }),
+    prependIcon: 'fa6-solid:exclamation',
+    disabled: retryableDownloadChaptersIds.value.length === 0,
+    onClick: () => doAction('retryDownload'),
+  },
+  {
+    title: t('comic.chapter.setReadMany', { count: unreadChaptersIds.value.length }),
+    prependIcon: 'fa6-solid:eye',
+    disabled: unreadChaptersIds.value.length === 0,
+    onClick: () => doAction('setRead'),
+  },
+  {
+    title: t('comic.chapter.setUnreadMany', { count: readChaptersIds.value.length }),
+    prependIcon: 'fa6-solid:eye-low-vision',
+    disabled: readChaptersIds.value.length === 0,
+    onClick: () => doAction('setUnread'),
+  },
+])
 </script>
 
 <template>
@@ -96,26 +137,11 @@ async function doAction(action: 'retryDownload' | 'setRead' | 'setUnread'): Prom
         class="border-thin"
       >
         <VListItem
-          :title="$t('comic.chapter.download.retryMany', { count: retryableDownloadChaptersIds.length })"
-          :disabled="retryableDownloadChaptersIds.length === 0"
-          prepend-icon="fa6-solid:exclamation"
+          v-for="({ onClick, ...item }, index) in items"
+          :key="index"
+          v-bind="item"
           density="compact"
-          @click="doAction('retryDownload')"
-        />
-        <VListItem
-          :title="$t('comic.chapter.setReadMany', { count: unreadChaptersIds.length })"
-          :disabled="unreadChaptersIds.length === 0"
-          prepend-icon="fa6-solid:check"
-          density="compact"
-          @click="doAction('setRead')"
-        />
-
-        <VListItem
-          :title="$t('comic.chapter.setUnreadMany', { count: readChaptersIds.length })"
-          :disabled="readChaptersIds.length === 0"
-          prepend-icon="fa6-solid:eye-low-vision"
-          density="compact"
-          @click="doAction('setUnread')"
+          @click="onClick"
         />
       </VList>
     </VMenu>

--- a/web/app/features/comics/components/Chapters/Continue.test.ts
+++ b/web/app/features/comics/components/Chapters/Continue.test.ts
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { VueWrapper } from '@vue/test-utils'
+import type { ComicProgressContinue } from '../../types'
+import type { Chapter } from '~/features/chapters/types'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it } from 'vitest'
+import { h } from 'vue'
+import { VApp, VBtn } from 'vuetify/components'
+import Continue from './Continue.vue'
+
+function chapter(overrides: Partial<Chapter> = {}): Chapter {
+  return {
+    id: 'ch-1',
+    comicId: 'c1',
+    title: 'Chapter 1',
+    number: 1,
+    publishedAt: new Date('2026-08-18T12:00:00.000Z'),
+    sourceChapterSlug: '1',
+    pagesNb: 20,
+    download: 100,
+    ...overrides,
+  }
+}
+
+async function mount(props: {
+  comicId?: string
+  continue?: ComicProgressContinue
+  chapters?: Chapter[]
+  sort?: 'asc' | 'desc'
+} = {}): Promise<VueWrapper> {
+  return mountSuspended({
+    render: () => h(VApp, () => [h(Continue, {
+      comicId: props.comicId ?? 'c1',
+      continue: props.continue,
+      chapters: props.chapters ?? [
+        chapter({ id: 'ch-1', number: 1, pagesNb: 20 }),
+        chapter({ id: 'ch-2', number: 2, pagesNb: 20 }),
+      ],
+      sort: props.sort ?? 'desc',
+    })]),
+  })
+}
+
+describe('comicsChaptersContinue', () => {
+  it('renders "Start" button for the first chapter when no continue progress is present', async () => {
+    const wrapper = await mount({
+      continue: undefined,
+      chapters: [
+        chapter({ id: 'ch-1', number: 1 }),
+        chapter({ id: 'ch-2', number: 2 }),
+      ],
+    })
+
+    const btn = wrapper.findComponent(VBtn)
+    expect(btn.props('text')).toBe('Start')
+    expect(btn.props('color')).toBe('primary')
+    expect(wrapper.find('a').attributes('href')).toBe('/comic/c1/ch-1')
+  })
+
+  it('renders "Continue" button for the current chapter when it is partially read', async () => {
+    const wrapper = await mount({
+      continue: { chapterId: 'ch-2', page: 10 },
+      chapters: [
+        chapter({ id: 'ch-1', number: 1 }),
+        chapter({ id: 'ch-2', number: 2 }),
+      ],
+    })
+
+    const btn = wrapper.findComponent(VBtn)
+    expect(btn.props('text')).toBe('Continue')
+    expect(wrapper.find('a').attributes('href')).toBe('/comic/c1/ch-2')
+  })
+
+  it('advances to the next chapter when the current chapter is fully read', async () => {
+    const wrapper = await mount({
+      continue: { chapterId: 'ch-1', page: 20 },
+      chapters: [
+        chapter({ id: 'ch-1', number: 1, pagesNb: 20 }),
+        chapter({ id: 'ch-2', number: 2, pagesNb: 20 }),
+      ],
+    })
+
+    const btn = wrapper.findComponent(VBtn)
+    expect(btn.props('text')).toBe('Continue')
+    expect(wrapper.find('a').attributes('href')).toBe('/comic/c1/ch-2')
+  })
+
+  it('renders "Up to date" when the last chapter is fully read', async () => {
+    const wrapper = await mount({
+      continue: { chapterId: 'ch-2', page: 20 },
+      chapters: [
+        chapter({ id: 'ch-1', number: 1, pagesNb: 20 }),
+        chapter({ id: 'ch-2', number: 2, pagesNb: 20 }),
+      ],
+    })
+
+    const btn = wrapper.findComponent(VBtn)
+    expect(btn.props('text')).toBe('Up to date !')
+    expect(btn.props('readonly')).toBe(true)
+    expect(btn.props('color')).toBe('secondary')
+    expect(wrapper.find('a').exists()).toBe(false)
+  })
+
+  it('handles chapters passed in asc sort order properly', async () => {
+    const wrapper = await mount({
+      sort: 'asc',
+      continue: { chapterId: 'ch-1', page: 20 },
+      chapters: [
+        chapter({ id: 'ch-1', number: 1, pagesNb: 20 }),
+        chapter({ id: 'ch-2', number: 2, pagesNb: 20 }),
+      ],
+    })
+
+    const btn = wrapper.findComponent(VBtn)
+    expect(btn.props('text')).toBe('Continue')
+    expect(wrapper.find('a').attributes('href')).toBe('/comic/c1/ch-2')
+  })
+})

--- a/web/app/features/comics/components/Chapters/Continue.vue
+++ b/web/app/features/comics/components/Chapters/Continue.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import type { ComicProgressContinue } from '../../types'
+import type { Chapter } from '~/features/chapters/types'
+
+const props = defineProps<{
+  comicId: string
+  continue?: ComicProgressContinue
+  chapters: Chapter[]
+  sort: 'asc' | 'desc'
+}>()
+
+const { smAndDown } = useDisplay()
+
+const nextChapter = computed(() => {
+  const chaptersCpy = props.sort === 'asc' ? props.chapters : props.chapters.toSorted((a, b) => a.number - b.number)
+  const continueCpy = props.continue
+
+  if (!continueCpy) {
+    return chaptersCpy[0] as Chapter
+  }
+
+  const i = chaptersCpy.findIndex(chapter => chapter.id === continueCpy.chapterId)
+  if (i === -1) {
+    return
+  }
+
+  if (continueCpy.page === chaptersCpy[i]!.pagesNb) {
+    if (i === chaptersCpy.length - 1) {
+      return
+    }
+
+    return chaptersCpy[i + 1] as Chapter
+  }
+
+  return chaptersCpy[i] as Chapter
+})
+
+const nextChapterText = computed(() => {
+  if (smAndDown.value) {
+    return
+  }
+
+  if (!nextChapter.value) {
+    return $t('common.upToDate')
+  }
+
+  return nextChapter.value.number === 1 ? $t('common.start') : $t('common.continue')
+})
+
+const to = computed(() => {
+  if (!nextChapter.value) {
+    return undefined
+  }
+
+  return `/comic/${props.comicId}/${nextChapter.value.id}`
+})
+
+const icon = computed(() => {
+  if (!nextChapter.value) {
+    return 'fa6-solid:check'
+  }
+
+  return 'fa6-solid:play'
+})
+</script>
+
+<template>
+  <AtomLink :to>
+    <VBtn
+      :variant="nextChapter ? 'tonal' : 'outlined'"
+      :class="{ 'border-thin-primary': nextChapter }"
+      :icon="smAndDown ? icon : undefined"
+      :prepend-icon="smAndDown ? undefined : icon"
+      :text="nextChapterText"
+      :readonly="!nextChapter"
+      :color="nextChapter ? 'primary' : 'secondary'"
+      :size="smAndDown ? 'small' : undefined"
+    />
+  </AtomLink>
+</template>

--- a/web/app/features/comics/components/Chapters/Item.test.ts
+++ b/web/app/features/comics/components/Chapters/Item.test.ts
@@ -28,6 +28,7 @@ async function mount(value: Chapter = chapter(), isRetryLoading = false): Promis
     render: () => h(VApp, () => [h(Item, {
       chapter: value,
       retryLoading: isRetryLoading,
+      updateProgressLoading: false,
       selectable: false,
       onRetry: vi.fn(),
     })]),
@@ -71,6 +72,7 @@ describe('comicsChaptersItem', () => {
       render: () => h(VApp, () => [h(Item, {
         chapter: chapter({ download: -1 }),
         retryLoading: false,
+        updateProgressLoading: false,
         selectable: false,
         onRetry,
       })]),

--- a/web/app/features/comics/components/Chapters/Item.test.ts
+++ b/web/app/features/comics/components/Chapters/Item.test.ts
@@ -28,6 +28,7 @@ async function mount(value: Chapter = chapter(), isRetryLoading = false): Promis
     render: () => h(VApp, () => [h(Item, {
       chapter: value,
       retryLoading: isRetryLoading,
+      selectable: false,
       onRetry: vi.fn(),
     })]),
   })
@@ -70,6 +71,7 @@ describe('comicsChaptersItem', () => {
       render: () => h(VApp, () => [h(Item, {
         chapter: chapter({ download: -1 }),
         retryLoading: false,
+        selectable: false,
         onRetry,
       })]),
     })

--- a/web/app/features/comics/components/Chapters/Item.test.ts
+++ b/web/app/features/comics/components/Chapters/Item.test.ts
@@ -82,4 +82,93 @@ describe('comicsChaptersItem', () => {
 
     expect(onRetry).toHaveBeenCalled()
   })
+
+  it('renders selectable checkbox and toggles selection on click', async () => {
+    const onUpdateSelected = vi.fn()
+    const wrapper = await mountSuspended({
+      render: () => h(VApp, () => [h(Item, {
+        'chapter': chapter(),
+        'retryLoading': false,
+        'updateProgressLoading': false,
+        'selectable': true,
+        'selected': false,
+        'onUpdate:selected': onUpdateSelected,
+      })]),
+    })
+
+    const icon = wrapper.find('.v-icon[class*="fa6-regular:square"], .v-icon')
+    expect(icon.exists()).toBe(true)
+
+    await wrapper.find('.readable-chapter').trigger('click')
+    expect(onUpdateSelected).toHaveBeenCalledWith(true)
+  })
+
+  it('does not toggle selection when disabled', async () => {
+    const onUpdateSelected = vi.fn()
+    const wrapper = await mountSuspended({
+      render: () => h(VApp, () => [h(Item, {
+        'chapter': chapter(),
+        'retryLoading': false,
+        'updateProgressLoading': false,
+        'selectable': true,
+        'selected': false,
+        'disabled': true,
+        'onUpdate:selected': onUpdateSelected,
+      })]),
+    })
+
+    await wrapper.find('.readable-chapter').trigger('click')
+    expect(onUpdateSelected).not.toHaveBeenCalled()
+  })
+
+  it('shows progress loading indicator when updateProgressLoading is true', async () => {
+    const wrapper = await mountSuspended({
+      render: () => h(VApp, () => [h(Item, {
+        chapter: chapter(),
+        retryLoading: false,
+        updateProgressLoading: true,
+        selectable: false,
+      })]),
+    })
+
+    expect(wrapper.findComponent(VProgressCircular).exists()).toBe(true)
+  })
+
+  it('emits updateProgress with read when chapter is unread', async () => {
+    const onUpdateProgress = vi.fn()
+    const wrapper = await mountSuspended({
+      render: () => h(VApp, () => [h(Item, {
+        chapter: chapter({ progress: undefined }),
+        retryLoading: false,
+        updateProgressLoading: false,
+        selectable: false,
+        onUpdateProgress,
+      })]),
+    })
+
+    const eyeIcons = wrapper.findAll('.v-icon')
+    const progressIcon = eyeIcons.at(-1)
+    await progressIcon?.trigger('click')
+
+    expect(onUpdateProgress).toHaveBeenCalledWith('read')
+  })
+
+  it('emits updateProgress with unread when chapter is read', async () => {
+    const onUpdateProgress = vi.fn()
+    const wrapper = await mountSuspended({
+      render: () => h(VApp, () => [h(Item, {
+        chapter: chapter({ progress: { page: 20, updatedAt: new Date() } }),
+        retryLoading: false,
+        updateProgressLoading: false,
+        selectable: false,
+        onUpdateProgress,
+      })]),
+    })
+
+    const eyeIcons = wrapper.findAll('.v-icon')
+    const progressIcon = eyeIcons.at(-1)
+    await progressIcon?.trigger('click')
+
+    expect(onUpdateProgress).toHaveBeenCalledWith('unread')
+  })
 })

--- a/web/app/features/comics/components/Chapters/Item.vue
+++ b/web/app/features/comics/components/Chapters/Item.vue
@@ -6,9 +6,13 @@ import { formatRelativeTime } from '~/utils/date.utils'
 const props = defineProps<{
   chapter: Chapter
   retryLoading: boolean
+  selectable: boolean
+  disabled?: boolean
 }>()
 
 defineEmits<{ retry: [] }>()
+
+const isSelected = defineModel<boolean>('selected', { required: false, default: false })
 
 const { locale } = useI18n()
 
@@ -36,12 +40,22 @@ const isChapterDownloaded = computed(() => props.chapter.download === 100)
 const isChapterDownloadingError = computed(() => props.chapter.download === -1 && !props.retryLoading)
 
 const to = computed(() => {
-  if (props.chapter.download !== 100) {
+  if (props.chapter.download !== 100 || props.disabled || props.selectable) {
     return
   }
 
   return `/comic/${props.chapter.comicId}/${props.chapter.id}`
 })
+
+function handleClick(): void {
+  if (props.disabled) {
+    return
+  }
+
+  if (props.selectable) {
+    isSelected.value = !isSelected.value
+  }
+}
 </script>
 
 <template>
@@ -51,7 +65,9 @@ const to = computed(() => {
       :class="{
         'early-access-chapter': isEarlyAccess,
         'readable-chapter': !isEarlyAccess,
+        'cursor-pointer': !props.disabled,
       }"
+      @click="handleClick"
     >
       <div class="d-flex align-center ga-4">
         <div v-if="isEarlyAccess" class="d-flex flex-column items-center justify-center border-thin-gold pa-2 text-body-small rounded-lg early-access-icon">
@@ -119,7 +135,12 @@ const to = computed(() => {
           width="2"
           color="error"
         />
-        <span class="text-body-medium text-medium-emphasis" :class="{ 'text-gold': isEarlyAccess }">{{ date }}</span>
+        <VIcon v-if="props.selectable" :icon="isSelected ? 'fa6-solid:square-check' : 'fa6-regular:square'" />
+        <span
+          v-else
+          class="text-body-medium text-medium-emphasis"
+          :class="{ 'text-gold': isEarlyAccess }"
+        >{{ date }}</span>
       </div>
     </div>
   </AtomLink>

--- a/web/app/features/comics/components/Chapters/Item.vue
+++ b/web/app/features/comics/components/Chapters/Item.vue
@@ -6,11 +6,15 @@ import { formatRelativeTime } from '~/utils/date.utils'
 const props = defineProps<{
   chapter: Chapter
   retryLoading: boolean
+  updateProgressLoading: boolean
   selectable: boolean
   disabled?: boolean
 }>()
 
-defineEmits<{ retry: [] }>()
+defineEmits<{
+  retry: []
+  updateProgress: [mode: 'read' | 'unread']
+}>()
 
 const isSelected = defineModel<boolean>('selected', { required: false, default: false })
 
@@ -136,11 +140,27 @@ function handleClick(): void {
           color="error"
         />
         <VIcon v-if="props.selectable" :icon="isSelected ? 'fa6-solid:square-check' : 'fa6-regular:square'" />
-        <span
-          v-else
-          class="text-body-medium text-medium-emphasis"
-          :class="{ 'text-gold': isEarlyAccess }"
-        >{{ date }}</span>
+        <template v-else>
+          <span
+            class="text-body-medium text-medium-emphasis"
+            :class="{ 'text-gold': isEarlyAccess }"
+          >{{ date }}</span>
+
+          <VProgressCircular
+            v-if="props.updateProgressLoading"
+            indeterminate
+            size="18"
+            width="2"
+            color="primary"
+          />
+          <VIcon
+            v-else
+            :icon="chapter.progress && chapter.progress.page > 1 ? 'fa6-solid:eye' : 'fa6-solid:eye-low-vision'"
+            class="cursor-pointer"
+            color="surfaceVariant"
+            @click.prevent="$emit('updateProgress', (chapter.progress && chapter.progress.page > 1 ? 'unread' : 'read') as 'read' | 'unread')"
+          />
+        </template>
       </div>
     </div>
   </AtomLink>

--- a/web/app/features/comics/components/Chapters/index.test.ts
+++ b/web/app/features/comics/components/Chapters/index.test.ts
@@ -6,13 +6,15 @@ import type { Chapter } from '~/features/chapters/types'
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
-import { VApp } from 'vuetify/components'
+import { VApp, VIcon } from 'vuetify/components'
 import Chapters from './index.vue'
 
-const { getByComicId, getByIds, retryDownload, pause, resume } = vi.hoisted(() => ({
+const { getByComicId, getByIds, retryDownload, saveProgress, deleteProgress, pause, resume } = vi.hoisted(() => ({
   getByComicId: vi.fn(),
   getByIds: vi.fn(),
   retryDownload: vi.fn(),
+  saveProgress: vi.fn(),
+  deleteProgress: vi.fn(),
   pause: vi.fn(),
   resume: vi.fn(),
 }))
@@ -21,8 +23,10 @@ function chaptersApiStub(): {
   getByComicId: typeof getByComicId
   getByIds: typeof getByIds
   retryDownload: typeof retryDownload
+  saveProgress: typeof saveProgress
+  deleteProgress: typeof deleteProgress
 } {
-  return { getByComicId, getByIds, retryDownload }
+  return { getByComicId, getByIds, retryDownload, saveProgress, deleteProgress }
 }
 
 function intervalStub(_fn: () => void): { pause: typeof pause, resume: typeof resume } {
@@ -41,8 +45,30 @@ const ItemStub = defineComponent({
     selectable: { type: Boolean, default: false },
     disabled: { type: Boolean, default: false },
   },
-  emits: ['retry', 'update:selected'],
-  template: '<button data-test="chapter" @click="$emit(\'retry\')">{{ chapter.number }}</button>',
+  emits: ['retry', 'update:selected', 'updateProgress'],
+  template: `
+    <div>
+      <button data-test="chapter" @click="$emit('retry')">{{ chapter.number }}</button>
+      <button data-test="toggle-select" @click="$emit('update:selected')">Select {{ chapter.number }}</button>
+      <button data-test="mark-read" @click="$emit('updateProgress', 'read')">Read {{ chapter.number }}</button>
+      <button data-test="mark-unread" @click="$emit('updateProgress', 'unread')">Unread {{ chapter.number }}</button>
+    </div>
+  `,
+})
+
+const ActionsStub = defineComponent({
+  name: 'ComicsChaptersActions',
+  props: {
+    comicId: { type: String, required: true },
+    modelValue: { type: Array, required: true },
+  },
+  emits: ['refetchChapters', 'update:modelValue'],
+  template: '<div data-test="actions-component"><button data-test="action-refetch" @click="$emit(\'refetchChapters\', true)">Action</button></div>',
+})
+
+const ContinueStub = defineComponent({
+  name: 'ComicsChaptersContinue',
+  template: '<div data-test="continue-stub" />',
 })
 
 function chapter(overrides: Partial<Chapter> = {}): Chapter {
@@ -74,13 +100,15 @@ describe('selectableChapters logic in Chapters', () => {
   })
 })
 
-async function mount(id = 'c1'): Promise<VueWrapper> {
+async function mount(id = 'c1', onRefetchProgress = vi.fn()): Promise<VueWrapper> {
   return mountSuspended(
-    { render: () => h(VApp, () => [h(Chapters, { id })]) },
+    { render: () => h(VApp, () => [h(Chapters, { id, onRefetchProgress })]) },
     {
       global: {
         stubs: {
           ComicsChaptersItem: ItemStub,
+          ComicsChaptersActions: ActionsStub,
+          ComicsChaptersContinue: ContinueStub,
           VVirtualScroll: false,
         },
       },
@@ -92,11 +120,15 @@ beforeEach(() => {
   getByComicId.mockReset()
   getByIds.mockReset()
   retryDownload.mockReset()
+  saveProgress.mockReset()
+  deleteProgress.mockReset()
   pause.mockReset()
   resume.mockReset()
   getByComicId.mockResolvedValue({ success: true, data: [] })
   getByIds.mockResolvedValue({ success: true, data: [] })
   retryDownload.mockResolvedValue({ success: true, data: undefined })
+  saveProgress.mockResolvedValue({ success: true, data: { page: 10, updatedAt: new Date() } })
+  deleteProgress.mockResolvedValue({ success: true, data: undefined })
 })
 
 describe('comicsChapters', () => {
@@ -145,5 +177,71 @@ describe('comicsChapters', () => {
     await wrapper.find('[data-test="chapter"]').trigger('click')
 
     expect(retryDownload).toHaveBeenCalledWith('ch-1')
+  })
+
+  it('marks a chapter as read and emits refetchProgress', async () => {
+    const onRefetchProgress = vi.fn()
+    getByComicId.mockResolvedValue({ success: true, data: [chapter({ id: 'ch-1', pagesNb: 10 })] })
+    const wrapper = await mount('c1', onRefetchProgress)
+    await vi.waitFor(() => expect(wrapper.find('[data-test="mark-read"]').exists()).toBe(true))
+
+    await wrapper.find('[data-test="mark-read"]').trigger('click')
+
+    expect(saveProgress).toHaveBeenCalledWith({ id: 'ch-1', page: 10 })
+    expect(onRefetchProgress).toHaveBeenCalled()
+  })
+
+  it('marks a chapter as unread and emits refetchProgress', async () => {
+    const onRefetchProgress = vi.fn()
+    getByComicId.mockResolvedValue({
+      success: true,
+      data: [chapter({ id: 'ch-1', pagesNb: 10, progress: { page: 10, updatedAt: new Date() } })],
+    })
+    const wrapper = await mount('c1', onRefetchProgress)
+    await vi.waitFor(() => expect(wrapper.find('[data-test="mark-unread"]').exists()).toBe(true))
+
+    await wrapper.find('[data-test="mark-unread"]').trigger('click')
+
+    expect(deleteProgress).toHaveBeenCalledWith('ch-1')
+    expect(onRefetchProgress).toHaveBeenCalled()
+  })
+
+  it('selects and deselects all selectable chapters when clicking the select-all icon', async () => {
+    getByComicId.mockResolvedValue({
+      success: true,
+      data: [
+        chapter({ id: 'ch-1', number: 1 }),
+        chapter({ id: 'ch-2', number: 2 }),
+      ],
+    })
+    const wrapper = await mount()
+    await vi.waitFor(() => expect(wrapper.findAll('[data-test="chapter"]').length).toBe(2))
+
+    // Click select all
+    const selectAllIcon = wrapper.findAllComponents(VIcon).find(icon => icon.props('size') === 'large')!
+    await selectAllIcon.trigger('click')
+
+    // Actions component should now be rendered
+    expect(wrapper.find('[data-test="actions-component"]').exists()).toBe(true)
+
+    // Click select all again to deselect
+    const deselectAllIcon = wrapper.findAllComponents(VIcon).find(icon => icon.props('size') === 'large')!
+    await deselectAllIcon.trigger('click')
+    expect(wrapper.find('[data-test="actions-component"]').exists()).toBe(false)
+  })
+
+  it('toggles selection on an individual chapter', async () => {
+    getByComicId.mockResolvedValue({
+      success: true,
+      data: [chapter({ id: 'ch-1', number: 1 })],
+    })
+    const wrapper = await mount()
+    await vi.waitFor(() => expect(wrapper.find('[data-test="toggle-select"]').exists()).toBe(true))
+
+    await wrapper.find('[data-test="toggle-select"]').trigger('click')
+    expect(wrapper.find('[data-test="actions-component"]').exists()).toBe(true)
+
+    await wrapper.find('[data-test="toggle-select"]').trigger('click')
+    expect(wrapper.find('[data-test="actions-component"]').exists()).toBe(false)
   })
 })

--- a/web/app/features/comics/components/Chapters/index.test.ts
+++ b/web/app/features/comics/components/Chapters/index.test.ts
@@ -37,8 +37,11 @@ const ItemStub = defineComponent({
   props: {
     chapter: { type: Object, required: true },
     retryLoading: { type: Boolean, default: false },
+    selected: { type: Boolean, default: false },
+    selectable: { type: Boolean, default: false },
+    disabled: { type: Boolean, default: false },
   },
-  emits: ['retry'],
+  emits: ['retry', 'update:selected'],
   template: '<button data-test="chapter" @click="$emit(\'retry\')">{{ chapter.number }}</button>',
 })
 
@@ -55,6 +58,21 @@ function chapter(overrides: Partial<Chapter> = {}): Chapter {
     ...overrides,
   }
 }
+
+describe('selectableChapters logic in Chapters', () => {
+  it('filters out early access chapters in the future but keeps past early access and regular chapters', () => {
+    const pastEarlyAccess = new Date(Date.now() - 3600_000)
+    const futureEarlyAccess = new Date(Date.now() + 3600_000)
+    const chList = [
+      chapter({ id: 'ch-1', number: 1, earlyAccessUntil: pastEarlyAccess }),
+      chapter({ id: 'ch-2', number: 2, earlyAccessUntil: futureEarlyAccess }),
+      chapter({ id: 'ch-3', number: 3 }),
+    ]
+
+    const selectable = chList.filter(({ earlyAccessUntil }) => !earlyAccessUntil || earlyAccessUntil < new Date())
+    expect(selectable.map(c => c.id)).toEqual(['ch-1', 'ch-3'])
+  })
+})
 
 async function mount(id = 'c1'): Promise<VueWrapper> {
   return mountSuspended(
@@ -106,7 +124,7 @@ describe('comicsChapters', () => {
 
     expect(wrapper.text()).toContain('Latest')
 
-    await wrapper.findAll('button').at(0)!.trigger('click')
+    await wrapper.findAll('button').find(b => b.text().includes('Latest'))!.trigger('click')
 
     expect(wrapper.text()).toContain('Oldest')
     expect(wrapper.findAll('[data-test="chapter"]').map(n => n.text())).toEqual(['1', '2'])

--- a/web/app/features/comics/components/Chapters/index.test.ts
+++ b/web/app/features/comics/components/Chapters/index.test.ts
@@ -61,8 +61,8 @@ function chapter(overrides: Partial<Chapter> = {}): Chapter {
 
 describe('selectableChapters logic in Chapters', () => {
   it('filters out early access chapters in the future but keeps past early access and regular chapters', () => {
-    const pastEarlyAccess = new Date(Date.now() - 3600_000)
-    const futureEarlyAccess = new Date(Date.now() + 3600_000)
+    const pastEarlyAccess = new Date(Date.now() - 3_600_000)
+    const futureEarlyAccess = new Date(Date.now() + 3_600_000)
     const chList = [
       chapter({ id: 'ch-1', number: 1, earlyAccessUntil: pastEarlyAccess }),
       chapter({ id: 'ch-2', number: 2, earlyAccessUntil: futureEarlyAccess }),

--- a/web/app/features/comics/components/Chapters/index.vue
+++ b/web/app/features/comics/components/Chapters/index.vue
@@ -133,10 +133,6 @@ async function retryChapter(chapterId: string): Promise<void> {
 }
 
 const nextChapter = computed(() => {
-  if (!props.continue) {
-    return
-  }
-
   const chaptersCpy = sort.value === 'asc' ? chapters.value : chapters.value.toSorted((a, b) => a.number - b.number)
   const continueCpy = props.continue
 

--- a/web/app/features/comics/components/Chapters/index.vue
+++ b/web/app/features/comics/components/Chapters/index.vue
@@ -143,6 +143,74 @@ const sortText = computed(() => {
   return sort.value === 'asc' ? $t('common.sort.oldest') : $t('common.sort.latest')
 })
 
+const updateProgressLoading = ref<Record<string, boolean>>({})
+async function updateProgress(chapterId: string, mode: 'read' | 'unread'): Promise<void> {
+  if (updateProgressLoading.value[chapterId]) {
+    return
+  }
+
+  updateProgressLoading.value[chapterId] = true
+
+  let success = false
+
+  switch (mode) {
+    case 'read':
+      success = await setChapterRead(chapterId)
+      break
+    case 'unread':
+      success = await setChapterUnread(chapterId)
+      break
+  }
+
+  if (success) {
+    emit('refetchProgress')
+  }
+
+  delete updateProgressLoading.value[chapterId]
+}
+
+async function setChapterRead(chapterId: string): Promise<boolean> {
+  const index = chapters.value.findIndex(chapter => chapter.id === chapterId)
+  if (index === -1) {
+    return false
+  }
+
+  const res = await api.saveProgress({
+    id: chapterId,
+    page: chapters.value[index]!.pagesNb,
+  })
+
+  if (!res.success) {
+    console.error('chaptersApi.saveProgress', res.error)
+    toast.error(t('error.unknown'))
+
+    return false
+  }
+
+  chapters.value[index]!.progress = res.data
+
+  return true
+}
+
+async function setChapterUnread(chapterId: string): Promise<boolean> {
+  const index = chapters.value.findIndex(chapter => chapter.id === chapterId)
+  if (index === -1) {
+    return false
+  }
+
+  const res = await api.deleteProgress(chapterId)
+  if (!res.success) {
+    console.error('chaptersApi.deleteProgress', res.error)
+    toast.error(t('error.unknown'))
+
+    return false
+  }
+
+  chapters.value[index]!.progress = undefined
+
+  return true
+}
+
 const selectedChapters = ref<Chapter[]>([])
 const selectableChapters = computed(() => sortedChapters.value.filter(({ earlyAccessUntil }) => !earlyAccessUntil || earlyAccessUntil < new Date()))
 const selectAllChaptersIcon = computed(() => {
@@ -262,7 +330,9 @@ function onSelectionAction(updateContinue: boolean): void {
           :selectable="selectedChapters.length > 0"
           :selected="selectedChapters.some(chapter => chapter.id === item.id)"
           :retry-loading="!!retryChaptersLoading[item.id]"
+          :update-progress-loading="!!updateProgressLoading[item.id]"
           @update:selected="toggleSelectChapter(item.id)"
+          @update-progress="updateProgress(item.id, $event)"
           @retry="retryChapter(item.id)"
         />
       </template>

--- a/web/app/features/comics/components/Chapters/index.vue
+++ b/web/app/features/comics/components/Chapters/index.vue
@@ -8,6 +8,8 @@ const props = defineProps<{
   continue?: ComicProgressContinue
 }>()
 
+const emit = defineEmits<{ refetchProgress: [] }>()
+
 const POLL_INTERVAL_MS = 2000
 
 const { t } = useI18n()
@@ -132,37 +134,6 @@ async function retryChapter(chapterId: string): Promise<void> {
   delete retryChaptersLoading.value[chapterId]
 }
 
-const nextChapter = computed(() => {
-  const chaptersCpy = sort.value === 'asc' ? chapters.value : chapters.value.toSorted((a, b) => a.number - b.number)
-  const continueCpy = props.continue
-
-  if (!continueCpy) {
-    return chaptersCpy[0] as Chapter
-  }
-
-  const i = chaptersCpy.findIndex(chapter => chapter.id === continueCpy.chapterId)
-  if (i === -1) {
-    return
-  }
-
-  if (continueCpy.page === chaptersCpy[i]!.pagesNb) {
-    if (i === chaptersCpy.length - 1) {
-      return
-    }
-
-    return chaptersCpy[i + 1] as Chapter
-  }
-
-  return chaptersCpy[i] as Chapter
-})
-const nextChapterText = computed(() => {
-  if (!nextChapter.value || smAndDown.value) {
-    return
-  }
-
-  return nextChapter.value.number === 1 ? $t('common.start') : $t('common.continue')
-})
-
 const sortIcon = computed(() => sort.value === 'asc' ? 'fa6-solid:arrow-down-short-wide' : 'fa6-solid:arrow-up-short-wide')
 const sortText = computed(() => {
   if (smAndDown.value) {
@@ -171,34 +142,106 @@ const sortText = computed(() => {
 
   return sort.value === 'asc' ? $t('common.sort.oldest') : $t('common.sort.latest')
 })
+
+const selectedChapters = ref<Chapter[]>([])
+const selectableChapters = computed(() => sortedChapters.value.filter(({ earlyAccessUntil }) => !earlyAccessUntil || earlyAccessUntil < new Date()))
+const selectAllChaptersIcon = computed(() => {
+  if (!selectedChapters.value.length || selectableChapters.value.length === 0) {
+    return 'fa6-regular:square'
+  }
+
+  if (selectableChapters.value.length > 0 && selectedChapters.value.length === selectableChapters.value.length) {
+    return 'fa6-solid:square-check'
+  }
+
+  return 'fa6-solid:square-minus'
+})
+
+function toggleSelectAllChapters(): void {
+  if (selectedChapters.value.length === selectableChapters.value.length) {
+    selectedChapters.value = []
+
+    return
+  }
+
+  selectedChapters.value = [...selectableChapters.value]
+}
+
+function toggleSelectChapter(chapterId: string): void {
+  const chapter = chapters.value.find(chapter => chapter.id === chapterId)
+  if (!chapter || (chapter.earlyAccessUntil && chapter.earlyAccessUntil > new Date())) {
+    return
+  }
+
+  if (selectedChapters.value.some(chapter => chapter.id === chapterId)) {
+    selectedChapters.value = selectedChapters.value.filter(chapter => chapter.id !== chapterId)
+  } else {
+    selectedChapters.value.push(chapters.value.find(chapter => chapter.id === chapterId)!)
+  }
+}
+
+function onSelectionAction(updateContinue: boolean): void {
+  if (updateContinue) {
+    emit('refetchProgress')
+  }
+
+  fetchChapters()
+}
 </script>
 
 <template>
   <div class="d-flex flex-column w-100 position-relative bg-surface" style="border-radius: 12px; max-height: 40rem;">
-    <div class="d-flex justify-space-between ga-6 pa-4 border-b-thin bg-surface align-center" style="z-index: 1; border-top-left-radius: 12px; border-top-right-radius: 12px;">
+    <div
+      v-if="selectedChapters.length === 0"
+      class="d-flex justify-space-between ga-6 pa-4 border-b-thin bg-surface align-center"
+      style="z-index: 1; border-top-left-radius: 12px; border-top-right-radius: 12px;"
+    >
       <span class="text-title-large font-weight-bold">{{ $t('sources.asurascans.comic.chaptersCount', { count: chapters.length }) }}</span>
-      <AtomLink
-        v-if="nextChapter"
-        :to="nextChapter && nextChapter.download === 100 ? `/comic/${props.id}/${nextChapter.id}` : undefined"
-      >
+      <ComicsChaptersContinue
+        :comic-id="props.id"
+        :continue="props.continue"
+        :chapters="sortedChapters"
+        :sort
+      />
+
+      <div class="d-flex align-center ga-4">
         <VBtn
           variant="tonal"
-          class="border-thin-primary"
-          :icon="smAndDown ? 'fa6-solid:play' : undefined"
-          :prepend-icon="smAndDown ? undefined : 'fa6-solid:play'"
-          :text="nextChapterText"
+          class="text-body-medium"
+          color="surfaceVariant"
+          :icon="smAndDown ? sortIcon : undefined"
+          :text="sortText"
           :size="smAndDown ? 'small' : undefined"
+          :prepend-icon="smAndDown ? undefined : sortIcon"
+          @click="sort = sort === 'asc' ? 'desc' : 'asc'"
         />
-      </AtomLink>
-      <VBtn
-        variant="tonal"
-        class="text-body-medium"
-        color="surfaceVariant"
-        :icon="smAndDown ? sortIcon : undefined"
-        :text="sortText"
-        :size="smAndDown ? 'small' : undefined"
-        :prepend-icon="smAndDown ? undefined : sortIcon"
-        @click="sort = sort === 'asc' ? 'desc' : 'asc'"
+
+        <VIcon
+          :icon="selectAllChaptersIcon"
+          cursor="pointer"
+          size="large"
+          @click="toggleSelectAllChapters"
+        />
+      </div>
+    </div>
+    <div
+      v-else
+      class="d-flex ga-6 pa-4 border-b-thin bg-surface align-center"
+      style="z-index: 1; border-top-left-radius: 12px; border-top-right-radius: 12px;"
+    >
+      <div class="d-flex align-center w-100 justify-center">
+        <ComicsChaptersActions
+          v-model="selectedChapters"
+          :comic-id="props.id"
+          @refetch-chapters="onSelectionAction"
+        />
+      </div>
+
+      <VIcon
+        :icon="selectAllChaptersIcon"
+        cursor="pointer"
+        size="large"
+        @click="toggleSelectAllChapters"
       />
     </div>
 
@@ -215,7 +258,11 @@ const sortText = computed(() => {
       <template #default="{ item }">
         <ComicsChaptersItem
           :chapter="item"
+          :disabled="item.earlyAccessUntil && item.earlyAccessUntil > new Date() && selectedChapters.length > 0"
+          :selectable="selectedChapters.length > 0"
+          :selected="selectedChapters.some(chapter => chapter.id === item.id)"
           :retry-loading="!!retryChaptersLoading[item.id]"
+          @update:selected="toggleSelectChapter(item.id)"
           @retry="retryChapter(item.id)"
         />
       </template>

--- a/web/app/features/comics/composables/comics.api.test.ts
+++ b/web/app/features/comics/composables/comics.api.test.ts
@@ -150,3 +150,94 @@ describe('createComicsApi().search', () => {
     expect(res.success === false && res.error.status).toBe(502)
   })
 })
+
+describe('createComicsApi().refreshById', () => {
+  it('posts to /:id/refresh and returns the refreshed comic', async () => {
+    call.mockResolvedValue(comic)
+
+    const res = await createComicsApi().refreshById('c1')
+
+    expect(call).toHaveBeenCalledWith('/c1/refresh', { method: 'POST' })
+    expect(res).toEqual({ success: true, data: comic })
+  })
+
+  it('surfaces a failure with its status', async () => {
+    call.mockRejectedValue({ statusCode: 500, data: {} })
+
+    const res = await createComicsApi().refreshById('c1')
+
+    expect(res.success === false && res.error.status).toBe(500)
+  })
+})
+
+describe('createComicsApi().getProgress', () => {
+  it('gets the comic progress by id', async () => {
+    const progressData = { continue: { chapterId: 'ch-1', page: 5 } }
+    call.mockResolvedValue(progressData)
+
+    const res = await createComicsApi().getProgress('c1')
+
+    expect(call).toHaveBeenCalledWith('/c1/progress', { method: 'GET' })
+    expect(res).toEqual({ success: true, data: { continue: progressData.continue } })
+  })
+
+  it('surfaces a failure with its status', async () => {
+    call.mockRejectedValue({ statusCode: 404, data: {} })
+
+    const res = await createComicsApi().getProgress('c1')
+
+    expect(res.success === false && res.error.status).toBe(404)
+  })
+})
+
+describe('createComicsApi().setChaptersProgress', () => {
+  it('posts chapter progress updates to /:comicId/progress', async () => {
+    call.mockResolvedValue(undefined)
+
+    const res = await createComicsApi().setChaptersProgress({
+      comicId: 'c1',
+      chapterIds: ['ch-1', 'ch-2'],
+      read: true,
+    })
+
+    expect(call).toHaveBeenCalledWith('/c1/progress', {
+      method: 'POST',
+      body: { chapterIds: ['ch-1', 'ch-2'], read: true },
+    })
+    expect(res).toEqual({ success: true, data: undefined })
+  })
+
+  it('surfaces a failure with its status', async () => {
+    call.mockRejectedValue({ statusCode: 400, data: {} })
+
+    const res = await createComicsApi().setChaptersProgress({
+      comicId: 'c1',
+      chapterIds: ['ch-1'],
+      read: false,
+    })
+
+    expect(res.success === false && res.error.status).toBe(400)
+  })
+})
+
+describe('createComicsApi().retryChaptersDownload', () => {
+  it('posts retry request to /:comicId/retry', async () => {
+    call.mockResolvedValue(undefined)
+
+    const res = await createComicsApi().retryChaptersDownload('c1', ['ch-1', 'ch-2'])
+
+    expect(call).toHaveBeenCalledWith('/c1/retry', {
+      method: 'POST',
+      body: { chapterIds: ['ch-1', 'ch-2'] },
+    })
+    expect(res).toEqual({ success: true, data: undefined })
+  })
+
+  it('surfaces a failure with its status', async () => {
+    call.mockRejectedValue({ statusCode: 500, data: {} })
+
+    const res = await createComicsApi().retryChaptersDownload('c1', ['ch-1'])
+
+    expect(res.success === false && res.error.status).toBe(500)
+  })
+})

--- a/web/app/features/comics/composables/comics.api.ts
+++ b/web/app/features/comics/composables/comics.api.ts
@@ -12,6 +12,7 @@ export interface ComicsApi {
   refreshById: (id: string) => Promise<ApiResponse<Comic>>
   getProgress: (id: string) => Promise<ApiResponse<ComicProgress>>
   setChaptersProgress: (params: SetChaptersProgressParams) => Promise<ApiResponse<void>>
+  retryChaptersDownload: (comicId: string, chapterIds: string[]) => Promise<ApiResponse<void>>
 }
 
 export interface CreateComicParams {
@@ -108,6 +109,16 @@ export function createComicsApi(): ComicsApi {
     }
   }
 
+  async function retryChaptersDownload(comicId: string, chapterIds: string[]): Promise<ApiResponse<void>> {
+    try {
+      await api<void>(`/${comicId}/retry`, { method: 'POST', body: { chapterIds } })
+
+      return { success: true, data: undefined }
+    } catch (error) {
+      return { success: false, error: ApiError.fromFetchError(error) }
+    }
+  }
+
   return {
     create,
     deleteById,
@@ -116,5 +127,6 @@ export function createComicsApi(): ComicsApi {
     refreshById,
     getProgress,
     setChaptersProgress,
+    retryChaptersDownload,
   }
 }

--- a/web/app/features/comics/composables/comics.api.ts
+++ b/web/app/features/comics/composables/comics.api.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import type { Comic, ComicProgress, LightComic, SearchComicParams, SearchComicResponse } from '../types'
+import type { Comic, ComicProgress, LightComic, SearchComicParams, SearchComicResponse, SetChaptersProgressParams } from '../types'
 import type { ApiResponse } from '~/utils/api'
 import { ApiError, initApi } from '~/utils/api'
 
@@ -11,6 +11,7 @@ export interface ComicsApi {
   getById: (id: string) => Promise<ApiResponse<Comic>>
   refreshById: (id: string) => Promise<ApiResponse<Comic>>
   getProgress: (id: string) => Promise<ApiResponse<ComicProgress>>
+  setChaptersProgress: (params: SetChaptersProgressParams) => Promise<ApiResponse<void>>
 }
 
 export interface CreateComicParams {
@@ -97,6 +98,16 @@ export function createComicsApi(): ComicsApi {
     }
   }
 
+  async function setChaptersProgress({ comicId, ...body }: SetChaptersProgressParams): Promise<ApiResponse<void>> {
+    try {
+      await api<void>(`/${comicId}/progress`, { method: 'POST', body })
+
+      return { success: true, data: undefined }
+    } catch (error) {
+      return { success: false, error: ApiError.fromFetchError(error) }
+    }
+  }
+
   return {
     create,
     deleteById,
@@ -104,5 +115,6 @@ export function createComicsApi(): ComicsApi {
     getById,
     refreshById,
     getProgress,
+    setChaptersProgress,
   }
 }

--- a/web/app/features/comics/types.ts
+++ b/web/app/features/comics/types.ts
@@ -57,3 +57,9 @@ export interface ComicProgressContinue {
   chapterId: string
   page: number
 }
+
+export interface SetChaptersProgressParams {
+  comicId: string
+  chapterIds: string[]
+  read: boolean
+}

--- a/web/app/features/reader/components/Overlay/Footer/ChaptersMenu.vue
+++ b/web/app/features/reader/components/Overlay/Footer/ChaptersMenu.vue
@@ -115,7 +115,7 @@ async function pollChapters(): Promise<void> {
 <template>
   <VBtn
     prepend-icon="fa6-solid:bars"
-    color="grey"
+    color="surfaceVariant"
     class="border-thin"
     :loading="chaptersLoading"
     :disabled="!chaptersLoading && chapters.length === 0"

--- a/web/app/features/reader/composables/reader.composable.test.ts
+++ b/web/app/features/reader/composables/reader.composable.test.ts
@@ -190,7 +190,7 @@ describe('useReader', () => {
     const { reader } = await setup()
     await waitUntilIdle(reader)
 
-    expect(reader.page.value).toBe(2)
+    expect(reader.page.value).toBe(1)
   })
 
   it('skips restored progress when ignoreProgress is set', async () => {
@@ -288,7 +288,7 @@ describe('useReader', () => {
     saveProgress.mockClear()
 
     reader.page.value = 1
-    await vi.waitFor(() => expect(saveProgress).toHaveBeenCalledWith({ id: 'ch-2', page: 1 }))
+    await vi.waitFor(() => expect(saveProgress).toHaveBeenCalledWith({ id: 'ch-2', page: 2 }))
   })
 
   it('saves the right-hand page when double page is on', async () => {
@@ -303,7 +303,7 @@ describe('useReader', () => {
     saveProgress.mockClear()
 
     reader.page.value = 2
-    await vi.waitFor(() => expect(saveProgress).toHaveBeenCalledWith({ id: 'ch-2', page: 3 }))
+    await vi.waitFor(() => expect(saveProgress).toHaveBeenCalledWith({ id: 'ch-2', page: 4 }))
   })
 
   it('evicts the oldest chapter once more than three are loaded', async () => {
@@ -360,11 +360,11 @@ describe('useReader polling', () => {
     }))
     const { reader } = await setup()
     await waitUntilIdle(reader)
-    expect(reader.page.value).toBe(2)
+    expect(reader.page.value).toBe(1)
     getById.mockResolvedValue(chapterResponse({ download: 40 }))
 
     await vi.waitFor(() => expect(reader.chapter.value?.download).toBe(40), { timeout: 3000 })
-    expect(reader.page.value).toBe(2)
+    expect(reader.page.value).toBe(1)
   })
 
   it('does not poll once the download is complete', async () => {

--- a/web/app/features/reader/composables/reader.composable.ts
+++ b/web/app/features/reader/composables/reader.composable.ts
@@ -129,7 +129,7 @@ export function useReader(opts: ReaderComposableOptions): ReaderComposable {
     }
 
     if (!opts.ignoreProgress?.value && chapter.value.progress) {
-      page.value = chapter.value.progress.page
+      page.value = chapter.value.progress.page - 1
     }
 
     if (opts.ignoreProgress?.value && opts.onAfterProgressIgnored) {
@@ -262,9 +262,10 @@ export function useReader(opts: ReaderComposableOptions): ReaderComposable {
       return
     }
 
-    const actualPage = readerSettings.value.doublePage && value + 1 < chapter.value.pagesNb
-      ? value + 1
-      : value
+    let actualPage = value + 1
+    if (readerSettings.value.doublePage && actualPage < chapter.value.pagesNb) {
+      actualPage++
+    }
 
     if (!chapter.value.progress || chapter.value.progress.page < actualPage) {
       saveProgress(chapter.value.id, actualPage)

--- a/web/app/pages/comic/[id]/index.test.ts
+++ b/web/app/pages/comic/[id]/index.test.ts
@@ -55,8 +55,12 @@ const GeneralStub = defineComponent({
 
 const ChaptersStub = defineComponent({
   name: 'ComicsChapters',
-  props: { id: { type: String, required: true } },
-  template: '<div data-test="chapters">{{ id }}</div>',
+  props: {
+    id: { type: String, required: true },
+    continue: { type: Object, default: undefined },
+  },
+  emits: ['refetchProgress'],
+  template: '<div data-test="chapters"><button data-test="refetch-progress-btn" @click="$emit(\'refetchProgress\')">{{ id }}</button></div>',
 })
 
 const DeleteStub = defineComponent({
@@ -127,8 +131,19 @@ describe('comicPage', () => {
 
     await vi.waitFor(() => expect(wrapper.find('[data-test="status-infos"]').text()).toBe('Solo Leveling'))
     expect(getById).toHaveBeenCalledWith('c1')
+    expect(getProgress).toHaveBeenCalledWith('c1')
     expect(wrapper.find('[data-test="general-infos"]').exists()).toBe(true)
-    expect(wrapper.find('[data-test="chapters"]').text()).toBe('c1')
+    expect(wrapper.find('[data-test="chapters"]').text()).toContain('c1')
+  })
+
+  it('refetches progress when ComicsChapters emits refetchProgress', async () => {
+    const wrapper = await mount()
+    await vi.waitFor(() => expect(wrapper.find('[data-test="status-infos"]').exists()).toBe(true))
+
+    getProgress.mockClear()
+    await wrapper.find('[data-test="refetch-progress-btn"]').trigger('click')
+
+    expect(getProgress).toHaveBeenCalledWith('c1')
   })
 
   it('shows the refresh and remove-from-library actions', async () => {

--- a/web/app/pages/comic/[id]/index.vue
+++ b/web/app/pages/comic/[id]/index.vue
@@ -221,7 +221,11 @@ const showDeleteModal = ref(false)
           :comic
         />
         <ComicsGeneralInfos :comic />
-        <ComicsChapters :id="route.params.id" :continue="continueProgress" />
+        <ComicsChapters
+          :id="route.params.id"
+          :continue="continueProgress"
+          @refetch-progress="fetchProgress"
+        />
       </div>
     </div>
   </OrganismPageLayout>

--- a/web/i18n/locales/en.json
+++ b/web/i18n/locales/en.json
@@ -213,7 +213,9 @@
       "oldest": "Oldest"
     },
     "start": "Start",
-    "continue": "Continue"
+    "continue": "Continue",
+    "actions": "Actions",
+    "upToDate": "Up to date !"
   },
   "role": {
     "admin": "Admin",
@@ -322,8 +324,11 @@
       "download": {
         "error": "Chapter download error",
         "retry": "Retry",
-        "loading": "Chapter downloading..."
-      }
+        "loading": "Chapter downloading...",
+        "retryMany": "Retry download | Retry download (1) | Retry download ({count})"
+      },
+      "setReadMany": "Mark selected as read | Mark selected as read (1) | Mark selected as read ({count})",
+      "setUnreadMany": "Mark selected as not read | Mark selected as not read (1) | Mark selected as not read ({count})"
     },
     "betweenChapters": {
       "current": "Current chapter",

--- a/web/i18n/locales/fr.json
+++ b/web/i18n/locales/fr.json
@@ -213,7 +213,8 @@
       "latest": "Plus récent"
     },
     "start": "Commencer",
-    "continue": "Continuer"
+    "continue": "Continuer",
+    "actions": "Actes"
   },
   "role": {
     "admin": "Administrateur",
@@ -356,8 +357,11 @@
       "download": {
         "error": "Erreur de téléchargement de chapitre",
         "retry": "Réessayer",
-        "loading": "Téléchargement du chapitre..."
-      }
+        "loading": "Téléchargement du chapitre...",
+        "retryMany": "Re-télécharger | Re-télécharger (1) | Re-télécharger ({count})"
+      },
+      "setReadMany": "Marque comme lu | Marque comme lu (1) | Marque comme lu ({count})",
+      "setUnreadMany": "Marquer comme non-lu | Marquer comme non-lu (1) | Marquer comme non-lu ({count})"
     },
     "betweenChapters": {
       "current": "Chapitre actuel",


### PR DESCRIPTION
## Summary

- Introduces selection mode on the library comic page chapter list (`/comic/:id`) with multi-select and select-all capabilities (#96).
- Action bar allowing bulk operations:
  - Mark as read / mark as unread for selected chapters
  - Bulk retry failed chapter downloads via `POST /api/comics/:id/retry`
- Single chapter item action menu for toggling read status and retrying downloads
- Backend APIs & service updates:
  - `POST /api/comics/:id/retry` endpoint to retry downloading specified chapters
  - Support `read` boolean on `POST /api/chapters/:id/progress` and `DELETE /api/chapters/:id/progress`
  - Repository and service methods for batch progress deletions and updates

## Test plan

- [x] Selection mode is off by default; toggle button in header enables it
- [x] Select all selects all chapters in the list (including locked or not downloaded)
- [x] Clicking a row in selection mode toggles selection only without navigating
- [x] Bulk mark as read / unread updates chapter progress and exits selection mode
- [x] Bulk retry triggers retry download for selected chapters
- [x] Individual chapter actions (mark read/unread, retry) work as expected
- [x] Backend Go tests pass (`go test ./...`)
- [x] Frontend tests and checks pass (`pnpm test`, `pnpm typecheck`, `pnpm lint`, `pnpm knip`)

Closes #96