### PR TITLE
ci: publish multi-arch GHCR images and Releases on v* tags (#98)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [master]
+    tags: ["v*"]
   pull_request:
 
 permissions:
@@ -160,16 +161,64 @@ jobs:
   docker:
     name: Docker image
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
       - uses: actions/checkout@v7
 
+      - uses: docker/setup-qemu-action@v3
+
       # The Dockerfile uses RUN --mount=type=cache, which needs buildx.
       - uses: docker/setup-buildx-action@v4
+
+      - name: Image tags
+        id: meta
+        run: |
+          IMAGE=ghcr.io/kharente-deuh/uchiyomi
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            TAG="${GITHUB_REF_NAME}"
+            {
+              echo "tags<<EOF"
+              echo "${IMAGE}:${TAG}"
+              if [[ "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                echo "${IMAGE}:latest"
+              fi
+              echo "EOF"
+            } >> "${GITHUB_OUTPUT}"
+            if [[ "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "prerelease=false" >> "${GITHUB_OUTPUT}"
+            else
+              echo "prerelease=true" >> "${GITHUB_OUTPUT}"
+            fi
+          else
+            echo "tags=" >> "${GITHUB_OUTPUT}"
+            echo "prerelease=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Log in to GHCR
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Build
         uses: docker/build-push-action@v7
         with:
           context: .
-          push: false
+          platforms: linux/amd64,linux/arm64
+          push: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          tags: ${{ steps.meta.outputs.tags }}
+          provenance: false
+          sbom: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          extra=()
+          if [[ "${{ steps.meta.outputs.prerelease }}" == "true" ]]; then
+            extra+=(--prerelease)
+          fi
+          gh release create "${GITHUB_REF_NAME}" --generate-notes --title "${GITHUB_REF_NAME}" "${extra[@]}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:26-alpine AS web
+FROM --platform=$BUILDPLATFORM node:26-alpine AS web
 
 WORKDIR /web
 
@@ -14,7 +14,7 @@ COPY web/ ./
 
 RUN pnpm build
 
-FROM golang:1.26-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS build
 
 WORKDIR /src
 


### PR DESCRIPTION
## Summary

Closes #98.

- On `v*` tags, build `linux/amd64` and `linux/arm64` in one job, push a single GHCR image only if both platforms succeed, and open a GitHub Release with generated notes (no binaries)
- Stable `vX.Y.Z` tags also move `:latest` and create a non-prerelease Release; prerelease tags (`-rc`, `-beta`, …) publish the git tag only and do not move `latest`
- PR / `master` CI keeps the same multi-arch build with `push: false`
- Cross-compile the web and Go stages on `BUILDPLATFORM` so QEMU does not run Node/Go under the target arch

## Test plan

- [ ] CI Docker job is green on a PR/`master` push (both architectures, no GHCR push)
- [ ] Push `vX.Y.Z` → `ghcr.io/kharente-deuh/uchiyomi:vX.Y.Z` and `:latest` for amd64 and arm64, plus a non-prerelease Release whose notes start from the previous `v*` tag
- [ ] Push `vX.Y.Z-rc.1` → that image tag only, prerelease Release, `latest` unchanged
- [ ] If either architecture fails, GHCR and the GitHub Release are not published
- [ ] README documents `docker pull ghcr.io/kharente-deuh/uchiyomi:…`


Made with [Cursor](https://cursor.com)