### PR TITLE
style(comic): refactor mobile comic page

### DIFF
--- a/web/app/components/Organism/PageLayout.vue
+++ b/web/app/components/Organism/PageLayout.vue
@@ -44,7 +44,7 @@ const { height: headerHeight } = useElementSize(headerRef, undefined, { box: 'bo
   >
     <div
       ref="headerRef"
-      class="d-flex flex-column ga-2 pt-4 bg-background page-layout__sticky-header"
+      class="d-flex flex-column ga-2 bg-background page-layout__sticky-header"
       :class="{ 'pt-4': !smAndDown }"
     >
       <div

--- a/web/app/features/comics/components/Chapters/Continue.vue
+++ b/web/app/features/comics/components/Chapters/Continue.vue
@@ -36,10 +36,6 @@ const nextChapter = computed(() => {
 })
 
 const nextChapterText = computed(() => {
-  if (smAndDown.value) {
-    return
-  }
-
   if (!nextChapter.value) {
     return $t('common.upToDate')
   }
@@ -69,8 +65,7 @@ const icon = computed(() => {
     <VBtn
       :variant="nextChapter ? 'tonal' : 'outlined'"
       :class="{ 'border-thin-primary': nextChapter }"
-      :icon="smAndDown ? icon : undefined"
-      :prepend-icon="smAndDown ? undefined : icon"
+      :prepend-icon="icon"
       :text="nextChapterText"
       :readonly="!nextChapter"
       :color="nextChapter ? 'primary' : 'secondary'"

--- a/web/app/features/comics/components/Chapters/index.vue
+++ b/web/app/features/comics/components/Chapters/index.vue
@@ -261,7 +261,11 @@ function onSelectionAction(updateContinue: boolean): void {
   <div class="d-flex flex-column w-100 position-relative bg-surface" style="border-radius: 12px; max-height: 40rem;">
     <div
       v-if="selectedChapters.length === 0"
-      class="d-flex justify-space-between ga-6 pa-4 border-b-thin bg-surface align-center"
+      class="d-flex justify-space-between pa-4 border-b-thin bg-surface align-center"
+      :class="{
+        'ga-6': !smAndDown,
+        'ga-4': smAndDown,
+      }"
       style="z-index: 1; border-top-left-radius: 12px; border-top-right-radius: 12px;"
     >
       <span class="text-title-large font-weight-bold">{{ $t('sources.asurascans.comic.chaptersCount', { count: chapters.length }) }}</span>
@@ -274,6 +278,7 @@ function onSelectionAction(updateContinue: boolean): void {
 
       <div class="d-flex align-center ga-4">
         <VBtn
+          v-if="!smAndDown"
           variant="tonal"
           class="text-body-medium"
           color="surfaceVariant"
@@ -287,7 +292,7 @@ function onSelectionAction(updateContinue: boolean): void {
         <VIcon
           :icon="selectAllChaptersIcon"
           cursor="pointer"
-          size="large"
+          :size="smAndDown ? 'default' : 'large'"
           @click="toggleSelectAllChapters"
         />
       </div>

--- a/web/app/features/comics/components/Chip/Source.vue
+++ b/web/app/features/comics/components/Chip/Source.vue
@@ -17,7 +17,7 @@ const details = computed(() => getSourceDetails(props.source))
     :src="details.image"
     aspect-ratio="1"
     width="31"
-    class="rounded-lg"
+    class="rounded-lg w-fit"
     :style="{ border: `1px solid ${details.color}C8` }"
   />
   <div
@@ -29,6 +29,7 @@ const details = computed(() => getSourceDetails(props.source))
       :src="details.image"
       aspect-ratio="1"
       width="20"
+      height="20"
       class="rounded-lg"
     />
     <span class="text-body-large text-truncate">{{ details.name }}</span>

--- a/web/app/features/comics/components/Chip/Type.vue
+++ b/web/app/features/comics/components/Chip/Type.vue
@@ -2,12 +2,19 @@
 <script setup lang="ts">
 import type { ComicType } from '../../types'
 
-defineProps<{ type: ComicType }>()
+withDefaults(defineProps<{
+  type: ComicType
+  size?: 'default' | 'small'
+}>(), { size: 'default' })
 </script>
 
 <template>
   <span
-    class="ga-3 w-fit px-2 py-1 border-thin text-body-large text-truncate text-uppercase bg-background"
+    class="ga-3 w-fit h-fit px-2 py-1 border-thin text-truncate text-uppercase bg-background"
+    :class="{
+      'text-body-large': size === 'default',
+      'text-body-medium': size === 'small',
+    }"
     :style="{ borderRadius: '12px' }"
   >
     <span class="">{{ $t(`sources.asura.type.${type}`) }}</span>

--- a/web/app/pages/comic/[id]/index.test.ts
+++ b/web/app/pages/comic/[id]/index.test.ts
@@ -150,8 +150,8 @@ describe('comicPage', () => {
     const wrapper = await mount()
 
     await vi.waitFor(() => expect(wrapper.find('[data-test="status-infos"]').exists()).toBe(true))
-    expect(buttons(wrapper).some(btn => (btn as any).props('icon') === 'fa6-solid:repeat')).toBe(true)
-    expect(buttons(wrapper).some(btn => (btn as any).props('icon') === 'fa6-solid:trash' && (btn as any).props('color') === 'error')).toBe(true)
+    expect(buttons(wrapper).some(btn => (btn as any).props('prependIcon') === 'fa6-solid:repeat')).toBe(true)
+    expect(buttons(wrapper).some(btn => (btn as any).props('prependIcon') === 'fa6-solid:trash' && (btn as any).props('color') === 'error')).toBe(true)
     expect(wrapper.find('[data-test="delete-modal"]').exists()).toBe(true)
   })
 
@@ -161,7 +161,7 @@ describe('comicPage', () => {
     const wrapper = await mount()
 
     await vi.waitFor(() => expect(wrapper.find('[data-test="status-infos"]').exists()).toBe(true))
-    expect(buttons(wrapper).some(btn => (btn as any).props('icon') === 'fa6-solid:repeat')).toBe(false)
+    expect(buttons(wrapper).some(btn => (btn as any).props('prependIcon') === 'fa6-solid:repeat')).toBe(false)
   })
 
   it('redirects to the library when the comic is missing', async () => {

--- a/web/app/pages/comic/[id]/index.vue
+++ b/web/app/pages/comic/[id]/index.vue
@@ -122,6 +122,7 @@ const showDeleteModal = ref(false)
   >
     <div
       v-if="comic"
+      class="bg-background pb-8"
       :class="smAndDown ? 'd-flex flex-column ga-8 px-6' : 'comic-infos-grid'"
     >
       <ComicsModalDelete
@@ -142,23 +143,21 @@ const showDeleteModal = ref(false)
           @error="coverSrc = defaultCover"
         />
 
-        <div class="d-flex justify-space-between ga-4 w-100 pa-2">
+        <div class="d-flex justify-space-between ga-4 w-100 py-2">
           <VBtn
             v-if="canRefresh"
-            v-tooltip="$t('comics.refresh.title')"
-            icon="fa6-solid:repeat"
+            :text="$t('comics.refresh.title')"
+            prepend-icon="fa6-solid:repeat"
             color="secondary"
-            size="small"
             class="border-thin-secondary"
             @click="refreshComic"
           />
 
           <VBtn
-            v-tooltip="$t('comics.remove.title')"
+            :text="$t('comics.remove.titleShort')"
             class="border-thin-error"
             color="error"
-            icon="fa6-solid:trash"
-            size="small"
+            prepend-icon="fa6-solid:trash"
             @click="showDeleteModal = true"
           />
         </div>
@@ -183,43 +182,61 @@ const showDeleteModal = ref(false)
             @error="coverSrc = defaultCover"
           />
 
-          <span
-            class="font-title font-weight-bold"
-            :class="{
-              'text-display-medium': !smAndDown,
-              'text-title-large': smAndDown,
-            }"
-          >{{ comic.title }}</span>
+          <div class="d-flex ga-2 flex-column">
+            <span
+              class="font-title font-weight-bold"
+              :class="{
+                'text-display-medium': !smAndDown,
+                'text-title-large': smAndDown,
+              }"
+            >{{ comic.title }}</span>
+
+            <template v-if="smAndDown">
+              <div v-if="comic.author" class="d-flex ga-2 justify-space-between mt-1">
+                <span class="text-body-medium text-medium-emphasis text-uppercase text-truncate">{{ $t('comic.fields.author') }}</span>
+                <span class="text-body-medium font-weight-bold text-truncate">{{ comic.author }}</span>
+              </div>
+              <div v-if="comic.artist" class="d-flex ga-2 justify-space-between">
+                <span class="text-body-medium text-medium-emphasis text-uppercase text-truncate">{{ $t('comic.fields.artist') }}</span>
+                <span class="text-body-medium font-weight-bold text-truncate">{{ comic.artist }}</span>
+              </div>
+
+              <div class="d-flex flex-wrap ga-3 align-center mt-1">
+                <ComicsIconStatus :status="comic.status" with-background />
+                <ComicsChipType :type="comic.type" size="small" />
+                <div>
+                  <ComicsChipSource
+                    :source="comic.source"
+                    size="small"
+                  />
+                </div>
+              </div>
+            </template>
+          </div>
         </div>
 
         <div
           v-if="smAndDown"
-          class="d-flex justify-space-between ga-4 w-100 pa-2"
+          class="d-flex justify-space-between ga-4 w-100"
         >
           <VBtn
             v-if="canRefresh"
-            v-tooltip="$t('comics.refresh.title')"
-            icon="fa6-solid:repeat"
+            prepend-icon="fa6-solid:repeat"
             color="secondary"
-            size="small"
+            :text="$t('comics.refresh.title')"
             class="border-thin-secondary"
             @click="refreshComic"
           />
 
           <VBtn
-            v-tooltip="$t('comics.remove.title')"
+            :text="$t('comics.remove.title')"
             class="border-thin-error"
             color="error"
-            icon="fa6-solid:trash"
-            size="small"
+            prepend-icon="fa6-solid:trash"
             @click="showDeleteModal = true"
           />
         </div>
 
-        <ComicsStatusInfos
-          v-if="smAndDown"
-          :comic
-        />
         <ComicsGeneralInfos :comic />
         <ComicsChapters
           :id="route.params.id"

--- a/web/app/pages/comic/[id]/index.vue
+++ b/web/app/pages/comic/[id]/index.vue
@@ -182,9 +182,9 @@ const showDeleteModal = ref(false)
             @error="coverSrc = defaultCover"
           />
 
-          <div class="d-flex ga-2 flex-column">
+          <div class="d-flex ga-2 flex-column text-truncate justify-space-between w-100">
             <span
-              class="font-title font-weight-bold"
+              class="font-title font-weight-bold text-wrap"
               :class="{
                 'text-display-medium': !smAndDown,
                 'text-title-large': smAndDown,
@@ -192,16 +192,7 @@ const showDeleteModal = ref(false)
             >{{ comic.title }}</span>
 
             <template v-if="smAndDown">
-              <div v-if="comic.author" class="d-flex ga-2 justify-space-between mt-1">
-                <span class="text-body-medium text-medium-emphasis text-uppercase text-truncate">{{ $t('comic.fields.author') }}</span>
-                <span class="text-body-medium font-weight-bold text-truncate">{{ comic.author }}</span>
-              </div>
-              <div v-if="comic.artist" class="d-flex ga-2 justify-space-between">
-                <span class="text-body-medium text-medium-emphasis text-uppercase text-truncate">{{ $t('comic.fields.artist') }}</span>
-                <span class="text-body-medium font-weight-bold text-truncate">{{ comic.artist }}</span>
-              </div>
-
-              <div class="d-flex flex-wrap ga-3 align-center mt-1">
+              <div class="d-flex flex-wrap ga-3 align-center my-1">
                 <ComicsIconStatus :status="comic.status" with-background />
                 <ComicsChipType :type="comic.type" size="small" />
                 <div>
@@ -210,6 +201,15 @@ const showDeleteModal = ref(false)
                     size="small"
                   />
                 </div>
+              </div>
+
+              <div v-if="comic.author" class="d-flex ga-2 justify-space-between">
+                <span class="text-body-medium text-medium-emphasis text-uppercase text-truncate">{{ $t('comic.fields.author') }}</span>
+                <span class="text-body-medium font-weight-bold text-truncate">{{ comic.author }}</span>
+              </div>
+              <div v-if="comic.artist" class="d-flex ga-2 justify-space-between">
+                <span class="text-body-medium text-medium-emphasis text-uppercase text-truncate">{{ $t('comic.fields.artist') }}</span>
+                <span class="text-body-medium font-weight-bold text-truncate">{{ comic.artist }}</span>
               </div>
             </template>
           </div>

--- a/web/i18n/locales/en.json
+++ b/web/i18n/locales/en.json
@@ -301,7 +301,8 @@
   },
   "comics": {
     "remove": {
-      "title": "Remove from library"
+      "title": "Remove from library",
+      "titleShort": "Remove"
     },
     "create": {
       "error": {

--- a/web/i18n/locales/fr.json
+++ b/web/i18n/locales/fr.json
@@ -299,7 +299,8 @@
   },
   "comics": {
     "remove": {
-      "title": "Supprimer de la bibliothèque"
+      "title": "Supprimer de la bibliothèque",
+      "titleShort": "Supprimer"
     },
     "create": {
       "error": {


### PR DESCRIPTION
## Summary
- Refactored comic details header layout for mobile viewports (`smAndDown`) to display status, type, source badges, and author/artist metadata alongside the cover.
- Updated action buttons on the comic page to include text and prepend icons, adding `comics.remove.titleShort` translations.
- Adjusted compact layout styling across `PageLayout`, chapter list header controls, and `Continue` button.
- Updated comic page unit tests to match new button icon props.

## Screenshots
<img width="345" height="762" alt="image" src="https://github.com/user-attachments/assets/7c93d5a8-5668-496c-89b2-592041584267" />

## Test plan
- [x] Open a comic details page on mobile/small screen: verify layout, metadata chips, author/artist, and buttons.
- [x] Test the Refresh and Remove comic buttons in both mobile and desktop views.
- [x] Verify the chapter list header and Continue button appearance on mobile and desktop.
- [x] Run frontend unit tests (`pnpm test:unit` or equivalent).