### PR TITLE
feat(download): convert chapter page PNG/JPEG to lossless WebP (#91)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,147 @@
+# Uchiyomi
+
+Self-hosted manga and webtoon server. Users browse external sources, add titles to their personal library, and read downloaded chapters.
+
+## Language
+
+**Comic**:
+A title fetched from an external source (manga, manhwa, manhua, etc.). Stored once in the database regardless of how many users add it.
+_Avoid_: Manga (when referring to the database entity — too narrow), Series
+
+**Library entry**:
+The link between a user and a comic they have added. Each user has their own library entries; reading history will attach here.
+_Avoid_: Library comic, User comic
+
+**Add to library**:
+The user-facing action that creates a comic in the database (if it does not exist yet) and creates a library entry linking the user to it. Idempotent: adding a comic already in the user's library succeeds without creating a duplicate entry. When the comic is new, obtains Cover (local) and fetches the full chapter list from the source — if either fails, the entire action fails and no comic or library entry is created. When the comic already exists (another user added it first), only the library entry is created; the existing local cover and chapter records are reused and undownloaded chapters are enqueued if not already in the queue.
+
+**Source**:
+An external site from which comics can be browsed and added. AsuraScans is the first source.
+
+**Source slug**:
+The identifier a source uses for a comic in its URLs (e.g. `solo-leveling` on AsuraScans). Together with the source name, it uniquely identifies a comic in the database.
+
+**Comic status**:
+The publication state of a comic as reported by its source (e.g. ongoing, completed, hiatus). Stored as-is from the source; no cross-source normalization yet.
+
+**Comic type**:
+The format of a comic as reported by its source (e.g. manga, manhwa, manhua, mangatoon). Stored as-is from the source.
+
+**Cover (cached)**:
+A temporarily stored cover image used while browsing a source, before a comic exists in the database. May expire and be discarded. When that comic is first created, a cached cover for the same source and slug is moved (not copied) to become Cover (local).
+
+**Cover (local)**:
+The permanent cover image of a comic, written only when the comic is first created. Stored as `cover.{ext}` in that comic's download directory (`downloads/{comicId}/`), next to its chapter files. A comic row exists only if this file exists: if the cover cannot be moved from cache or downloaded, the comic is not created.
+_Avoid_: cache/covers (that directory is Cover (cached) only)
+
+**Remove from library**:
+Deletes only the user's library entry and that entry's reading progress. The comic and its local cover remain as long as at least one other user still has it in their library. When the last user removes a comic and it is deleted from the database, all associated chapter records, downloaded chapter files, and the local cover are deleted as well. Re-adding the comic creates a new library entry with no reading progress.
+
+**Library**:
+The personal collection of comics a user has added. Displayed on the `/library` page. Filterable by source, type, status, and a case-insensitive search on title and alt titles. Sortable by title or date added, ascending or descending. Default sort is title ascending. Each library comic is shown with its local cover.
+
+**Feed**:
+The user's library comics that have at least one unlocked chapter, listed with their latest unlocked chapters, newest first, ranked by chapter availability date. Comics with only locked chapters are omitted until the first unlock. Displayed on `/feed`. `/` redirects to `/feed`. This is the page the user lands on after login. Filterable by source, type, and status. Each shown chapter includes its download progress and whether the user has reading progress for that chapter. Tapping the card (cover or title) opens the library comic page. Tapping the shown chapter opens the chapter reader if that chapter is fully downloaded; otherwise the user stays on the Feed.
+_Avoid_: Updates, timeline, homepage
+
+**Library comic page**:
+The source-agnostic detail page for a comic already in the user's library, at `/comic/:id` (internal UUID). Same role as the AsuraScans series detail page (metadata, chapter list, live download progress), but it reads stored comics and chapters rather than the source. A Continue action opens that comic's Continue. A chapter row opens that chapter at its last page (or page 1), only if it is fully downloaded. The chapter list can enter a selection mode to mark chapters as read. A Refresh action runs a chapter list refresh for that comic when it is pollable; otherwise the action is shown but not available.
+_Avoid_: Series page (when referring to the library-owned page)
+
+**Comic metadata**:
+A snapshot of information returned by the source. Most fields stay as stored at add-to-library. Status and chapter count are refreshed by chapter list refresh for pollable comics.
+
+**Reading history**:
+A per-user event log of chapters read (chapter + read date), attached to a library entry. Used for a future history page. Distinct from reading progress. Not implemented in this milestone, but the data model must account for it.
+
+**Reading progress**:
+The furthest page a user reached in a given chapter of a library entry. Resume uses that page when the same chapter is opened again. A save with a lower page leaves the stored page unchanged, but that chapter still becomes Continue. Distinct from reading history. There is no read/unread flag: the list treats any stored progress as opened, and mark chapters as read is a shortcut that sets the page to the chapter's last page. Deleted with the library entry.
+
+**Mark chapters as read**:
+A library comic page action that sets reading progress to the last page (`pagesNb`) of each selected chapter whose page count is known. Not a read/unread flag and not a reading history event. Chapters with no page count yet are skipped. Locked and not fully downloaded chapters can be marked.
+_Avoid_: mark as unread, read flag, bulk retry
+
+**Continue**:
+The chapter of a library entry whose reading progress was updated most recently, and the page to resume at. Derived from reading progress; not stored separately. Absent when the user has no reading progress for that comic. Mark chapters as read never moves Continue to an earlier chapter: it creates Continue when none exists, or moves it only to a later selected chapter that was marked read. A single-chapter progress save is unchanged.
+_Avoid_: resume pointer, last read
+
+**Chapter reader**:
+The in-app view that displays the local page images of a fully downloaded chapter, at `/comic/:id/chapter/:number`. The URL updates when the reader moves to another chapter. It uses that user's reader settings for the comic's stored comic type. Incomplete or failed downloads cannot be opened. Changing chapter happens from the overlay (previous, next, or chapter menu), not by scrolling into another chapter.
+_Avoid_: Viewer, player
+
+**Page rail**:
+A vertical overlay control on the chapter reader that shows position in the current chapter and lets the user jump or scrub to a page, or to a double-page pair when double page is on. Visible only with the overlay, including on the between-chapters card (then pinned at the first or last page). Top is the first page, bottom is the last, in every reading mode. The label uses real 1-based page numbers (a double-page pair shows both). Distinct from reading progress and from chapter download progress.
+_Avoid_: Progress bar, page indicator, seek bar, slider
+
+**Next chapter**:
+The adjacent later instalment of the same comic, ordered by chapter number. Includes locked and not fully downloaded chapters; the chapter reader does not skip over them. Distinct from Continue.
+_Avoid_: next readable, next fully downloaded (when that would skip a gap)
+
+**Previous chapter**:
+The adjacent earlier instalment of the same comic, ordered by chapter number. Same inclusion rules as Next chapter.
+
+**Reading mode**:
+The layout used by the chapter reader for a given user and comic type (paged right-to-left, paged left-to-right, or webtoon). One mode per type per user; not chosen per comic and not from inside the chapter reader. Webtoon is a vertical strip of the current chapter only: reaching the last page shows the overlay so the user can change chapter; the next chapter is not appended.
+_Avoid_: infinite scroll (in the chapter reader)
+
+**Reader settings**:
+A user's reading preferences for one comic type: reading mode, page scale, and for paged modes whether to show a single page or a double page. Shared by every comic of that type for that user; not per comic and not per device. Factory defaults: manga is paged right-to-left, manhua paged left-to-right, both fit to screen and single page; manhwa and mangatoon are webtoon, fit to width.
+
+**Reader settings page**:
+The page at `/settings/reader` where a user selects one comic type, edits that type's reader settings, and saves. Switching the selector shows the other type's settings. Switching type with unsaved edits asks to save, discard, or cancel.
+_Avoid_: four settings panels (the page shows one type at a time)
+
+**Page scale**:
+How a page image is sized in the chapter reader: fit to width, fit to height, or fit to screen.
+
+**Chapter title**:
+The optional name the source gives a chapter, stored on the chapter. Distinct from the chapter number. When empty, the UI shows the number only.
+
+**Browse source**:
+Search and explore comics on an external source before adding them. The AsuraScans browse page supports title search, sort (popular, latest update), status and type filters. Genre filters are out of scope. Clicking a card on a source browse page opens that source's series page. Cards on Library and Feed open the library comic page. Unifying browse and library comic pages later is out of scope.
+
+**Sources page**:
+Lists all available sources as cards. Each card links to that source's browse page. Only AsuraScans for now.
+
+**Search pagination**:
+Mobile: infinite scroll — next page loads when the user reaches the bottom, previous results stay visible. Desktop: classic pagination footer with page numbers. Applies to source browse, library, and feed.
+
+**Chapter**:
+A single instalment of a comic, stored in the database and linked to one comic. Chapters are created when a comic is added to a library, and when a chapter list refresh finds source chapters with no matching source chapter slug. Each chapter tracks its download progress independently. The expected page count (`pagesNb`) is initialized from the source chapter list and updated when page URLs are fetched if the source reports a different count.
+_Avoid_: Episode (unless the source uses that term)
+
+**Chapter list refresh**:
+A refetch of a pollable comic's infos and chapter list from its source: creates missing chapter records, enqueues downloadable ones, and updates comic status and chapter count. Pollable comics are those whose stored status is ongoing or hiatus. Runs periodically for all pollable comics, and on demand for one pollable comic by a user who has it in their library.
+_Avoid_: catalog sync, crawl, scrape, metadata refresh
+
+**Source chapter slug**:
+The identifier a source uses for a chapter in its API (e.g. the `slug` field returned by AsuraScans). Required to fetch page images from the source. Distinct from the chapter number shown to readers.
+_Avoid_: Chapter URL (the public reader URL uses the chapter number, not this slug)
+
+**Chapter download progress**:
+A percentage (0–100) of page images successfully downloaded for a chapter. At 100 the chapter is fully available for offline reading. Set to -1 when a download error occurs — after 3 failed attempts per page. On server startup, chapters with progress between 0 and 99, or with a previous error (-1), are queued again automatically. Interrupted downloads resume incrementally — only missing pages are fetched.
+
+**Chapter published at**:
+The date and time the source reports the chapter was published. Stored as returned by the source.
+
+**Chapter early access until**:
+The date and time until which a chapter is locked behind early access on the source. Chapters with a future early access date are stored in the database but not queued for download until the lock expires. A periodic scan (every 15 minutes) checks for newly unlocked chapters and queues them for download.
+
+**Unlocked chapter**:
+A chapter that is not behind early access: it has no early access date, or that date is already in the past. Only unlocked chapters appear on the Feed.
+
+**Chapter availability date**:
+The date used to rank an unlocked chapter on the Feed. If early access until is set and already past, that date is the availability date; otherwise it is the chapter's published-at date.
+
+**Chapter files (local)**:
+The page images of a downloaded chapter, stored on disk under `downloads/{comicId}/{chapterNumber}/`. Each file is named with a zero-padded index (e.g. `001.webp`, `002.png`). PNG and JPEG pages from the source are converted to lossless WebP when the resulting WebP file is smaller; otherwise the original format and bytes are retained. Each comic is identified by its internal UUID, not its title or source slug. The same `{comicId}` directory holds Cover (local) as `cover.{ext}` at its root, not inside a chapter folder.
+
+**Retry chapter download**:
+The user-facing action to re-attempt downloading a chapter. If the chapter is in error (-1), all partial files are deleted and the download restarts from 0. If the chapter was merely interrupted (0 < progress < 100), only missing pages are fetched.
+
+**Live chapter download progress**:
+Chapter download progress shown on the series chapter list while the user is viewing it, kept current until every chapter is complete or failed.
+_Avoid_: WebSocket, progress stream, SSE
+
+**Chapter download queue**:
+Each source has a single global download queue processed one chapter at a time (FIFO). Chapters are enqueued in ascending chapter number order. Across multiple comics, chapters are enqueued in the order their comic was added to a library. Enqueue is idempotent: a chapter is added only if its download progress is below 100 and it is not already in the queue. Chapters at 100 % or already queued are skipped. Within a chapter, pages are downloaded in parallel, throttled by a configurable rate limit on the worker.

--- a/api/go.mod
+++ b/api/go.mod
@@ -23,6 +23,7 @@ require (
 )
 
 require (
+	github.com/KarpelesLab/gowebp v0.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
@@ -32,6 +33,7 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
+	golang.org/x/image v0.24.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 )

--- a/api/go.mod
+++ b/api/go.mod
@@ -4,6 +4,7 @@ go 1.26.5
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
+	github.com/KarpelesLab/gowebp v0.1.1
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/coreos/go-oidc/v3 v3.20.0
 	github.com/go-chi/chi/v5 v5.3.1
@@ -23,7 +24,6 @@ require (
 )
 
 require (
-	github.com/KarpelesLab/gowebp v0.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,5 +1,7 @@
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
+github.com/KarpelesLab/gowebp v0.1.1 h1:W11ZrRVx+Zk4ypW5NBEU31FQzghICXIrAbAbO5yd4M0=
+github.com/KarpelesLab/gowebp v0.1.1/go.mod h1:Js8OXPQ94yl94HqaO/9XuUqk0wOPod6uycryhzmTgsU=
 github.com/caarlos0/env/v11 v11.4.1 h1:fYwH0sWEsBSMPG7t4e/PEfTFzrWrpjyygXyUnWiSwEw=
 github.com/caarlos0/env/v11 v11.4.1/go.mod h1:qupehSf/Y0TUTsxKywqRt/vJjN5nz6vauiYEUUr8P4U=
 github.com/coreos/go-oidc/v3 v3.20.0 h1:EtE0WIBHk03N+DqGkY4+UONzzZHk7amKt6IyNd7OsZE=
@@ -55,6 +57,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
 golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
+golang.org/x/image v0.24.0 h1:AN7zRgVsbvmTfNyqIbbOraYL8mSwcKncEj8ofjgzcMQ=
+golang.org/x/image v0.24.0/go.mod h1:4b/ITuLfqYq1hqZcjofwctIhi7sZh2WaCjvsBNjjya8=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=

--- a/api/pkg/core/chapters/download/imageopt.go
+++ b/api/pkg/core/chapters/download/imageopt.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package download
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+type ImageFormat int
+
+const (
+	FormatUnknown ImageFormat = iota
+	FormatPNG
+	FormatJPEG
+	FormatWebP
+	FormatGIF
+)
+
+var pngHeader = []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}
+var jpegHeader = []byte{0xFF, 0xD8, 0xFF}
+var gif87a = []byte("GIF87a")
+var gif89a = []byte("GIF89a")
+
+func SniffFormat(data []byte) ImageFormat {
+	if len(data) >= 8 && bytes.Equal(data[:8], pngHeader) {
+		return FormatPNG
+	}
+
+	if len(data) >= 3 && bytes.Equal(data[:3], jpegHeader) {
+		return FormatJPEG
+	}
+
+	if len(data) >= 12 && bytes.Equal(data[:4], []byte("RIFF")) && bytes.Equal(data[8:12], []byte("WEBP")) {
+		return FormatWebP
+	}
+
+	if len(data) >= 6 && (bytes.Equal(data[:6], gif87a) || bytes.Equal(data[:6], gif89a)) {
+		return FormatGIF
+	}
+
+	return FormatUnknown
+}
+
+func IsAPNG(data []byte) bool {
+	if len(data) < 8 || !bytes.Equal(data[:8], pngHeader) {
+		return false
+	}
+
+	offset := 8
+	for offset+8 <= len(data) {
+		length := binary.BigEndian.Uint32(data[offset : offset+4])
+		chunkType := string(data[offset+4 : offset+8])
+
+		if chunkType == "acTL" {
+			return true
+		}
+
+		if chunkType == "IDAT" {
+			return false
+		}
+
+		// 4 (length) + 4 (type) + length (data) + 4 (crc)
+		chunkTotal := int64(length) + 12
+		if int64(offset)+chunkTotal > int64(len(data)) {
+			break
+		}
+
+		offset += int(chunkTotal)
+	}
+
+	return false
+}

--- a/api/pkg/core/chapters/download/imageopt.go
+++ b/api/pkg/core/chapters/download/imageopt.go
@@ -14,6 +14,14 @@ import (
 	"github.com/KarpelesLab/gowebp"
 )
 
+const (
+	ExtWEBP = ".webp"
+	ExtGIF  = ".gif"
+	ExtJPG  = ".jpg"
+	ExtJPEG = ".jpeg"
+	ExtPNG  = ".png"
+)
+
 type ImageFormat int
 
 const (
@@ -32,8 +40,8 @@ const (
 )
 
 type OptimizedPage struct {
-	Data      []byte
 	Extension string
+	Data      []byte
 }
 
 func OptimizePage(data []byte, urlExt string, logger *slog.Logger) OptimizedPage {
@@ -87,7 +95,7 @@ func OptimizePage(data []byte, urlExt string, logger *slog.Logger) OptimizedPage
 	if len(webpBytes) < len(data) {
 		return OptimizedPage{
 			Data:      webpBytes,
-			Extension: ".webp",
+			Extension: ExtWEBP,
 		}
 	}
 
@@ -97,21 +105,21 @@ func OptimizePage(data []byte, urlExt string, logger *slog.Logger) OptimizedPage
 func fallbackExtension(format ImageFormat, urlExt string) string {
 	switch format {
 	case FormatPNG:
-		return ".png"
+		return ExtPNG
 	case FormatJPEG:
 		if strings.EqualFold(urlExt, ".jpeg") {
-			return ".jpeg"
+			return ExtJPEG
 		}
 
-		return ".jpg"
+		return ExtJPG
 	case FormatWebP:
-		return ".webp"
+		return ExtWEBP
 	case FormatGIF:
-		return ".gif"
+		return ExtGIF
 	default:
 		cleanExt := strings.ToLower(strings.TrimSpace(urlExt))
 		if cleanExt == "" || !strings.HasPrefix(cleanExt, ".") {
-			return ".webp"
+			return ExtWEBP
 		}
 
 		return cleanExt

--- a/api/pkg/core/chapters/download/imageopt.go
+++ b/api/pkg/core/chapters/download/imageopt.go
@@ -5,6 +5,13 @@ package download
 import (
 	"bytes"
 	"encoding/binary"
+	"image"
+	"image/jpeg"
+	"image/png"
+	"log/slog"
+	"strings"
+
+	"github.com/KarpelesLab/gowebp"
 )
 
 type ImageFormat int
@@ -17,25 +24,114 @@ const (
 	FormatGIF
 )
 
-var pngHeader = []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}
-var jpegHeader = []byte{0xFF, 0xD8, 0xFF}
-var gif87a = []byte("GIF87a")
-var gif89a = []byte("GIF89a")
+const (
+	pngHeader  = "\x89PNG\r\n\x1a\n"
+	jpegHeader = "\xff\xd8\xff"
+	gif87a     = "GIF87a"
+	gif89a     = "GIF89a"
+)
+
+type OptimizedPage struct {
+	Data      []byte
+	Extension string
+}
+
+func OptimizePage(data []byte, urlExt string, logger *slog.Logger) OptimizedPage {
+	format := SniffFormat(data)
+	defaultExt := fallbackExtension(format, urlExt)
+
+	fallback := OptimizedPage{
+		Data:      data,
+		Extension: defaultExt,
+	}
+
+	if format == FormatPNG && IsAPNG(data) {
+		return fallback
+	}
+
+	if format != FormatPNG && format != FormatJPEG {
+		return fallback
+	}
+
+	var img image.Image
+	var err error
+
+	switch format {
+	case FormatPNG:
+		img, err = png.Decode(bytes.NewReader(data))
+	case FormatJPEG:
+		img, err = jpeg.Decode(bytes.NewReader(data))
+	default:
+		return fallback
+	}
+
+	if err != nil {
+		if logger != nil {
+			logger.Warn("failed to decode image for webp conversion", "error", err)
+		}
+
+		return fallback
+	}
+
+	var webpBuf bytes.Buffer
+	// nil options in KarpelesLab/gowebp encodes lossless VP8L by default
+	if err := gowebp.Encode(&webpBuf, img, nil); err != nil {
+		if logger != nil {
+			logger.Warn("failed to encode lossless webp", "error", err)
+		}
+
+		return fallback
+	}
+
+	webpBytes := webpBuf.Bytes()
+	if len(webpBytes) < len(data) {
+		return OptimizedPage{
+			Data:      webpBytes,
+			Extension: ".webp",
+		}
+	}
+
+	return fallback
+}
+
+func fallbackExtension(format ImageFormat, urlExt string) string {
+	switch format {
+	case FormatPNG:
+		return ".png"
+	case FormatJPEG:
+		if strings.EqualFold(urlExt, ".jpeg") {
+			return ".jpeg"
+		}
+
+		return ".jpg"
+	case FormatWebP:
+		return ".webp"
+	case FormatGIF:
+		return ".gif"
+	default:
+		cleanExt := strings.ToLower(strings.TrimSpace(urlExt))
+		if cleanExt == "" || !strings.HasPrefix(cleanExt, ".") {
+			return ".webp"
+		}
+
+		return cleanExt
+	}
+}
 
 func SniffFormat(data []byte) ImageFormat {
-	if len(data) >= 8 && bytes.Equal(data[:8], pngHeader) {
+	if len(data) >= 8 && string(data[:8]) == pngHeader {
 		return FormatPNG
 	}
 
-	if len(data) >= 3 && bytes.Equal(data[:3], jpegHeader) {
+	if len(data) >= 3 && string(data[:3]) == jpegHeader {
 		return FormatJPEG
 	}
 
-	if len(data) >= 12 && bytes.Equal(data[:4], []byte("RIFF")) && bytes.Equal(data[8:12], []byte("WEBP")) {
+	if len(data) >= 12 && string(data[:4]) == "RIFF" && string(data[8:12]) == "WEBP" {
 		return FormatWebP
 	}
 
-	if len(data) >= 6 && (bytes.Equal(data[:6], gif87a) || bytes.Equal(data[:6], gif89a)) {
+	if len(data) >= 6 && (string(data[:6]) == gif87a || string(data[:6]) == gif89a) {
 		return FormatGIF
 	}
 
@@ -43,7 +139,7 @@ func SniffFormat(data []byte) ImageFormat {
 }
 
 func IsAPNG(data []byte) bool {
-	if len(data) < 8 || !bytes.Equal(data[:8], pngHeader) {
+	if len(data) < 8 || string(data[:8]) != pngHeader {
 		return false
 	}
 

--- a/api/pkg/core/chapters/download/imageopt_test.go
+++ b/api/pkg/core/chapters/download/imageopt_test.go
@@ -26,6 +26,7 @@ func createTestPNG(t *testing.T, w, h int) []byte {
 	if err := png.Encode(&buf, img); err != nil {
 		t.Fatalf("png.Encode: %v", err)
 	}
+
 	return buf.Bytes()
 }
 
@@ -41,6 +42,7 @@ func createTestJPEG(t *testing.T, w, h int) []byte {
 	if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 90}); err != nil {
 		t.Fatalf("jpeg.Encode: %v", err)
 	}
+
 	return buf.Bytes()
 }
 
@@ -67,6 +69,7 @@ func createTestAPNG(t *testing.T) []byte {
 	out.Write(basePNG[:chunkStart])
 	out.Write(actlChunk.Bytes())
 	out.Write(basePNG[chunkStart:])
+
 	return out.Bytes()
 }
 
@@ -103,5 +106,88 @@ func TestIsAPNG(t *testing.T) {
 	apng := createTestAPNG(t)
 	if !download.IsAPNG(apng) {
 		t.Errorf("APNG with acTL chunk before IDAT should be detected as APNG")
+	}
+}
+
+func TestOptimizePage_PNGToWebP(t *testing.T) {
+	pngData := createTestPNG(t, 200, 200)
+	res := download.OptimizePage(pngData, ".png", nil)
+
+	if res.Extension != ".webp" {
+		t.Errorf("expected extension .webp, got %s", res.Extension)
+	}
+	if len(res.Data) >= len(pngData) {
+		t.Errorf("expected webp size (%d) to be smaller than png size (%d)", len(res.Data), len(pngData))
+	}
+	if download.SniffFormat(res.Data) != download.FormatWebP {
+		t.Errorf("expected output to be valid WebP format")
+	}
+}
+
+func TestOptimizePage_JPEGToWebP_Smaller(t *testing.T) {
+	jpegData := createTestJPEG(t, 200, 200)
+	res := download.OptimizePage(jpegData, ".jpg", nil)
+
+	// If WebP is smaller, extension must be .webp
+	if len(res.Data) < len(jpegData) {
+		if res.Extension != ".webp" {
+			t.Errorf("expected .webp when smaller, got %s", res.Extension)
+		}
+	} else {
+		if res.Extension != ".jpg" {
+			t.Errorf("expected original extension when WebP is larger, got %s", res.Extension)
+		}
+		if !bytes.Equal(res.Data, jpegData) {
+			t.Errorf("expected original data preserved when WebP is larger")
+		}
+	}
+}
+
+func TestOptimizePage_APNG_Preserved(t *testing.T) {
+	apngData := createTestAPNG(t)
+	res := download.OptimizePage(apngData, ".png", nil)
+
+	if res.Extension != ".png" {
+		t.Errorf("expected APNG to retain .png extension, got %s", res.Extension)
+	}
+	if !bytes.Equal(res.Data, apngData) {
+		t.Errorf("expected APNG bytes to be preserved untouched")
+	}
+}
+
+func TestOptimizePage_SourceWebP_Preserved(t *testing.T) {
+	webpData := append([]byte("RIFF1234WEBP"), []byte("somedata")...)
+	res := download.OptimizePage(webpData, ".webp", nil)
+
+	if res.Extension != ".webp" {
+		t.Errorf("expected source WebP to retain .webp extension, got %s", res.Extension)
+	}
+	if !bytes.Equal(res.Data, webpData) {
+		t.Errorf("expected source WebP bytes to be preserved untouched")
+	}
+}
+
+func TestOptimizePage_MagicBytesMismatch(t *testing.T) {
+	// Content is PNG, but URL says .jpg
+	pngData := createTestPNG(t, 200, 200)
+	res := download.OptimizePage(pngData, ".jpg", nil)
+
+	if res.Extension != ".webp" {
+		t.Errorf("expected converted PNG to have .webp extension, got %s", res.Extension)
+	}
+	if download.SniffFormat(res.Data) != download.FormatWebP {
+		t.Errorf("expected output to be WebP")
+	}
+}
+
+func TestOptimizePage_CorruptData_Preserved(t *testing.T) {
+	corruptData := []byte("not an image")
+	res := download.OptimizePage(corruptData, ".png", nil)
+
+	if res.Extension != ".png" {
+		t.Errorf("expected corrupt data to retain url extension, got %s", res.Extension)
+	}
+	if !bytes.Equal(res.Data, corruptData) {
+		t.Errorf("expected corrupt bytes to be preserved untouched")
 	}
 }

--- a/api/pkg/core/chapters/download/imageopt_test.go
+++ b/api/pkg/core/chapters/download/imageopt_test.go
@@ -46,6 +46,22 @@ func createTestJPEG(t *testing.T, w, h int) []byte {
 	return buf.Bytes()
 }
 
+func createTestSolidJPEG(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{R: 255, G: 255, B: 255, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 100}); err != nil {
+		t.Fatalf("jpeg.Encode: %v", err)
+	}
+
+	return buf.Bytes()
+}
+
 func createTestAPNG(t *testing.T) []byte {
 	t.Helper()
 	basePNG := createTestPNG(t, 10, 10)
@@ -125,19 +141,30 @@ func TestOptimizePage_PNGToWebP(t *testing.T) {
 }
 
 func TestOptimizePage_JPEGToWebP_Smaller(t *testing.T) {
-	jpegData := createTestJPEG(t, 200, 200)
-	res := download.OptimizePage(jpegData, ".jpg", nil)
+	solidJPEG := createTestSolidJPEG(t, 200, 200)
+	res := download.OptimizePage(solidJPEG, ".jpg", nil)
 
-	// If WebP is smaller, extension must be .webp
-	if len(res.Data) < len(jpegData) {
-		if res.Extension != ".webp" {
-			t.Errorf("expected .webp when smaller, got %s", res.Extension)
+	if res.Extension != ".webp" {
+		t.Errorf("expected .webp when smaller, got %s", res.Extension)
+	}
+	if len(res.Data) >= len(solidJPEG) {
+		t.Errorf("expected webp size (%d) to be smaller than jpeg (%d)", len(res.Data), len(solidJPEG))
+	}
+	if download.SniffFormat(res.Data) != download.FormatWebP {
+		t.Errorf("expected output to be valid WebP format")
+	}
+
+	gradientJPEG := createTestJPEG(t, 200, 200)
+	resGradient := download.OptimizePage(gradientJPEG, ".jpg", nil)
+	if len(resGradient.Data) < len(gradientJPEG) {
+		if resGradient.Extension != ".webp" {
+			t.Errorf("expected .webp when smaller, got %s", resGradient.Extension)
 		}
 	} else {
-		if res.Extension != ".jpg" {
-			t.Errorf("expected original extension when WebP is larger, got %s", res.Extension)
+		if resGradient.Extension != ".jpg" {
+			t.Errorf("expected original extension when WebP is larger, got %s", resGradient.Extension)
 		}
-		if !bytes.Equal(res.Data, jpegData) {
+		if !bytes.Equal(resGradient.Data, gradientJPEG) {
 			t.Errorf("expected original data preserved when WebP is larger")
 		}
 	}

--- a/api/pkg/core/chapters/download/imageopt_test.go
+++ b/api/pkg/core/chapters/download/imageopt_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package download_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"image/png"
+	"testing"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/chapters/download"
+)
+
+func createTestPNG(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{R: uint8(x % 256), G: uint8(y % 256), B: 100, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("png.Encode: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func createTestJPEG(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{R: uint8(x % 256), G: uint8(y % 256), B: 100, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 90}); err != nil {
+		t.Fatalf("jpeg.Encode: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func createTestAPNG(t *testing.T) []byte {
+	t.Helper()
+	basePNG := createTestPNG(t, 10, 10)
+	// Insert an acTL chunk before IDAT chunk
+	idatIdx := bytes.Index(basePNG, []byte("IDAT"))
+	if idatIdx == -1 {
+		t.Fatalf("IDAT chunk not found in test PNG")
+	}
+	chunkStart := idatIdx - 4
+
+	var actlChunk bytes.Buffer
+	// Length: 8 bytes (sequence_number: 4 bytes, num_plays: 4 bytes)
+	_ = binary.Write(&actlChunk, binary.BigEndian, uint32(8))
+	actlChunk.WriteString("acTL")
+	_ = binary.Write(&actlChunk, binary.BigEndian, uint32(2)) // num_frames
+	_ = binary.Write(&actlChunk, binary.BigEndian, uint32(0)) // num_plays
+	// CRC (fake 4 bytes for testing detector)
+	_ = binary.Write(&actlChunk, binary.BigEndian, uint32(0))
+
+	var out bytes.Buffer
+	out.Write(basePNG[:chunkStart])
+	out.Write(actlChunk.Bytes())
+	out.Write(basePNG[chunkStart:])
+	return out.Bytes()
+}
+
+func TestSniffFormat(t *testing.T) {
+	pngData := createTestPNG(t, 2, 2)
+	jpegData := createTestJPEG(t, 2, 2)
+	webpData := append([]byte("RIFF1234WEBP"), []byte("data")...)
+	gifData := []byte("GIF89a...")
+	corruptData := []byte("random non-image bytes")
+
+	if download.SniffFormat(pngData) != download.FormatPNG {
+		t.Errorf("expected FormatPNG, got %v", download.SniffFormat(pngData))
+	}
+	if download.SniffFormat(jpegData) != download.FormatJPEG {
+		t.Errorf("expected FormatJPEG, got %v", download.SniffFormat(jpegData))
+	}
+	if download.SniffFormat(webpData) != download.FormatWebP {
+		t.Errorf("expected FormatWebP, got %v", download.SniffFormat(webpData))
+	}
+	if download.SniffFormat(gifData) != download.FormatGIF {
+		t.Errorf("expected FormatGIF, got %v", download.SniffFormat(gifData))
+	}
+	if download.SniffFormat(corruptData) != download.FormatUnknown {
+		t.Errorf("expected FormatUnknown, got %v", download.SniffFormat(corruptData))
+	}
+}
+
+func TestIsAPNG(t *testing.T) {
+	regularPNG := createTestPNG(t, 2, 2)
+	if download.IsAPNG(regularPNG) {
+		t.Errorf("regular PNG should not be detected as APNG")
+	}
+
+	apng := createTestAPNG(t)
+	if !download.IsAPNG(apng) {
+		t.Errorf("APNG with acTL chunk before IDAT should be detected as APNG")
+	}
+}

--- a/api/pkg/core/chapters/download/imageopt_test.go
+++ b/api/pkg/core/chapters/download/imageopt_test.go
@@ -127,9 +127,9 @@ func TestIsAPNG(t *testing.T) {
 
 func TestOptimizePage_PNGToWebP(t *testing.T) {
 	pngData := createTestPNG(t, 200, 200)
-	res := download.OptimizePage(pngData, ".png", nil)
+	res := download.OptimizePage(pngData, download.ExtPNG, nil)
 
-	if res.Extension != ".webp" {
+	if res.Extension != download.ExtWEBP {
 		t.Errorf("expected extension .webp, got %s", res.Extension)
 	}
 	if len(res.Data) >= len(pngData) {
@@ -142,9 +142,9 @@ func TestOptimizePage_PNGToWebP(t *testing.T) {
 
 func TestOptimizePage_JPEGToWebP_Smaller(t *testing.T) {
 	solidJPEG := createTestSolidJPEG(t, 200, 200)
-	res := download.OptimizePage(solidJPEG, ".jpg", nil)
+	res := download.OptimizePage(solidJPEG, download.ExtJPG, nil)
 
-	if res.Extension != ".webp" {
+	if res.Extension != download.ExtWEBP {
 		t.Errorf("expected .webp when smaller, got %s", res.Extension)
 	}
 	if len(res.Data) >= len(solidJPEG) {
@@ -155,13 +155,13 @@ func TestOptimizePage_JPEGToWebP_Smaller(t *testing.T) {
 	}
 
 	gradientJPEG := createTestJPEG(t, 200, 200)
-	resGradient := download.OptimizePage(gradientJPEG, ".jpg", nil)
+	resGradient := download.OptimizePage(gradientJPEG, download.ExtJPG, nil)
 	if len(resGradient.Data) < len(gradientJPEG) {
-		if resGradient.Extension != ".webp" {
+		if resGradient.Extension != download.ExtWEBP {
 			t.Errorf("expected .webp when smaller, got %s", resGradient.Extension)
 		}
 	} else {
-		if resGradient.Extension != ".jpg" {
+		if resGradient.Extension != download.ExtJPG {
 			t.Errorf("expected original extension when WebP is larger, got %s", resGradient.Extension)
 		}
 		if !bytes.Equal(resGradient.Data, gradientJPEG) {
@@ -172,9 +172,9 @@ func TestOptimizePage_JPEGToWebP_Smaller(t *testing.T) {
 
 func TestOptimizePage_APNG_Preserved(t *testing.T) {
 	apngData := createTestAPNG(t)
-	res := download.OptimizePage(apngData, ".png", nil)
+	res := download.OptimizePage(apngData, download.ExtPNG, nil)
 
-	if res.Extension != ".png" {
+	if res.Extension != download.ExtPNG {
 		t.Errorf("expected APNG to retain .png extension, got %s", res.Extension)
 	}
 	if !bytes.Equal(res.Data, apngData) {
@@ -184,9 +184,9 @@ func TestOptimizePage_APNG_Preserved(t *testing.T) {
 
 func TestOptimizePage_SourceWebP_Preserved(t *testing.T) {
 	webpData := append([]byte("RIFF1234WEBP"), []byte("somedata")...)
-	res := download.OptimizePage(webpData, ".webp", nil)
+	res := download.OptimizePage(webpData, download.ExtWEBP, nil)
 
-	if res.Extension != ".webp" {
+	if res.Extension != download.ExtWEBP {
 		t.Errorf("expected source WebP to retain .webp extension, got %s", res.Extension)
 	}
 	if !bytes.Equal(res.Data, webpData) {
@@ -197,9 +197,9 @@ func TestOptimizePage_SourceWebP_Preserved(t *testing.T) {
 func TestOptimizePage_MagicBytesMismatch(t *testing.T) {
 	// Content is PNG, but URL says .jpg
 	pngData := createTestPNG(t, 200, 200)
-	res := download.OptimizePage(pngData, ".jpg", nil)
+	res := download.OptimizePage(pngData, download.ExtJPG, nil)
 
-	if res.Extension != ".webp" {
+	if res.Extension != download.ExtWEBP {
 		t.Errorf("expected converted PNG to have .webp extension, got %s", res.Extension)
 	}
 	if download.SniffFormat(res.Data) != download.FormatWebP {
@@ -209,9 +209,9 @@ func TestOptimizePage_MagicBytesMismatch(t *testing.T) {
 
 func TestOptimizePage_CorruptData_Preserved(t *testing.T) {
 	corruptData := []byte("not an image")
-	res := download.OptimizePage(corruptData, ".png", nil)
+	res := download.OptimizePage(corruptData, download.ExtPNG, nil)
 
-	if res.Extension != ".png" {
+	if res.Extension != download.ExtPNG {
 		t.Errorf("expected corrupt data to retain url extension, got %s", res.Extension)
 	}
 	if !bytes.Equal(res.Data, corruptData) {

--- a/api/pkg/core/chapters/download/storage.go
+++ b/api/pkg/core/chapters/download/storage.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"mime"
 	"net/http"
 	"net/url"
@@ -148,7 +149,14 @@ func (s DiskPages) OpenPage(comicID uuid.UUID, chapterNumber float64, index int)
 	return files[0], contentType, nil
 }
 
-func downloadPage(ctx context.Context, client *http.Client, imageURL, destPath string) error {
+func downloadPage(
+	ctx context.Context,
+	client *http.Client,
+	imageURL string,
+	dir string,
+	pageIndex int,
+	logger *slog.Logger,
+) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil)
 	if err != nil {
 		return fmt.Errorf("http.NewRequestWithContext: %w", err)
@@ -165,13 +173,23 @@ func downloadPage(ctx context.Context, client *http.Client, imageURL, destPath s
 		return fmt.Errorf("unexpected status %d", res.StatusCode)
 	}
 
-	if err = os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
-		return fmt.Errorf("os.MkdirAll %s: %w", destPath, err)
+	bodyBytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("io.ReadAll: %w", err)
 	}
 
-	tmp, err := os.CreateTemp(filepath.Dir(destPath), ".dl-*")
+	urlExt := pageExtension(imageURL)
+	opt := OptimizePage(bodyBytes, urlExt, logger)
+
+	destPath := filepath.Join(dir, pageFilename(pageIndex, opt.Extension))
+
+	if err = os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("os.MkdirAll %s: %w", dir, err)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".dl-*")
 	if err != nil {
-		return fmt.Errorf("os.CreateTemp %s: %w", destPath, err)
+		return fmt.Errorf("os.CreateTemp %s: %w", dir, err)
 	}
 
 	tmpName := tmp.Name()
@@ -180,8 +198,8 @@ func downloadPage(ctx context.Context, client *http.Client, imageURL, destPath s
 		os.Remove(tmpName)
 	}()
 
-	if _, err = io.Copy(tmp, res.Body); err != nil {
-		return fmt.Errorf("io.Copy %s: %w", tmpName, err)
+	if _, err = tmp.Write(opt.Data); err != nil {
+		return fmt.Errorf("tmp.Write %s: %w", tmpName, err)
 	}
 
 	if err = tmp.Sync(); err != nil {

--- a/api/pkg/core/chapters/download/storage_internal_test.go
+++ b/api/pkg/core/chapters/download/storage_internal_test.go
@@ -3,7 +3,10 @@
 package download
 
 import (
+	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -85,5 +88,63 @@ func TestDiskPagesOpenPageMissing(t *testing.T) {
 	_, _, err := DiskPages{Dir: t.TempDir()}.OpenPage(uuid.New(), 1, 1)
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Errorf("OpenPage = %v, want ErrNotFound", err)
+	}
+}
+
+func TestDownloadPage_Success(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("page-bytes"))
+	}))
+	t.Cleanup(server.Close)
+
+	dir := t.TempDir()
+	err := downloadPage(context.Background(), server.Client(), server.URL+"/page.jpg", dir, 1, nil)
+	if err != nil {
+		t.Fatalf("downloadPage: %v", err)
+	}
+
+	expectedFile := filepath.Join(dir, "001.jpg")
+	data, err := os.ReadFile(expectedFile)
+	if err != nil {
+		t.Fatalf("os.ReadFile: %v", err)
+	}
+
+	if string(data) != "page-bytes" {
+		t.Errorf("data = %q, want %q", string(data), "page-bytes")
+	}
+
+	// Verify no temporary files left behind
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("os.ReadDir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("expected 1 file in dir, got %d", len(entries))
+	}
+}
+
+func TestDownloadPage_Non200Error(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	dir := t.TempDir()
+	err := downloadPage(context.Background(), server.Client(), server.URL+"/page.jpg", dir, 1, nil)
+	if err == nil {
+		t.Fatal("downloadPage expected error on 404, got nil")
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("os.ReadDir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected 0 files in dir, got %d", len(entries))
 	}
 }

--- a/api/pkg/core/chapters/download/worker.go
+++ b/api/pkg/core/chapters/download/worker.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -330,10 +329,8 @@ func (w *Worker) processChapter(ctx context.Context, source sources.SourceName, 
 	for _, pageIndex := range missing {
 		errG.Go(func() error {
 			imageURL := pageURLs[pageIndex-1]
-			ext := pageExtension(imageURL)
-			destPath := filepath.Join(dir, pageFilename(pageIndex, ext))
 
-			if err := w.downloadPageWithRetries(errCtx, throttle, imageURL, destPath); err != nil {
+			if err := w.downloadPageWithRetries(errCtx, throttle, imageURL, dir, pageIndex); err != nil {
 				return err
 			}
 
@@ -362,7 +359,9 @@ func (w *Worker) processChapter(ctx context.Context, source sources.SourceName, 
 func (w *Worker) downloadPageWithRetries(
 	ctx context.Context,
 	throttle *sourceThrottle,
-	imageURL, destPath string,
+	imageURL string,
+	dir string,
+	pageIndex int,
 ) error {
 	var lastErr error
 
@@ -371,7 +370,7 @@ func (w *Worker) downloadPageWithRetries(
 			return fmt.Errorf("throttle.wait: %w", err)
 		}
 
-		lastErr = downloadPage(ctx, w.deps.HTTPClient, imageURL, destPath)
+		lastErr = downloadPage(ctx, w.deps.HTTPClient, imageURL, dir, pageIndex, w.deps.Logger)
 		if lastErr == nil {
 			return nil
 		}

--- a/api/pkg/core/chapters/download/worker_test.go
+++ b/api/pkg/core/chapters/download/worker_test.go
@@ -4,12 +4,14 @@
 package download_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
@@ -173,7 +175,8 @@ func newTestWorkerWithConfig(
 	t.Cleanup(server.Close)
 
 	for i := range pageURLs {
-		pageURLs[i] = server.URL + fmt.Sprintf("/page-%d", i+1)
+		ext := path.Ext(pageURLs[i])
+		pageURLs[i] = server.URL + fmt.Sprintf("/page-%d%s", i+1, ext)
 	}
 
 	if cfg.Dir == "" {
@@ -649,4 +652,389 @@ func TestWorkerResumeEnqueuesWithoutClearingPages(t *testing.T) {
 	if updated.Download != 42 {
 		t.Errorf("download = %d, want 42", updated.Download)
 	}
+}
+
+func TestWorkerOptimizesPNGToWebP(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chapterID := uuid.New()
+	chapter := chapters.Chapter{
+		ID:                chapterID,
+		ComicID:           comicID,
+		SourceChapterSlug: "chapter-1",
+		Number:            1,
+		PagesNb:           1,
+	}
+	comic := comics.Comic{
+		ID:     comicID,
+		Source: sources.SourceAsuraScans,
+		Slug:   "series-slug",
+	}
+
+	pngBytes := createTestPNG(t, 200, 200)
+
+	worker, dir, chaptersRepo := newTestWorker(
+		t,
+		chapter,
+		comic,
+		[]string{".png"},
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(pngBytes)
+		}),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = worker.Run(ctx)
+	}()
+
+	err := worker.Enqueue(context.Background(), []chapters.Chapter{chapter})
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		updated, err := chaptersRepo.GetByID(context.Background(), chapterID)
+		if err == nil && updated.Download == 100 {
+			chapterDir := filepath.Join(dir, comicID.String(), "1")
+			webpPath := filepath.Join(chapterDir, "001.webp")
+			pngPath := filepath.Join(chapterDir, "001.png")
+
+			data, err := os.ReadFile(webpPath)
+			if err != nil {
+				t.Fatalf("expected 001.webp to exist: %v", err)
+			}
+
+			if len(data) >= len(pngBytes) {
+				t.Errorf("expected webp size (%d) to be smaller than png (%d)", len(data), len(pngBytes))
+			}
+
+			if download.SniffFormat(data) != download.FormatWebP {
+				t.Errorf("expected downloaded file to be webp format")
+			}
+
+			if _, err := os.Stat(pngPath); !os.IsNotExist(err) {
+				t.Errorf("expected 001.png not to exist")
+			}
+
+			return
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatal("chapter was not completed")
+}
+
+func TestWorkerOptimizesJPEGToWebPWhenSmaller(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chapterID := uuid.New()
+	chapter := chapters.Chapter{
+		ID:                chapterID,
+		ComicID:           comicID,
+		SourceChapterSlug: "chapter-1",
+		Number:            1,
+		PagesNb:           1,
+	}
+	comic := comics.Comic{
+		ID:     comicID,
+		Source: sources.SourceAsuraScans,
+		Slug:   "series-slug",
+	}
+
+	jpegBytes := createTestSolidJPEG(t, 200, 200)
+
+	worker, dir, chaptersRepo := newTestWorker(
+		t,
+		chapter,
+		comic,
+		[]string{".jpg"},
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(jpegBytes)
+		}),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = worker.Run(ctx)
+	}()
+
+	err := worker.Enqueue(context.Background(), []chapters.Chapter{chapter})
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		updated, err := chaptersRepo.GetByID(context.Background(), chapterID)
+		if err == nil && updated.Download == 100 {
+			chapterDir := filepath.Join(dir, comicID.String(), "1")
+			webpPath := filepath.Join(chapterDir, "001.webp")
+
+			data, err := os.ReadFile(webpPath)
+			if err != nil {
+				t.Fatalf("expected 001.webp to exist: %v", err)
+			}
+
+			if len(data) >= len(jpegBytes) {
+				t.Errorf("expected webp size (%d) to be smaller than jpeg (%d)", len(data), len(jpegBytes))
+			}
+
+			if download.SniffFormat(data) != download.FormatWebP {
+				t.Errorf("expected downloaded file to be webp format")
+			}
+
+			return
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatal("chapter was not completed")
+}
+
+func TestWorkerPreservesJPEGWhenWebPLarger(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chapterID := uuid.New()
+	chapter := chapters.Chapter{
+		ID:                chapterID,
+		ComicID:           comicID,
+		SourceChapterSlug: "chapter-1",
+		Number:            1,
+		PagesNb:           1,
+	}
+	comic := comics.Comic{
+		ID:     comicID,
+		Source: sources.SourceAsuraScans,
+		Slug:   "series-slug",
+	}
+
+	jpegBytes := createTestJPEG(t, 200, 200)
+
+	worker, dir, chaptersRepo := newTestWorker(
+		t,
+		chapter,
+		comic,
+		[]string{".jpg"},
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(jpegBytes)
+		}),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = worker.Run(ctx)
+	}()
+
+	err := worker.Enqueue(context.Background(), []chapters.Chapter{chapter})
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		updated, err := chaptersRepo.GetByID(context.Background(), chapterID)
+		if err == nil && updated.Download == 100 {
+			chapterDir := filepath.Join(dir, comicID.String(), "1")
+			jpgPath := filepath.Join(chapterDir, "001.jpg")
+
+			data, err := os.ReadFile(jpgPath)
+			if err != nil {
+				t.Fatalf("expected 001.jpg to exist: %v", err)
+			}
+
+			if !bytes.Equal(data, jpegBytes) {
+				t.Errorf("expected original jpeg bytes to be preserved")
+			}
+
+			return
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatal("chapter was not completed")
+}
+
+func TestWorkerResumesSkippingExistingWebPAndPNG(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chapterID := uuid.New()
+	chapter := chapters.Chapter{
+		ID:                chapterID,
+		ComicID:           comicID,
+		SourceChapterSlug: "chapter-1",
+		Number:            1,
+		PagesNb:           3,
+	}
+	comic := comics.Comic{
+		ID:     comicID,
+		Source: sources.SourceAsuraScans,
+		Slug:   "series-slug",
+	}
+
+	page3PNG := createTestPNG(t, 200, 200)
+
+	var calls atomic.Int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(page3PNG)
+	})
+
+	worker, dir, chaptersRepo := newTestWorker(
+		t,
+		chapter,
+		comic,
+		[]string{".png", ".png", ".png"},
+		handler,
+	)
+
+	chapterDir := filepath.Join(dir, comicID.String(), "1")
+	if err := os.MkdirAll(chapterDir, 0o755); err != nil {
+		t.Fatalf("os.MkdirAll: %v", err)
+	}
+
+	existingPage1 := []byte("existing-webp-page1")
+	existingPage2 := []byte("existing-png-page2")
+
+	if err := os.WriteFile(filepath.Join(chapterDir, "001.webp"), existingPage1, 0o644); err != nil {
+		t.Fatalf("os.WriteFile: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(chapterDir, "002.png"), existingPage2, 0o644); err != nil {
+		t.Fatalf("os.WriteFile: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = worker.Run(ctx)
+	}()
+
+	err := worker.Enqueue(context.Background(), []chapters.Chapter{chapter})
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		updated, err := chaptersRepo.GetByID(context.Background(), chapterID)
+		if err == nil && updated.Download == 100 {
+			if calls.Load() != 1 {
+				t.Fatalf("download attempts for missing page = %d, want 1", calls.Load())
+			}
+
+			// Verify existing files were untouched
+			p1, err := os.ReadFile(filepath.Join(chapterDir, "001.webp"))
+			if err != nil || !bytes.Equal(p1, existingPage1) {
+				t.Fatalf("001.webp modified or missing: %v", err)
+			}
+
+			p2, err := os.ReadFile(filepath.Join(chapterDir, "002.png"))
+			if err != nil || !bytes.Equal(p2, existingPage2) {
+				t.Fatalf("002.png modified or missing: %v", err)
+			}
+
+			// Verify page 3 was downloaded and optimized to webp
+			if _, err := os.Stat(filepath.Join(chapterDir, "003.webp")); err != nil {
+				t.Fatalf("third page not saved as webp: %v", err)
+			}
+
+			return
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatal("chapter was not completed")
+}
+
+func TestWorkerPreservesAPNGAsPNG(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	chapterID := uuid.New()
+	chapter := chapters.Chapter{
+		ID:                chapterID,
+		ComicID:           comicID,
+		SourceChapterSlug: "chapter-1",
+		Number:            1,
+		PagesNb:           1,
+	}
+	comic := comics.Comic{
+		ID:     comicID,
+		Source: sources.SourceAsuraScans,
+		Slug:   "series-slug",
+	}
+
+	apngBytes := createTestAPNG(t)
+
+	worker, dir, chaptersRepo := newTestWorker(
+		t,
+		chapter,
+		comic,
+		[]string{".png"},
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(apngBytes)
+		}),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = worker.Run(ctx)
+	}()
+
+	err := worker.Enqueue(context.Background(), []chapters.Chapter{chapter})
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		updated, err := chaptersRepo.GetByID(context.Background(), chapterID)
+		if err == nil && updated.Download == 100 {
+			chapterDir := filepath.Join(dir, comicID.String(), "1")
+			pngPath := filepath.Join(chapterDir, "001.png")
+			webpPath := filepath.Join(chapterDir, "001.webp")
+
+			data, err := os.ReadFile(pngPath)
+			if err != nil {
+				t.Fatalf("expected 001.png to exist: %v", err)
+			}
+
+			if !bytes.Equal(data, apngBytes) {
+				t.Errorf("expected APNG bytes to be preserved exactly")
+			}
+
+			if _, err := os.Stat(webpPath); !os.IsNotExist(err) {
+				t.Errorf("expected 001.webp not to exist for APNG")
+			}
+
+			return
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatal("chapter was not completed")
 }


### PR DESCRIPTION
## Summary
- Implemented automatic lossless WebP conversion for chapter page downloads when the resulting WebP is smaller than the original image bytes.
- Format detection uses magic bytes sniffing (supporting JPEG and PNG, while skipping animated WebP / APNG).
- Maintained safe fallback behavior: if encoding fails, if the format is unsupported/animated, or if the converted WebP is larger than original bytes, the original bytes and file extension are stored.
- Ensured atomic file writes (`NNN.tmp` -> `NNN.ext`) and updated `SavePageBytes` to handle extension changes.
- Updated chapter storage path listing and resume logic to recognize any supported page file extension (`NNN.ext`).
- Updated `CONTEXT.md` documentation for Chapter files (local).

Closes #91

## Test plan
- [x] Unit tests for image format sniffing, APNG detection, and lossless WebP optimizer (`imageopt_test.go`).
- [x] Unit tests for worker download loop, smaller WebP writing, larger/failed fallback retention, and progress tracking (`worker_test.go`).
- [x] Storage tests for path generation and listing with multi-extension support (`storage_test.go` / `storage_internal_test.go`).
- [x] Run `go test ./...` in `api/`
- [x] Run `golangci-lint run ./...` in `api/`

