### PR TITLE
refactor(docker): always embed the SPA in the image (#97)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,5 @@ jobs:
         with:
           context: .
           push: false
-          build-args: WITH_WEB=on
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,8 +38,8 @@ of the instance, used to build the redirect URI registered at the identity
 provider.
 
 In dev, Nuxt proxies `/api` to `:3000`. In production the SPA is embedded into
-the binary through the `webui` build tag (`WITH_WEB=on`), so a single container
-serves both. To exercise that path:
+the binary through the `webui` build tag. The Docker image always passes that
+tag, so a single container serves both. To exercise that path:
 
 ```bash
 docker compose up --build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-ARG WITH_WEB=off
-
-FROM node:26-alpine AS web-on
+FROM node:26-alpine AS web
 
 WORKDIR /web
 
@@ -16,12 +14,6 @@ COPY web/ ./
 
 RUN pnpm build
 
-FROM busybox AS web-off
-
-RUN mkdir -p /web/.output/public
-
-FROM web-${WITH_WEB} AS web
-
 FROM golang:1.26-alpine AS build
 
 WORKDIR /src
@@ -31,7 +23,6 @@ COPY api/cmd/ cmd/
 COPY api/pkg/ pkg/
 COPY --from=web /web/.output/public/ pkg/webui/dist/
 
-ARG WITH_WEB
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
 
@@ -40,7 +31,7 @@ ENV CGO_ENABLED=0
 RUN --mount=type=cache,target=/root/.cache/go-build \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -mod=readonly -trimpath \
-    -tags="$([ "${WITH_WEB}" = on ] && echo webui)" \
+    -tags=webui \
     -ldflags='-s -w' \
     -o /out/uchiyomiserver ./cmd/uchiyomiserver
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,9 +20,7 @@ services:
       start_period: 10s
 
   server:
-    build:
-      args:
-        WITH_WEB: ${WITH_WEB:-on}
+    build: .
     restart: unless-stopped
     depends_on:
       uchiyomi-db:


### PR DESCRIPTION
## Summary
- The Docker image always builds the Nuxt SPA and compiles the API with the `webui` tag, so a single container serves both.
- Removed `WITH_WEB` from the Dockerfile, `docker-compose.yml`, CI Docker job, and CONTRIBUTING.

Closes #97

## Test plan
- [ ] CI Docker job still builds successfully
- [ ] `docker compose up --build` produces a binary that serves the SPA
- [ ] Local `go run` + `pnpm dev` still works without embedding the SPA
- [ ] `WITH_WEB` is gone from Dockerfile, compose, workflows, and docs


Made with [Cursor](https://cursor.com)