### PR TITLE
feat(auth): start OIDC login by provider slug (#111)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -145,3 +145,16 @@ _Avoid_: WebSocket, progress stream, SSE
 
 **Chapter download queue**:
 Each source has a single global download queue processed one chapter at a time (FIFO). Chapters are enqueued in ascending chapter number order. Across multiple comics, chapters are enqueued in the order their comic was added to a library. Enqueue is idempotent: a chapter is added only if its download progress is below 100 and it is not already in the queue. Chapters at 100 % or already queued are skipped. Within a chapter, pages are downloaded in parallel, throttled by a configurable rate limit on the worker.
+
+### Auth
+
+**OIDC provider**:
+An identity provider registered on the instance so users can sign in with it. Distinct from Source.
+_Avoid_: OIDC client (the registered app at the identity provider is not this entity)
+
+**OIDC provider display name**:
+The human-facing label shown on the login button ("Sign in with …"). Distinct from OIDC provider slug.
+_Avoid_: OIDC_NAME, using this as a URL identifier
+
+**OIDC provider slug**:
+The unique, URL-safe identifier of an OIDC provider, used in the login start URL. Distinct from OIDC provider display name and from Source slug.

--- a/api/cmd/uchiyomiserver/setup_internal_test.go
+++ b/api/cmd/uchiyomiserver/setup_internal_test.go
@@ -131,6 +131,12 @@ func (emptyOIDCProvidersRepository) GetByIssuerURL(
 	return nil, errors.New("not implemented")
 }
 
+func (emptyOIDCProvidersRepository) GetBySlug(
+	context.Context, string,
+) (*oidcproviders.OIDCProvider, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (emptyOIDCProvidersRepository) Create(
 	context.Context, oidcproviders.CreateOIDCProviderOpts,
 ) (*oidcproviders.OIDCProvider, error) {

--- a/api/pkg/core/auth/domain.go
+++ b/api/pkg/core/auth/domain.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/users"
 )
@@ -47,8 +46,8 @@ type LogoutResult struct {
 }
 
 type StartOIDCLoginOpts struct {
-	Redirect   string
-	ProviderID uuid.UUID
+	Redirect     string
+	ProviderSlug string
 }
 
 type OIDCStart struct {

--- a/api/pkg/core/auth/gateway/http/controller.go
+++ b/api/pkg/core/auth/gateway/http/controller.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
 	sessionshttp "github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/sessions/gateway/http"
@@ -117,7 +116,7 @@ func (c *Controller) InitRouter(r chi.Router) {
 		r.Post("/login", c.loginWithPwd)
 		r.With(c.cfg.LogoutMiddlewares...).Post("/logout", c.logout)
 		r.Get("/providers", c.listProviders)
-		r.Get("/oidc/{id}/start", c.startOIDCLogin)
+		r.Get("/oidc/{slug}/start", c.startOIDCLogin)
 		r.Get("/oidc/callback", c.oidcCallback)
 		r.Post("/oidc/backchannel-logout", c.oidcBackchannelLogout)
 	})
@@ -196,6 +195,7 @@ func (c *Controller) listProviders(w http.ResponseWriter, r *http.Request) {
 	for _, p := range providers {
 		res = append(res, ProviderSummaryResponse{
 			ID:          p.ID.String(),
+			Slug:        p.Slug,
 			DisplayName: p.DisplayName,
 		})
 	}
@@ -206,16 +206,10 @@ func (c *Controller) listProviders(w http.ResponseWriter, r *http.Request) {
 func (c *Controller) startOIDCLogin(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	id, err := uuid.Parse(chi.URLParam(r, "id"))
-	if err != nil {
-		http.Redirect(w, r, "/login?error=oidcUnavailable", http.StatusFound)
-
-		return
-	}
-
+	slug := chi.URLParam(r, "slug")
 	res, err := c.deps.AuthService.StartOIDCLogin(ctx, auth.StartOIDCLoginOpts{
-		ProviderID: id,
-		Redirect:   r.URL.Query().Get("redirect"),
+		ProviderSlug: slug,
+		Redirect:     r.URL.Query().Get("redirect"),
 	})
 	if err != nil {
 		c.logOIDCError(ctx, "failed to start oidc login", err)

--- a/api/pkg/core/auth/gateway/http/controller_test.go
+++ b/api/pkg/core/auth/gateway/http/controller_test.go
@@ -916,11 +916,11 @@ func getProviders(t *testing.T, r chi.Router) *httptest.ResponseRecorder {
 	return rec
 }
 
-func getOIDCStart(t *testing.T, r chi.Router, id string) *httptest.ResponseRecorder {
+func getOIDCStart(t *testing.T, r chi.Router, slug string) *httptest.ResponseRecorder {
 	t.Helper()
 
 	rec := httptest.NewRecorder()
-	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/auth/oidc/"+id+"/start", nil))
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/auth/oidc/"+slug+"/start", nil))
 
 	return rec
 }
@@ -945,7 +945,7 @@ func TestListProvidersReturnsMappedShape(t *testing.T) {
 
 	id := uuid.New()
 	providers := &stubProvidersLister{result: []oidcproviders.LightOIDCProvider{
-		{ID: id, DisplayName: "Acme SSO"},
+		{ID: id, Slug: "acme", DisplayName: "Acme SSO"},
 	}}
 	r, _ := newTestRouterWithProviders(t, &stubAuthService{}, providers)
 
@@ -960,7 +960,7 @@ func TestListProvidersReturnsMappedShape(t *testing.T) {
 		t.Fatalf("json.Unmarshal(%s): %v", rec.Body.String(), err)
 	}
 
-	want := []authhttp.ProviderSummaryResponse{{ID: id.String(), DisplayName: "Acme SSO"}}
+	want := []authhttp.ProviderSummaryResponse{{ID: id.String(), Slug: "acme", DisplayName: "Acme SSO"}}
 	if len(got) != 1 || got[0] != want[0] {
 		t.Errorf("body = %+v, want %+v", got, want)
 	}
@@ -987,10 +987,11 @@ func TestListProvidersServiceError(t *testing.T) {
 	}
 }
 
-func TestStartOIDCLoginBadUUIDRedirects(t *testing.T) {
+func TestStartOIDCLoginUnknownSlugRedirects(t *testing.T) {
 	t.Parallel()
 
-	r, _ := newTestRouterWithProviders(t, &stubAuthService{}, &stubProvidersLister{})
+	svc := &stubAuthService{startErr: auth.ErrOIDCUnavailable}
+	r, _ := newTestRouterWithProviders(t, svc, &stubProvidersLister{})
 
 	rec := getOIDCStart(t, r, "not-a-uuid")
 
@@ -1006,7 +1007,6 @@ func TestStartOIDCLoginBadUUIDRedirects(t *testing.T) {
 func TestStartOIDCLoginHappyPathRedirectsAndSetsStateCookie(t *testing.T) {
 	t.Parallel()
 
-	id := uuid.New()
 	svc := &stubAuthService{startResult: &auth.OIDCStart{
 		AuthCodeURL:      "https://idp.example.com/authorize?state=abc",
 		StateCookieValue: "opaque-state",
@@ -1014,7 +1014,7 @@ func TestStartOIDCLoginHappyPathRedirectsAndSetsStateCookie(t *testing.T) {
 	}}
 	r, _ := newTestRouterWithProviders(t, svc, &stubProvidersLister{})
 
-	rec := getOIDCStart(t, r, id.String())
+	rec := getOIDCStart(t, r, "keycloak")
 
 	if rec.Code != http.StatusFound {
 		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusFound, rec.Body.String())
@@ -1024,8 +1024,8 @@ func TestStartOIDCLoginHappyPathRedirectsAndSetsStateCookie(t *testing.T) {
 		t.Errorf("Location = %q, want %q", loc, svc.startResult.AuthCodeURL)
 	}
 
-	if svc.gotStartOpts.ProviderID != id {
-		t.Errorf("ProviderID = %v, want %v", svc.gotStartOpts.ProviderID, id)
+	if svc.gotStartOpts.ProviderSlug != "keycloak" {
+		t.Errorf("ProviderSlug = %q, want %q", svc.gotStartOpts.ProviderSlug, "keycloak")
 	}
 
 	raw := rec.Header().Get("Set-Cookie")

--- a/api/pkg/core/auth/gateway/http/dto.go
+++ b/api/pkg/core/auth/gateway/http/dto.go
@@ -17,6 +17,7 @@ type LoginWithPwdResponse struct {
 
 type ProviderSummaryResponse struct {
 	ID          string `json:"id"`
+	Slug        string `json:"slug"`
 	DisplayName string `json:"displayName"`
 }
 

--- a/api/pkg/core/auth/oidc/client_test.go
+++ b/api/pkg/core/auth/oidc/client_test.go
@@ -233,6 +233,7 @@ func baseClaims(issuer, clientID, nonce string) map[string]any {
 func testProvider(issuer string) oidcproviders.OIDCProvider {
 	return oidcproviders.OIDCProvider{
 		ID:              uuid.New(),
+		Slug:            "keycloak",
 		IssuerURL:       issuer,
 		ClientID:        "test-client",
 		ClientSecretEnc: []byte("encrypted-secret"),

--- a/api/pkg/core/auth/oidc/revalidation_app_test.go
+++ b/api/pkg/core/auth/oidc/revalidation_app_test.go
@@ -87,6 +87,10 @@ func (r *stubOIDCProvidersRepo) GetByIssuerURL(context.Context, string) (*oidcpr
 	panic("GetByIssuerURL is not used by the revalidation app")
 }
 
+func (r *stubOIDCProvidersRepo) GetBySlug(context.Context, string) (*oidcproviders.OIDCProvider, error) {
+	panic("GetBySlug is not used by the revalidation app")
+}
+
 func (r *stubOIDCProvidersRepo) Create(
 	context.Context,
 	oidcproviders.CreateOIDCProviderOpts,

--- a/api/pkg/core/auth/oidc_login.go
+++ b/api/pkg/core/auth/oidc_login.go
@@ -34,7 +34,7 @@ type oidcStatePayload struct {
 }
 
 func (s *Service) StartOIDCLogin(ctx context.Context, opts StartOIDCLoginOpts) (*OIDCStart, error) {
-	provider, err := s.deps.OIDCProvidersRepository.GetByID(ctx, opts.ProviderID)
+	provider, err := s.deps.OIDCProvidersRepository.GetBySlug(ctx, opts.ProviderSlug)
 	if err != nil {
 		if errors.Is(err, domain.ErrNotFound) {
 			return nil, ErrOIDCUnavailable

--- a/api/pkg/core/auth/oidc_login_test.go
+++ b/api/pkg/core/auth/oidc_login_test.go
@@ -282,13 +282,18 @@ func TestStartOIDCLoginBuildsAuthCodeURLAndCookie(t *testing.T) {
 	t.Parallel()
 
 	f := newFakes()
+	svc := f.svc(t)
 
-	got, err := f.svc(t).StartOIDCLogin(context.Background(), auth.StartOIDCLoginOpts{
-		ProviderID: f.opr.provider.ID,
-		Redirect:   testRedirectPath,
+	got, err := svc.StartOIDCLogin(context.Background(), auth.StartOIDCLoginOpts{
+		ProviderSlug: f.opr.provider.Slug,
+		Redirect:     testRedirectPath,
 	})
 	if err != nil {
 		t.Fatalf("StartOIDCLogin: %v", err)
+	}
+
+	if f.opr.gotSlug != "keycloak" {
+		t.Errorf("gotSlug = %q, want keycloak", f.opr.gotSlug)
 	}
 
 	if got.AuthCodeURL != f.oc.authCodeURL {
@@ -310,6 +315,18 @@ func TestStartOIDCLoginBuildsAuthCodeURLAndCookie(t *testing.T) {
 	if f.oc.gotAuthParams.State == "" || f.oc.gotAuthParams.Nonce == "" || f.oc.gotAuthParams.Verifier == "" {
 		t.Errorf("AuthCodeParams incomplets: %+v", f.oc.gotAuthParams)
 	}
+
+	if _, err := svc.FinishOIDCLogin(context.Background(), auth.FinishOIDCLoginOpts{
+		Code:             testOIDCCode,
+		State:            f.oc.gotAuthParams.State,
+		StateCookieValue: got.StateCookieValue,
+	}); err != nil {
+		t.Fatalf("FinishOIDCLogin: %v", err)
+	}
+
+	if f.opr.gotID != f.opr.provider.ID {
+		t.Errorf("state cookie ProviderID = %v, want %v", f.opr.gotID, f.opr.provider.ID)
+	}
 }
 
 func TestStartOIDCLoginCookieRoundTripsThroughFinish(t *testing.T) {
@@ -319,8 +336,8 @@ func TestStartOIDCLoginCookieRoundTripsThroughFinish(t *testing.T) {
 	svc := f.svc(t)
 
 	start, err := svc.StartOIDCLogin(context.Background(), auth.StartOIDCLoginOpts{
-		ProviderID: f.opr.provider.ID,
-		Redirect:   testRedirectPath,
+		ProviderSlug: f.opr.provider.Slug,
+		Redirect:     testRedirectPath,
 	})
 	if err != nil {
 		t.Fatalf("StartOIDCLogin: %v", err)
@@ -358,7 +375,7 @@ func TestStartOIDCLoginUnknownProviderIsUnavailable(t *testing.T) {
 	f := newFakes()
 	f.opr.err = domain.ErrNotFound
 
-	_, err := f.svc(t).StartOIDCLogin(context.Background(), auth.StartOIDCLoginOpts{ProviderID: uuid.New()})
+	_, err := f.svc(t).StartOIDCLogin(context.Background(), auth.StartOIDCLoginOpts{ProviderSlug: "missing"})
 	if !errors.Is(err, auth.ErrOIDCUnavailable) {
 		t.Errorf("err = %v, want ErrOIDCUnavailable", err)
 	}
@@ -370,7 +387,7 @@ func TestStartOIDCLoginRepositoryFailureIsUnavailable(t *testing.T) {
 	f := newFakes()
 	f.opr.err = errors.New("connection refused")
 
-	_, err := f.svc(t).StartOIDCLogin(context.Background(), auth.StartOIDCLoginOpts{ProviderID: uuid.New()})
+	_, err := f.svc(t).StartOIDCLogin(context.Background(), auth.StartOIDCLoginOpts{ProviderSlug: "keycloak"})
 	if !errors.Is(err, auth.ErrOIDCUnavailable) {
 		t.Errorf("err = %v, want ErrOIDCUnavailable", err)
 	}
@@ -382,7 +399,7 @@ func TestStartOIDCLoginAuthCodeURLFailureIsUnavailable(t *testing.T) {
 	f := newFakes()
 	f.oc.authCodeErr = errors.New("discovery unreachable")
 
-	_, err := f.svc(t).StartOIDCLogin(context.Background(), auth.StartOIDCLoginOpts{ProviderID: f.opr.provider.ID})
+	_, err := f.svc(t).StartOIDCLogin(context.Background(), auth.StartOIDCLoginOpts{ProviderSlug: f.opr.provider.Slug})
 	if !errors.Is(err, auth.ErrOIDCUnavailable) {
 		t.Errorf("err = %v, want ErrOIDCUnavailable", err)
 	}
@@ -392,8 +409,8 @@ func startCookie(t *testing.T, f *fakes, svc *auth.Service) (string, string) {
 	t.Helper()
 
 	start, err := svc.StartOIDCLogin(context.Background(), auth.StartOIDCLoginOpts{
-		ProviderID: f.opr.provider.ID,
-		Redirect:   testRedirectPath,
+		ProviderSlug: f.opr.provider.Slug,
+		Redirect:     testRedirectPath,
 	})
 	if err != nil {
 		t.Fatalf("StartOIDCLogin: %v", err)
@@ -620,8 +637,8 @@ func TestFinishOIDCLoginUnsafeRedirectFallsBackToRoot(t *testing.T) {
 	svc := f.svc(t)
 
 	start, err := svc.StartOIDCLogin(context.Background(), auth.StartOIDCLoginOpts{
-		ProviderID: f.opr.provider.ID,
-		Redirect:   "//evil.example.com",
+		ProviderSlug: f.opr.provider.Slug,
+		Redirect:     "//evil.example.com",
 	})
 	if err != nil {
 		t.Fatalf("StartOIDCLogin: %v", err)

--- a/api/pkg/core/auth/oidc_login_test.go
+++ b/api/pkg/core/auth/oidc_login_test.go
@@ -292,8 +292,8 @@ func TestStartOIDCLoginBuildsAuthCodeURLAndCookie(t *testing.T) {
 		t.Fatalf("StartOIDCLogin: %v", err)
 	}
 
-	if f.opr.gotSlug != "keycloak" {
-		t.Errorf("gotSlug = %q, want keycloak", f.opr.gotSlug)
+	if f.opr.gotSlug != testProviderSlug {
+		t.Errorf("gotSlug = %q, want %q", f.opr.gotSlug, testProviderSlug)
 	}
 
 	if got.AuthCodeURL != f.oc.authCodeURL {
@@ -387,7 +387,7 @@ func TestStartOIDCLoginRepositoryFailureIsUnavailable(t *testing.T) {
 	f := newFakes()
 	f.opr.err = errors.New("connection refused")
 
-	_, err := f.svc(t).StartOIDCLogin(context.Background(), auth.StartOIDCLoginOpts{ProviderSlug: "keycloak"})
+	_, err := f.svc(t).StartOIDCLogin(context.Background(), auth.StartOIDCLoginOpts{ProviderSlug: testProviderSlug})
 	if !errors.Is(err, auth.ErrOIDCUnavailable) {
 		t.Errorf("err = %v, want ErrOIDCUnavailable", err)
 	}

--- a/api/pkg/core/auth/oidc_login_test.go
+++ b/api/pkg/core/auth/oidc_login_test.go
@@ -33,6 +33,7 @@ type fakeOIDCProvidersRepo struct {
 	err          error
 	issuerErr    error
 	gotIssuerURL string
+	gotSlug      string
 	gotID        uuid.UUID
 	calls        int
 	issuerCalls  int
@@ -61,6 +62,21 @@ func (f *fakeOIDCProvidersRepo) GetByIssuerURL(
 	}
 
 	if f.provider != nil && f.provider.IssuerURL == issuerURL {
+		return f.provider, nil
+	}
+
+	return nil, domain.ErrNotFound
+}
+
+func (f *fakeOIDCProvidersRepo) GetBySlug(_ context.Context, slug string) (*oidcproviders.OIDCProvider, error) {
+	f.calls++
+	f.gotSlug = slug
+
+	if f.err != nil {
+		return nil, f.err
+	}
+
+	if f.provider != nil && f.provider.Slug == slug {
 		return f.provider, nil
 	}
 

--- a/api/pkg/core/auth/oidcproviders/domain.go
+++ b/api/pkg/core/auth/oidcproviders/domain.go
@@ -13,6 +13,7 @@ import (
 type OIDCProvidersRepository interface {
 	GetByID(context.Context, uuid.UUID) (*OIDCProvider, error)
 	GetByIssuerURL(context.Context, string) (*OIDCProvider, error)
+	GetBySlug(context.Context, string) (*OIDCProvider, error)
 	Create(context.Context, CreateOIDCProviderOpts) (*OIDCProvider, error)
 	Update(context.Context, uuid.UUID, UpdateOIDCProviderOpts) (*OIDCProvider, error)
 	DeleteByID(context.Context, uuid.UUID) error
@@ -28,6 +29,7 @@ type OIDCProvider struct {
 	UsernameClaim   string
 	IssuerURL       string
 	DisplayName     string
+	Slug            string
 	Scopes          []string
 	ClientSecretEnc []byte
 	AdminValues     []string
@@ -38,6 +40,7 @@ type OIDCProvider struct {
 
 type UpdateOIDCProviderOpts struct {
 	DisplayName string
+	Slug        string
 
 	IssuerURL string
 	ClientID  string
@@ -53,6 +56,7 @@ type UpdateOIDCProviderOpts struct {
 
 type CreateOIDCProviderOpts struct {
 	DisplayName string
+	Slug        string
 
 	IssuerURL       string
 	ClientID        string
@@ -82,9 +86,12 @@ type OIDCProviderDetails struct {
 type LightOIDCProvider struct {
 	CreatedAt   time.Time
 	DisplayName string
+	Slug        string
 	ID          uuid.UUID
 	UserCount   int64
 }
+
+var ErrSlugTaken = errors.New("oidc provider slug already exists")
 
 var ErrIncompleteDiscovery = errors.New("discovery document is incomplete")
 

--- a/api/pkg/core/auth/oidcproviders/gateway/http/controller.go
+++ b/api/pkg/core/auth/oidcproviders/gateway/http/controller.go
@@ -121,6 +121,7 @@ func (c *Controller) list(w http.ResponseWriter, r *http.Request) {
 		res = append(res, LightProviderResponse{
 			CreatedAt:   p.CreatedAt,
 			ID:          p.ID.String(),
+			Slug:        p.Slug,
 			DisplayName: p.DisplayName,
 			UserCount:   p.UserCount,
 		})
@@ -167,6 +168,7 @@ func (c *Controller) create(w http.ResponseWriter, r *http.Request) {
 
 	provider, err := c.deps.Service.Create(ctx, oidcproviders.CreateOpts{
 		DisplayName:   req.DisplayName.String(),
+		Slug:          req.Slug.String(),
 		IssuerURL:     req.IssuerURL.String(),
 		ClientID:      req.ClientID.String(),
 		ClientSecret:  req.ClientSecret.String(),
@@ -211,6 +213,7 @@ func (c *Controller) update(w http.ResponseWriter, r *http.Request) {
 
 	provider, err := c.deps.Service.Update(ctx, id, oidcproviders.UpdateOpts{
 		DisplayName:   req.DisplayName.String(),
+		Slug:          req.Slug.String(),
 		IssuerURL:     req.IssuerURL.String(),
 		ClientID:      req.ClientID.String(),
 		UsernameClaim: req.UsernameClaim.String(),
@@ -285,6 +288,8 @@ func (c *Controller) writeServiceError(w http.ResponseWriter, r *http.Request, m
 			"issuer discovery document does not advertise the required endpoints")
 	case errors.Is(err, domain.ErrAlreadyExists):
 		httputils.WriteError(w, c.deps.Logger, http.StatusConflict, "issuer URL is already declared")
+	case errors.Is(err, oidcproviders.ErrSlugTaken):
+		httputils.WriteError(w, c.deps.Logger, http.StatusConflict, "slug is already declared")
 	case errors.Is(err, domain.ErrNotFound):
 		httputils.WriteError(w, c.deps.Logger, http.StatusNotFound, "")
 	default:
@@ -316,6 +321,7 @@ func toProviderResponse(p *oidcproviders.OIDCProvider) ProviderResponse {
 		UpdatedAt:     p.UpdatedAt,
 		RoleClaim:     p.RoleClaim,
 		ID:            p.ID.String(),
+		Slug:          p.Slug,
 		DisplayName:   p.DisplayName,
 		IssuerURL:     p.IssuerURL,
 		ClientID:      p.ClientID,

--- a/api/pkg/core/auth/oidcproviders/gateway/http/controller_test.go
+++ b/api/pkg/core/auth/oidcproviders/gateway/http/controller_test.go
@@ -156,6 +156,7 @@ func sampleProvider() *oidcproviders.OIDCProvider {
 	return &oidcproviders.OIDCProvider{
 		ID:            uuid.New(),
 		DisplayName:   testDisplayName,
+		Slug:          "keycloak",
 		IssuerURL:     testIssuerURL,
 		ClientID:      "uchiyomi",
 		UsernameClaim: "preferred_username",

--- a/api/pkg/core/auth/oidcproviders/gateway/http/controller_test.go
+++ b/api/pkg/core/auth/oidcproviders/gateway/http/controller_test.go
@@ -28,6 +28,7 @@ const (
 	cookieName      = "uchiyomi_session"
 	testToken       = "letoken"
 	testDisplayName = "Keycloak"
+	testSlug        = "keycloak"
 	testIssuerURL   = "https://sso.example.com"
 	testUsername    = "alice"
 
@@ -156,7 +157,7 @@ func sampleProvider() *oidcproviders.OIDCProvider {
 	return &oidcproviders.OIDCProvider{
 		ID:            uuid.New(),
 		DisplayName:   testDisplayName,
-		Slug:          "keycloak",
+		Slug:          testSlug,
 		IssuerURL:     testIssuerURL,
 		ClientID:      "uchiyomi",
 		UsernameClaim: "preferred_username",
@@ -174,7 +175,7 @@ func TestListReturnsOnlyTheLightFields(t *testing.T) {
 
 	id := uuid.New()
 	svc := &stubService{list: []oidcproviders.LightOIDCProvider{
-		{ID: id, DisplayName: testDisplayName, Slug: "keycloak", CreatedAt: time.Now(), UserCount: 3},
+		{ID: id, DisplayName: testDisplayName, Slug: testSlug, CreatedAt: time.Now(), UserCount: 3},
 	}}
 	r := newRouter(t, svc, adminMiddlewares(t, admin()))
 
@@ -212,8 +213,8 @@ func TestListReturnsOnlyTheLightFields(t *testing.T) {
 		t.Errorf("userCount = %v, want 3", got[0]["userCount"])
 	}
 
-	if got[0]["slug"] != "keycloak" {
-		t.Errorf("slug = %v, want keycloak", got[0]["slug"])
+	if got[0]["slug"] != testSlug {
+		t.Errorf("slug = %v, want %s", got[0]["slug"], testSlug)
 	}
 }
 
@@ -244,8 +245,8 @@ func TestGetReturnsTheProviderWithoutASecret(t *testing.T) {
 		t.Errorf("issuerUrl = %v, want the full provider", got["issuerUrl"])
 	}
 
-	if got["slug"] != "keycloak" {
-		t.Errorf("slug = %v, want keycloak", got["slug"])
+	if got["slug"] != testSlug {
+		t.Errorf("slug = %v, want %s", got["slug"], testSlug)
 	}
 }
 
@@ -390,8 +391,8 @@ func TestCreateReturnsCreated(t *testing.T) {
 		t.Errorf("displayName = %q", got.DisplayName)
 	}
 
-	if got.Slug != "keycloak" {
-		t.Errorf("slug = %q, want keycloak", got.Slug)
+	if got.Slug != testSlug {
+		t.Errorf("slug = %q, want %s", got.Slug, testSlug)
 	}
 }
 
@@ -492,10 +493,10 @@ func TestCreateRejectsAnInvalidSlug(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]string{
-		"missing slug": `{"displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","clientSecret":"s","usernameClaim":"u","scopes":["openid"]}`, //nolint:lll
-		"empty slug":   `{"slug":"","displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","clientSecret":"s","usernameClaim":"u","scopes":["openid"]}`, //nolint:lll
+		"missing slug":   `{"displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","clientSecret":"s","usernameClaim":"u","scopes":["openid"]}`,                   //nolint:lll
+		"empty slug":     `{"slug":"","displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","clientSecret":"s","usernameClaim":"u","scopes":["openid"]}`,         //nolint:lll
 		"wrong case key": `{"Slug":"Keycloak","displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","clientSecret":"s","usernameClaim":"u","scopes":["openid"]}`, //nolint:lll
-		"underscore":     `{"slug":"A_B","displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","clientSecret":"s","usernameClaim":"u","scopes":["openid"]}`,         //nolint:lll
+		"underscore":     `{"slug":"A_B","displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","clientSecret":"s","usernameClaim":"u","scopes":["openid"]}`,      //nolint:lll
 	}
 
 	for name, body := range tests {
@@ -521,9 +522,9 @@ func TestUpdateRejectsAnInvalidSlug(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]string{
-		"missing slug": `{"displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","usernameClaim":"u","scopes":["openid"]}`, //nolint:lll
+		"missing slug":   `{"displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","usernameClaim":"u","scopes":["openid"]}`,                   //nolint:lll
 		"wrong case key": `{"Slug":"Keycloak","displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","usernameClaim":"u","scopes":["openid"]}`, //nolint:lll
-		"underscore":     `{"slug":"A_B","displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","usernameClaim":"u","scopes":["openid"]}`,         //nolint:lll
+		"underscore":     `{"slug":"A_B","displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","usernameClaim":"u","scopes":["openid"]}`,      //nolint:lll
 	}
 
 	for name, body := range tests {

--- a/api/pkg/core/auth/oidcproviders/gateway/http/controller_test.go
+++ b/api/pkg/core/auth/oidcproviders/gateway/http/controller_test.go
@@ -32,10 +32,10 @@ const (
 	testUsername    = "alice"
 
 	//nolint:lll
-	validBody = `{"displayName":"Keycloak","issuerUrl":"https://sso.example.com","clientId":"uchiyomi","clientSecret":"s3cr3t","usernameClaim":"preferred_username","scopes":["openid"],"roleClaim":null,"adminValues":null,"allowedValues":null,"autoProvision":true}`
+	validBody = `{"slug":"keycloak","displayName":"Keycloak","issuerUrl":"https://sso.example.com","clientId":"uchiyomi","clientSecret":"s3cr3t","usernameClaim":"preferred_username","scopes":["openid"],"roleClaim":null,"adminValues":null,"allowedValues":null,"autoProvision":true}`
 
 	//nolint:lll
-	validPutBody = `{"displayName":"Keycloak","issuerUrl":"https://sso.example.com","clientId":"uchiyomi","usernameClaim":"preferred_username","scopes":["openid"],"roleClaim":null,"adminValues":null,"allowedValues":null,"autoProvision":true}`
+	validPutBody = `{"slug":"keycloak","displayName":"Keycloak","issuerUrl":"https://sso.example.com","clientId":"uchiyomi","usernameClaim":"preferred_username","scopes":["openid"],"roleClaim":null,"adminValues":null,"allowedValues":null,"autoProvision":true}`
 )
 
 var errUnexpected = errors.New("boom")
@@ -174,7 +174,7 @@ func TestListReturnsOnlyTheLightFields(t *testing.T) {
 
 	id := uuid.New()
 	svc := &stubService{list: []oidcproviders.LightOIDCProvider{
-		{ID: id, DisplayName: testDisplayName, CreatedAt: time.Now(), UserCount: 3},
+		{ID: id, DisplayName: testDisplayName, Slug: "keycloak", CreatedAt: time.Now(), UserCount: 3},
 	}}
 	r := newRouter(t, svc, adminMiddlewares(t, admin()))
 
@@ -193,7 +193,7 @@ func TestListReturnsOnlyTheLightFields(t *testing.T) {
 		t.Fatalf("len = %d, want 1", len(got))
 	}
 
-	want := map[string]bool{"id": true, "displayName": true, "createdAt": true, "userCount": true}
+	want := map[string]bool{"id": true, "slug": true, "displayName": true, "createdAt": true, "userCount": true}
 	for key := range got[0] {
 		if !want[key] {
 			t.Errorf("the list exposes %q, which belongs to the detail response", key)
@@ -210,6 +210,10 @@ func TestListReturnsOnlyTheLightFields(t *testing.T) {
 
 	if got[0]["userCount"] != float64(3) {
 		t.Errorf("userCount = %v, want 3", got[0]["userCount"])
+	}
+
+	if got[0]["slug"] != "keycloak" {
+		t.Errorf("slug = %v, want keycloak", got[0]["slug"])
 	}
 }
 
@@ -238,6 +242,10 @@ func TestGetReturnsTheProviderWithoutASecret(t *testing.T) {
 
 	if got["issuerUrl"] != testIssuerURL {
 		t.Errorf("issuerUrl = %v, want the full provider", got["issuerUrl"])
+	}
+
+	if got["slug"] != "keycloak" {
+		t.Errorf("slug = %v, want keycloak", got["slug"])
 	}
 }
 
@@ -381,6 +389,10 @@ func TestCreateReturnsCreated(t *testing.T) {
 	if got.DisplayName != testDisplayName {
 		t.Errorf("displayName = %q", got.DisplayName)
 	}
+
+	if got.Slug != "keycloak" {
+		t.Errorf("slug = %q, want keycloak", got.Slug)
+	}
 }
 
 func TestCreateAcceptsEmptyValueListsWithoutARoleClaim(t *testing.T) {
@@ -389,7 +401,7 @@ func TestCreateAcceptsEmptyValueListsWithoutARoleClaim(t *testing.T) {
 	r := newRouter(t, &stubService{provider: sampleProvider()}, adminMiddlewares(t, admin()))
 
 	//nolint:lll
-	body := `{"displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","clientSecret":"s","usernameClaim":"u","scopes":["openid"],"adminValues":[],"allowedValues":[]}`
+	body := `{"slug":"k","displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","clientSecret":"s","usernameClaim":"u","scopes":["openid"],"adminValues":[],"allowedValues":[]}`
 
 	rec := do(r, http.MethodPost, endpoint, body)
 
@@ -404,7 +416,7 @@ func TestUpdateRejectsValuesWithoutARoleClaim(t *testing.T) {
 	r := newRouter(t, &stubService{provider: sampleProvider()}, adminMiddlewares(t, admin()))
 
 	//nolint:lll
-	body := `{"displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","clientSecret":null,"usernameClaim":"u","scopes":["openid"],"adminValues":["admins"]}`
+	body := `{"slug":"k","displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","clientSecret":null,"usernameClaim":"u","scopes":["openid"],"adminValues":["admins"]}`
 
 	rec := do(r, http.MethodPut, endpoint+"/"+uuid.New().String(), body)
 
@@ -453,6 +465,83 @@ func TestCreateConflictOnADuplicateIssuer(t *testing.T) {
 
 	if rec.Code != http.StatusConflict {
 		t.Errorf("status = %d, want %d (body: %s)", rec.Code, http.StatusConflict, rec.Body.String())
+	}
+
+	if !strings.Contains(rec.Body.String(), "issuer URL is already declared") {
+		t.Errorf("body = %s, want issuer URL conflict message", rec.Body.String())
+	}
+}
+
+func TestCreateConflictOnADuplicateSlug(t *testing.T) {
+	t.Parallel()
+
+	r := newRouter(t, &stubService{err: oidcproviders.ErrSlugTaken}, adminMiddlewares(t, admin()))
+
+	rec := do(r, http.MethodPost, endpoint, validBody)
+
+	if rec.Code != http.StatusConflict {
+		t.Errorf("status = %d, want %d (body: %s)", rec.Code, http.StatusConflict, rec.Body.String())
+	}
+
+	if !strings.Contains(rec.Body.String(), "slug is already declared") {
+		t.Errorf("body = %s, want slug conflict message", rec.Body.String())
+	}
+}
+
+func TestCreateRejectsAnInvalidSlug(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"missing slug": `{"displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","clientSecret":"s","usernameClaim":"u","scopes":["openid"]}`, //nolint:lll
+		"empty slug":   `{"slug":"","displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","clientSecret":"s","usernameClaim":"u","scopes":["openid"]}`, //nolint:lll
+		"wrong case key": `{"Slug":"Keycloak","displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","clientSecret":"s","usernameClaim":"u","scopes":["openid"]}`, //nolint:lll
+		"underscore":     `{"slug":"A_B","displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","clientSecret":"s","usernameClaim":"u","scopes":["openid"]}`,         //nolint:lll
+	}
+
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			r := newRouter(t, &stubService{provider: sampleProvider()}, adminMiddlewares(t, admin()))
+
+			rec := do(r, http.MethodPost, endpoint, body)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+			}
+
+			if !strings.Contains(rec.Body.String(), "slug") {
+				t.Errorf("body = %s, want slug validation message", rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestUpdateRejectsAnInvalidSlug(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"missing slug": `{"displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","usernameClaim":"u","scopes":["openid"]}`, //nolint:lll
+		"wrong case key": `{"Slug":"Keycloak","displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","usernameClaim":"u","scopes":["openid"]}`, //nolint:lll
+		"underscore":     `{"slug":"A_B","displayName":"K","issuerUrl":"https://s.example.com","clientId":"c","usernameClaim":"u","scopes":["openid"]}`,         //nolint:lll
+	}
+
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			r := newRouter(t, &stubService{provider: sampleProvider()}, adminMiddlewares(t, admin()))
+
+			rec := do(r, http.MethodPut, endpoint+"/"+uuid.New().String(), body)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+			}
+
+			if !strings.Contains(rec.Body.String(), "slug") {
+				t.Errorf("body = %s, want slug validation message", rec.Body.String())
+			}
+		})
 	}
 }
 
@@ -512,7 +601,7 @@ func TestUpdateRejectsAClientSecret(t *testing.T) {
 	r := newRouter(t, svc, adminMiddlewares(t, admin()))
 
 	//nolint:lll
-	body := `{"displayName":"Keycloak","issuerUrl":"https://sso.example.com","clientId":"uchiyomi","clientSecret":"rotated","usernameClaim":"preferred_username","scopes":["openid"],"roleClaim":null,"adminValues":null,"allowedValues":null,"autoProvision":true}`
+	body := `{"slug":"keycloak","displayName":"Keycloak","issuerUrl":"https://sso.example.com","clientId":"uchiyomi","clientSecret":"rotated","usernameClaim":"preferred_username","scopes":["openid"],"roleClaim":null,"adminValues":null,"allowedValues":null,"autoProvision":true}`
 
 	rec := do(r, http.MethodPut, endpoint+"/"+uuid.New().String(), body)
 

--- a/api/pkg/core/auth/oidcproviders/gateway/http/dto.go
+++ b/api/pkg/core/auth/oidcproviders/gateway/http/dto.go
@@ -7,11 +7,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/httputils"
 )
 
 type CreateProviderRequest struct {
 	RoleClaim     *string                 `json:"roleClaim"`
+	Slug          httputils.TrimmedString `json:"slug" validate:"required,max=64"`
 	DisplayName   httputils.TrimmedString `json:"displayName" validate:"required,max=64"`
 	IssuerURL     httputils.TrimmedString `json:"issuerUrl" validate:"required,url"`
 	ClientID      httputils.TrimmedString `json:"clientId" validate:"required"`
@@ -25,6 +27,7 @@ type CreateProviderRequest struct {
 
 type UpdateProviderRequest struct {
 	RoleClaim     *string                 `json:"roleClaim"`
+	Slug          httputils.TrimmedString `json:"slug" validate:"required,max=64"`
 	DisplayName   httputils.TrimmedString `json:"displayName" validate:"required,max=64"`
 	IssuerURL     httputils.TrimmedString `json:"issuerUrl" validate:"required,url"`
 	ClientID      httputils.TrimmedString `json:"clientId" validate:"required"`
@@ -35,14 +38,33 @@ type UpdateProviderRequest struct {
 	AutoProvision bool                    `json:"autoProvision"`
 }
 
-var errRoleClaimRequired = errors.New("roleClaim is required when adminValues or allowedValues is set")
+var (
+	errRoleClaimRequired = errors.New("roleClaim is required when adminValues or allowedValues is set")
+	errSlugInvalid       = errors.New("slug is invalid")
+)
 
 func (r CreateProviderRequest) validate() error {
-	return validateRoleClaim(r.RoleClaim, r.AdminValues, r.AllowedValues)
+	if err := validateRoleClaim(r.RoleClaim, r.AdminValues, r.AllowedValues); err != nil {
+		return err
+	}
+
+	if !oidcproviders.IsValidSlug(r.Slug.String()) {
+		return errSlugInvalid
+	}
+
+	return nil
 }
 
 func (r UpdateProviderRequest) validate() error {
-	return validateRoleClaim(r.RoleClaim, r.AdminValues, r.AllowedValues)
+	if err := validateRoleClaim(r.RoleClaim, r.AdminValues, r.AllowedValues); err != nil {
+		return err
+	}
+
+	if !oidcproviders.IsValidSlug(r.Slug.String()) {
+		return errSlugInvalid
+	}
+
+	return nil
 }
 
 func validateRoleClaim(claim *string, adminValues, allowedValues []string) error {
@@ -64,6 +86,7 @@ type ProbeRequest struct {
 type LightProviderResponse struct {
 	CreatedAt   time.Time `json:"createdAt"`
 	ID          string    `json:"id"`
+	Slug        string    `json:"slug"`
 	DisplayName string    `json:"displayName"`
 	UserCount   int64     `json:"userCount"`
 }
@@ -73,6 +96,7 @@ type ProviderResponse struct {
 	UpdatedAt     time.Time `json:"updatedAt"`
 	RoleClaim     *string   `json:"roleClaim"`
 	ID            string    `json:"id"`
+	Slug          string    `json:"slug"`
 	DisplayName   string    `json:"displayName"`
 	IssuerURL     string    `json:"issuerUrl"`
 	ClientID      string    `json:"clientId"`

--- a/api/pkg/core/auth/oidcproviders/repository/pg/repository.go
+++ b/api/pkg/core/auth/oidcproviders/repository/pg/repository.go
@@ -6,9 +6,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/repository/pgmodels"
@@ -81,8 +83,19 @@ func (r *PGOIDCProvidersRepository) GetByIssuerURL(ctx context.Context, issuerUR
 	return &p, nil
 }
 
-func (r *PGOIDCProvidersRepository) GetBySlug(context.Context, string) (*oidcproviders.OIDCProvider, error) {
-	panic("GetBySlug is not implemented")
+func (r *PGOIDCProvidersRepository) GetBySlug(ctx context.Context, slug string) (*oidcproviders.OIDCProvider, error) {
+	model, err := r.db(ctx).Where("slug = ?", slug).First(ctx)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrNotFound
+		}
+
+		return nil, fmt.Errorf("r.db(ctx).Where: %w", err)
+	}
+
+	p := model.Domain()
+
+	return &p, nil
 }
 
 func (r *PGOIDCProvidersRepository) GetAll(ctx context.Context) ([]oidcproviders.LightOIDCProvider, error) {
@@ -91,7 +104,7 @@ func (r *PGOIDCProvidersRepository) GetAll(ctx context.Context) ([]oidcproviders
 	err := pgtx.From(ctx, r.deps.DB).
 		WithContext(ctx).
 		Model(&pgmodels.OIDCProvider{}).
-		Select("oidc_providers.id, oidc_providers.display_name, oidc_providers.created_at, " +
+		Select("oidc_providers.id, oidc_providers.display_name, oidc_providers.slug, oidc_providers.created_at, " +
 			"COUNT(DISTINCT federated_identities.user_id) AS user_count").
 		Joins("LEFT JOIN federated_identities ON federated_identities.provider_id = oidc_providers.id").
 		Group("oidc_providers.id").
@@ -142,6 +155,7 @@ func (r *PGOIDCProvidersRepository) Create(ctx context.Context, opts oidcprovide
 		UpdatedAt: now,
 
 		DisplayName:     opts.DisplayName,
+		Slug:            opts.Slug,
 		IssuerURL:       opts.IssuerURL,
 		ClientID:        opts.ClientID,
 		ClientSecretEnc: opts.ClientSecretEnc,
@@ -155,8 +169,8 @@ func (r *PGOIDCProvidersRepository) Create(ctx context.Context, opts oidcprovide
 
 	err := r.db(ctx).Create(ctx, model)
 	if err != nil {
-		if errors.Is(err, gorm.ErrDuplicatedKey) {
-			return nil, domain.ErrAlreadyExists
+		if mapped := mapDuplicate(err); mapped != nil {
+			return nil, mapped
 		}
 
 		return nil, fmt.Errorf("r.db(ctx).Create: %w", err)
@@ -171,6 +185,7 @@ func (r *PGOIDCProvidersRepository) Create(ctx context.Context, opts oidcprovide
 func (r *PGOIDCProvidersRepository) Update(ctx context.Context, id uuid.UUID, opts oidcproviders.UpdateOIDCProviderOpts) (*oidcproviders.OIDCProvider, error) {
 	values := map[string]any{
 		"display_name":   opts.DisplayName,
+		"slug":           opts.Slug,
 		"issuer_url":     opts.IssuerURL,
 		"client_id":      opts.ClientID,
 		"scopes":         pq.StringArray(opts.Scopes),
@@ -184,8 +199,8 @@ func (r *PGOIDCProvidersRepository) Update(ctx context.Context, id uuid.UUID, op
 
 	rows, err := r.db(ctx).Where("id = ?", id).Set(clause.Assignments(values)).Update(ctx)
 	if err != nil {
-		if errors.Is(err, gorm.ErrDuplicatedKey) {
-			return nil, domain.ErrAlreadyExists
+		if mapped := mapDuplicate(err); mapped != nil {
+			return nil, mapped
 		}
 
 		return nil, fmt.Errorf("r.db(ctx).Updates: %w", err)
@@ -214,6 +229,7 @@ func (r *PGOIDCProvidersRepository) DeleteByID(ctx context.Context, id uuid.UUID
 type lightProviderRow struct {
 	CreatedAt   time.Time
 	DisplayName string
+	Slug        string
 	ID          uuid.UUID
 	UserCount   int64
 }
@@ -222,9 +238,27 @@ func (r *lightProviderRow) Domain() oidcproviders.LightOIDCProvider {
 	return oidcproviders.LightOIDCProvider{
 		ID:          r.ID,
 		DisplayName: r.DisplayName,
+		Slug:        r.Slug,
 		CreatedAt:   r.CreatedAt,
 		UserCount:   r.UserCount,
 	}
+}
+
+func mapDuplicate(err error) error {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && strings.Contains(pgErr.ConstraintName, "slug") {
+		return oidcproviders.ErrSlugTaken
+	}
+
+	if strings.Contains(err.Error(), "idx_oidc_providers_slug") {
+		return oidcproviders.ErrSlugTaken
+	}
+
+	if errors.Is(err, gorm.ErrDuplicatedKey) || (pgErr != nil && pgErr.Code == "23505") {
+		return domain.ErrAlreadyExists
+	}
+
+	return nil
 }
 
 type providerUserRow struct {

--- a/api/pkg/core/auth/oidcproviders/repository/pg/repository.go
+++ b/api/pkg/core/auth/oidcproviders/repository/pg/repository.go
@@ -81,6 +81,10 @@ func (r *PGOIDCProvidersRepository) GetByIssuerURL(ctx context.Context, issuerUR
 	return &p, nil
 }
 
+func (r *PGOIDCProvidersRepository) GetBySlug(context.Context, string) (*oidcproviders.OIDCProvider, error) {
+	panic("GetBySlug is not implemented")
+}
+
 func (r *PGOIDCProvidersRepository) GetAll(ctx context.Context) ([]oidcproviders.LightOIDCProvider, error) {
 	var rows []lightProviderRow
 

--- a/api/pkg/core/auth/oidcproviders/repository/pg/repository_test.go
+++ b/api/pkg/core/auth/oidcproviders/repository/pg/repository_test.go
@@ -36,12 +36,14 @@ const (
 	scopeProfile       = "profile"
 	adminGroupValue    = "admins"
 	testIssuerURL      = "https://sso.example.com"
+	testSlug           = "keycloak"
 )
 
-func duplicateKeyErr() error {
+func duplicateKeyErr(constraint string) error {
 	return &pgconn.PgError{
-		Code:    "23505",
-		Message: `duplicate key value violates unique constraint "idx_oidc_providers_issuer_url"`,
+		Code:           "23505",
+		ConstraintName: constraint,
+		Message:        `duplicate key value violates unique constraint "` + constraint + `"`,
 	}
 }
 
@@ -60,11 +62,11 @@ func newRepo(t *testing.T) (*pg.PGOIDCProvidersRepository, sqlmock.Sqlmock) {
 
 func providerRows(id uuid.UUID) *sqlmock.Rows {
 	return sqlmock.NewRows([]string{
-		"id", colDisplayName, "issuer_url", "client_id", colClientSecretEnc,
+		"id", colDisplayName, "slug", "issuer_url", "client_id", colClientSecretEnc,
 		colScopes, "username_claim", "role_claim", "admin_values",
 		"allowed_values", "auto_provision",
 	}).AddRow(
-		id, testDisplayName, testIssuerURL, "uchiyomi", []byte("enc"),
+		id, testDisplayName, testSlug, testIssuerURL, "uchiyomi", []byte("enc"),
 		pq.StringArray{scopeOpenID, scopeProfile}, "preferred_username",
 		"groups", pq.StringArray{adminGroupValue},
 		pq.StringArray{"users"},
@@ -203,6 +205,27 @@ func TestGetByIssuerURL(t *testing.T) {
 	}
 }
 
+func TestGetBySlug(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newRepo(t)
+
+	id := uuid.New()
+
+	mock.ExpectQuery(`SELECT \* FROM "oidc_providers" WHERE slug = \$1`).
+		WithArgs(testSlug, 1).
+		WillReturnRows(providerRows(id))
+
+	got, err := r.GetBySlug(context.Background(), testSlug)
+	if err != nil {
+		t.Fatalf("GetBySlug: %v", err)
+	}
+
+	if got.ID != id || got.Slug != testSlug {
+		t.Errorf("GetBySlug() = %+v", got)
+	}
+}
+
 func TestGetByIssuerURLNotFound(t *testing.T) {
 	t.Parallel()
 
@@ -225,11 +248,11 @@ func TestGetAll(t *testing.T) {
 	id1, id2 := uuid.New(), uuid.New()
 	testCreatedAt := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
 
-	mock.ExpectQuery(`COUNT\(DISTINCT federated_identities.user_id\).*LEFT JOIN federated_identities`).
+	mock.ExpectQuery(`oidc_providers\.slug.*LEFT JOIN federated_identities`).
 		WillReturnRows(
-			sqlmock.NewRows([]string{"id", colDisplayName, "created_at", "user_count"}).
-				AddRow(id1, testDisplayName, testCreatedAt, 2).
-				AddRow(id2, "Authentik", testCreatedAt, 0),
+			sqlmock.NewRows([]string{"id", colDisplayName, "slug", "created_at", "user_count"}).
+				AddRow(id1, testDisplayName, testSlug, testCreatedAt, 2).
+				AddRow(id2, "Authentik", "authentik", testCreatedAt, 0),
 		)
 
 	got, err := r.GetAll(context.Background())
@@ -238,8 +261,8 @@ func TestGetAll(t *testing.T) {
 	}
 
 	want := []oidcproviders.LightOIDCProvider{
-		{ID: id1, DisplayName: testDisplayName, CreatedAt: testCreatedAt, UserCount: 2},
-		{ID: id2, DisplayName: "Authentik", CreatedAt: testCreatedAt, UserCount: 0},
+		{ID: id1, DisplayName: testDisplayName, Slug: testSlug, CreatedAt: testCreatedAt, UserCount: 2},
+		{ID: id2, DisplayName: "Authentik", Slug: "authentik", CreatedAt: testCreatedAt, UserCount: 0},
 	}
 
 	if !reflect.DeepEqual(got, want) {
@@ -353,6 +376,7 @@ func TestCreate(t *testing.T) {
 
 	got, err := r.Create(context.Background(), oidcproviders.CreateOIDCProviderOpts{
 		DisplayName:     testDisplayName,
+		Slug:            testSlug,
 		IssuerURL:       testIssuerURL,
 		ClientID:        "uchiyomi",
 		ClientSecretEnc: []byte("enc"),
@@ -370,7 +394,7 @@ func TestCreate(t *testing.T) {
 		t.Error("Create did not generate ID")
 	}
 
-	if got.DisplayName != testDisplayName || got.IssuerURL != testIssuerURL {
+	if got.DisplayName != testDisplayName || got.IssuerURL != testIssuerURL || got.Slug != testSlug {
 		t.Errorf("Create() = %+v", got)
 	}
 
@@ -389,12 +413,31 @@ func TestCreateDuplicate(t *testing.T) {
 	r, mock := newRepo(t)
 
 	mock.ExpectBegin()
-	mock.ExpectQuery(`INSERT INTO "oidc_providers"`).WillReturnError(duplicateKeyErr())
+	mock.ExpectQuery(`INSERT INTO "oidc_providers"`).WillReturnError(duplicateKeyErr("idx_oidc_providers_issuer_url"))
 	mock.ExpectRollback()
 
 	got, err := r.Create(context.Background(), oidcproviders.CreateOIDCProviderOpts{IssuerURL: testIssuerURL})
 	if !errors.Is(err, domain.ErrAlreadyExists) {
 		t.Errorf("Create = %v, want domain.ErrAlreadyExists", err)
+	}
+
+	if got != nil {
+		t.Errorf("Create returned %+v in addition to the error", got)
+	}
+}
+
+func TestCreateDuplicateSlug(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newRepo(t)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`INSERT INTO "oidc_providers"`).WillReturnError(duplicateKeyErr("idx_oidc_providers_slug"))
+	mock.ExpectRollback()
+
+	got, err := r.Create(context.Background(), oidcproviders.CreateOIDCProviderOpts{Slug: testSlug})
+	if !errors.Is(err, oidcproviders.ErrSlugTaken) {
+		t.Errorf("Create = %v, want oidcproviders.ErrSlugTaken", err)
 	}
 
 	if got != nil {
@@ -540,12 +583,27 @@ func TestUpdateDuplicate(t *testing.T) {
 	r, mock := newRepo(t)
 
 	mock.ExpectBegin()
-	mock.ExpectExec(`UPDATE "oidc_providers"`).WillReturnError(duplicateKeyErr())
+	mock.ExpectExec(`UPDATE "oidc_providers"`).WillReturnError(duplicateKeyErr("idx_oidc_providers_issuer_url"))
 	mock.ExpectRollback()
 
 	_, err := r.Update(context.Background(), uuid.New(), oidcproviders.UpdateOIDCProviderOpts{IssuerURL: testIssuerURL})
 	if !errors.Is(err, domain.ErrAlreadyExists) {
 		t.Errorf("Update = %v, want domain.ErrAlreadyExists", err)
+	}
+}
+
+func TestUpdateDuplicateSlug(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newRepo(t)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "oidc_providers"`).WillReturnError(duplicateKeyErr("idx_oidc_providers_slug"))
+	mock.ExpectRollback()
+
+	_, err := r.Update(context.Background(), uuid.New(), oidcproviders.UpdateOIDCProviderOpts{Slug: testSlug})
+	if !errors.Is(err, oidcproviders.ErrSlugTaken) {
+		t.Errorf("Update = %v, want oidcproviders.ErrSlugTaken", err)
 	}
 }
 

--- a/api/pkg/core/auth/oidcproviders/service.go
+++ b/api/pkg/core/auth/oidcproviders/service.go
@@ -64,6 +64,7 @@ func (deps *ServiceDeps) Validate() error {
 
 type CreateOpts struct {
 	DisplayName   string
+	Slug          string
 	IssuerURL     string
 	ClientID      string
 	ClientSecret  string
@@ -80,6 +81,7 @@ type CreateOpts struct {
 
 type UpdateOpts struct {
 	DisplayName   string
+	Slug          string
 	IssuerURL     string
 	ClientID      string
 	UsernameClaim string
@@ -155,6 +157,7 @@ func (s *Service) Create(ctx context.Context, opts CreateOpts) (*OIDCProvider, e
 
 	provider, err := s.deps.Repository.Create(ctx, CreateOIDCProviderOpts{
 		DisplayName:     opts.DisplayName,
+		Slug:            opts.Slug,
 		IssuerURL:       opts.IssuerURL,
 		ClientID:        opts.ClientID,
 		ClientSecretEnc: secretEnc,
@@ -179,6 +182,7 @@ func (s *Service) Update(ctx context.Context, id uuid.UUID, opts UpdateOpts) (*O
 
 	provider, err := s.deps.Repository.Update(ctx, id, UpdateOIDCProviderOpts{
 		DisplayName:   opts.DisplayName,
+		Slug:          opts.Slug,
 		IssuerURL:     opts.IssuerURL,
 		ClientID:      opts.ClientID,
 		Scopes:        opts.Scopes,

--- a/api/pkg/core/auth/oidcproviders/service_test.go
+++ b/api/pkg/core/auth/oidcproviders/service_test.go
@@ -19,6 +19,7 @@ const (
 	testRedirect      = "https://manga.example.com/api/auth/oidc/callback"
 	testSecret        = "s3cr3t"
 	testDisplayName   = "Keycloak"
+	testSlug          = "keycloak"
 	testClientID      = "uchiyomi"
 	testUsernameClaim = "preferred_username"
 	testScope         = "openid"
@@ -152,6 +153,7 @@ func newService(
 func createOpts() oidcproviders.CreateOpts {
 	return oidcproviders.CreateOpts{
 		DisplayName:   testDisplayName,
+		Slug:          testSlug,
 		IssuerURL:     testIssuerURL,
 		ClientID:      testClientID,
 		ClientSecret:  testSecret,
@@ -181,6 +183,10 @@ func TestCreateEncryptsTheClientSecret(t *testing.T) {
 
 	if !bytes.Equal(repo.created.ClientSecretEnc, []byte("sealed:"+testSecret)) {
 		t.Errorf("ClientSecretEnc = %q, want the sealed secret", repo.created.ClientSecretEnc)
+	}
+
+	if repo.created.Slug != testSlug {
+		t.Errorf("Slug = %q, want %q", repo.created.Slug, testSlug)
 	}
 }
 
@@ -260,6 +266,7 @@ func TestUpdateNeverSealsASecret(t *testing.T) {
 
 	_, err := s.Update(context.Background(), uuid.New(), oidcproviders.UpdateOpts{
 		DisplayName:   testDisplayName,
+		Slug:          testSlug,
 		IssuerURL:     testIssuerURL,
 		ClientID:      testClientID,
 		Scopes:        []string{testScope},
@@ -271,6 +278,10 @@ func TestUpdateNeverSealsASecret(t *testing.T) {
 
 	if repo.updated == nil {
 		t.Fatal("the repository was never called")
+	}
+
+	if repo.updated.Slug != testSlug {
+		t.Errorf("Slug = %q, want %q", repo.updated.Slug, testSlug)
 	}
 
 	if cipher.seals != 0 {

--- a/api/pkg/core/auth/oidcproviders/service_test.go
+++ b/api/pkg/core/auth/oidcproviders/service_test.go
@@ -42,6 +42,18 @@ func (f *fakeRepository) GetByIssuerURL(context.Context, string) (*oidcproviders
 	return f.provider, f.err
 }
 
+func (f *fakeRepository) GetBySlug(_ context.Context, slug string) (*oidcproviders.OIDCProvider, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+
+	if f.provider != nil && f.provider.Slug == slug {
+		return f.provider, nil
+	}
+
+	return nil, domain.ErrNotFound
+}
+
 //nolint:lll
 func (f *fakeRepository) Create(_ context.Context, opts oidcproviders.CreateOIDCProviderOpts) (*oidcproviders.OIDCProvider, error) {
 	f.created = &opts

--- a/api/pkg/core/auth/oidcproviders/slug.go
+++ b/api/pkg/core/auth/oidcproviders/slug.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package oidcproviders
+
+import "regexp"
+
+const MaxSlugLength = 64
+
+var SlugPattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+
+func IsValidSlug(slug string) bool {
+	return len(slug) > 0 && len(slug) <= MaxSlugLength && SlugPattern.MatchString(slug)
+}

--- a/api/pkg/core/auth/oidcproviders/slug_test.go
+++ b/api/pkg/core/auth/oidcproviders/slug_test.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package oidcproviders_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/auth/oidcproviders"
+)
+
+func TestIsValidSlug(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		slug string
+		ok   bool
+	}{
+		{"keycloak", "keycloak", true},
+		{"acme-sso", "acme-sso", true},
+		{"a", "a", true},
+		{"max-length", strings.Repeat("a", 64), true},
+		{"empty", "", false},
+		{"Keycloak", "Keycloak", false},
+		{"-acme", "-acme", false},
+		{"acme-", "acme-", false},
+		{"acme--sso", "acme--sso", false},
+		{"acme_sso", "acme_sso", false},
+		{"over-max-length", strings.Repeat("a", 65), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := oidcproviders.IsValidSlug(tc.slug); got != tc.ok {
+				t.Errorf("IsValidSlug(%q) = %v, want %v", tc.slug, got, tc.ok)
+			}
+		})
+	}
+}

--- a/api/pkg/core/auth/service_test.go
+++ b/api/pkg/core/auth/service_test.go
@@ -324,6 +324,7 @@ func newFakes() *fakes {
 	provider := &oidcproviders.OIDCProvider{
 		ID:            uuid.New(),
 		DisplayName:   "Example IdP",
+		Slug:          "keycloak",
 		IssuerURL:     "https://idp.example.com",
 		ClientID:      "client-id",
 		UsernameClaim: usernameClaimKey,

--- a/api/pkg/core/auth/service_test.go
+++ b/api/pkg/core/auth/service_test.go
@@ -32,6 +32,7 @@ const (
 	testCipherKey    = "abcdefghijklmnopqrstuvwxyz012345"
 	usernameClaimKey = "preferred_username"
 	testSubject      = "sub-123"
+	testProviderSlug = "keycloak"
 )
 
 type txCtxKey struct{}
@@ -324,7 +325,7 @@ func newFakes() *fakes {
 	provider := &oidcproviders.OIDCProvider{
 		ID:            uuid.New(),
 		DisplayName:   "Example IdP",
-		Slug:          "keycloak",
+		Slug:          testProviderSlug,
 		IssuerURL:     "https://idp.example.com",
 		ClientID:      "client-id",
 		UsernameClaim: usernameClaimKey,

--- a/api/pkg/repository/pgmodels/oidcprovider.go
+++ b/api/pkg/repository/pgmodels/oidcprovider.go
@@ -17,6 +17,7 @@ type OIDCProvider struct {
 	ClientID            string
 	UsernameClaim       string
 	IssuerURL           string `gorm:"type:text;not null;uniqueIndex"`
+	Slug                string `gorm:"type:text;not null;uniqueIndex:idx_oidc_providers_slug"`
 	DisplayName         string
 	Scopes              pq.StringArray `gorm:"type:text[];not null;default:'{openid,profile}'"`
 	ClientSecretEnc     []byte
@@ -35,6 +36,7 @@ func (p *OIDCProvider) Domain() oidcproviders.OIDCProvider {
 	return oidcproviders.OIDCProvider{
 		ID:              p.ID,
 		DisplayName:     p.DisplayName,
+		Slug:            p.Slug,
 		IssuerURL:       p.IssuerURL,
 		ClientID:        p.ClientID,
 		ClientSecretEnc: p.ClientSecretEnc,

--- a/web/app/components/Molecule/Card/Component.vue
+++ b/web/app/components/Molecule/Card/Component.vue
@@ -17,7 +17,10 @@ defineProps<{
   >
     <div class="d-flex ga-4 align-center mb-6">
       <VIcon :icon color="secondary" />
-      <span class="font-title text-title-large">{{ title }}</span>
+      <div class="d-flex flex-column ga-1">
+        <span class="font-title text-title-large">{{ title }}</span>
+        <slot name="subtitle" />
+      </div>
     </div>
     <slot />
   </VCard>

--- a/web/app/features/auth/components/OidcProviderButtons.test.ts
+++ b/web/app/features/auth/components/OidcProviderButtons.test.ts
@@ -8,8 +8,8 @@ import { oidcStartUrl } from '~/features/auth/composables/auth.api'
 import OidcProviderButtons from './OidcProviderButtons.vue'
 
 const providers: ProviderSummary[] = [
-  { id: 'okta', displayName: 'Okta' },
-  { id: 'google', displayName: 'Google' },
+  { id: 'id-okta', slug: 'okta', displayName: 'Okta' },
+  { id: 'id-google', slug: 'google', displayName: 'Google' },
 ]
 
 describe('authOidcProviderButtons', () => {
@@ -30,7 +30,7 @@ describe('authOidcProviderButtons', () => {
       const anchor = wrapper.find(`[data-test="login-oidc-${provider.id}"]`)
       expect(anchor.exists()).toBe(true)
       expect(anchor.element.tagName).toBe('A')
-      expect(anchor.attributes('href')).toBe(oidcStartUrl(provider.id, '/library'))
+      expect(anchor.attributes('href')).toBe(oidcStartUrl(provider.slug, '/library'))
     }
   })
 

--- a/web/app/features/auth/components/OidcProviderButtons.vue
+++ b/web/app/features/auth/components/OidcProviderButtons.vue
@@ -16,7 +16,7 @@ defineProps<Props>()
     <VBtn
       v-for="provider in providers"
       :key="provider.id"
-      :href="oidcStartUrl(provider.id, redirect)"
+      :href="oidcStartUrl(provider.slug, redirect)"
       variant="outlined"
       size="large"
       class="w-100"

--- a/web/app/features/auth/composables/auth.api.test.ts
+++ b/web/app/features/auth/composables/auth.api.test.ts
@@ -50,8 +50,8 @@ describe('createAuthApi().getProviders', () => {
   })
 
   const providers = [
-    { id: 'google', displayName: 'Google' },
-    { id: 'okta', displayName: 'Okta' },
+    { id: 'id-google', slug: 'google', displayName: 'Google' },
+    { id: 'id-okta', slug: 'okta', displayName: 'Okta' },
   ]
 
   it('returns the provider list on success', async () => {

--- a/web/app/features/auth/composables/auth.api.ts
+++ b/web/app/features/auth/composables/auth.api.ts
@@ -16,6 +16,7 @@ export interface AuthApi {
 
 export interface ProviderSummary {
   id: string
+  slug: string
   displayName: string
 }
 
@@ -77,8 +78,8 @@ export function createAuthApi(): AuthApi {
   }
 }
 
-export function oidcStartUrl(providerId: string, redirect: string): string {
+export function oidcStartUrl(slug: string, redirect: string): string {
   const params = new URLSearchParams({ redirect })
 
-  return `/api/auth/oidc/${providerId}/start?${params.toString()}`
+  return `/api/auth/oidc/${slug}/start?${params.toString()}`
 }

--- a/web/app/features/auth/composables/oidc-providers.composable.test.ts
+++ b/web/app/features/auth/composables/oidc-providers.composable.test.ts
@@ -8,8 +8,8 @@ const getProviders = vi.fn()
 vi.mock('./auth.api', () => ({ createAuthApi: () => ({ getProviders }) }))
 
 const providers = [
-  { id: 'google', displayName: 'Google' },
-  { id: 'okta', displayName: 'Okta' },
+  { id: 'id-google', slug: 'google', displayName: 'Google' },
+  { id: 'id-okta', slug: 'okta', displayName: 'Okta' },
 ]
 
 beforeEach(() => {

--- a/web/app/features/oidc/components/Card/Category/Claims.test.ts
+++ b/web/app/features/oidc/components/Card/Category/Claims.test.ts
@@ -22,6 +22,7 @@ vi.mock('~/features/oidc/composables/oidc-provider.composable', () => ({
 const base = {
   id: 'p1',
   displayName: 'PocketID',
+  slug: 'pocket-id',
   issuerUrl: 'https://id.example.org',
   clientId: 'client',
   usernameClaim: 'preferred_username',

--- a/web/app/features/oidc/components/Card/Category/Informations.test.ts
+++ b/web/app/features/oidc/components/Card/Category/Informations.test.ts
@@ -28,6 +28,7 @@ const TestBtnStub = defineComponent({
 const base = {
   id: 'p1',
   displayName: 'PocketID',
+  slug: 'pocket-id',
   issuerUrl: 'https://id.example.org',
   clientId: 'client',
   usernameClaim: 'preferred_username',
@@ -63,6 +64,7 @@ describe('oidcCardCategoryInformations', () => {
     const values = wrapper.findAll('input').map(i => (i.element as HTMLInputElement).value)
 
     expect(values).toContain('PocketID')
+    expect(values).toContain('pocket-id')
     expect(values).toContain('client')
     expect(values).toContain('https://id.example.org')
   })
@@ -142,5 +144,26 @@ describe('oidcCardCategoryInformations', () => {
     await saveButton(wrapper).trigger('click')
 
     expect(update).not.toHaveBeenCalled()
+  })
+
+  it('enables save once the slug changed', async () => {
+    const wrapper = await mount()
+
+    await inputByValue(wrapper, 'pocket-id').setValue('new-slug')
+
+    await vi.waitFor(() => expect(saveButton(wrapper).attributes('disabled')).toBeUndefined())
+  })
+
+  it('submits the edited slug to update', async () => {
+    const wrapper = await mount()
+
+    await inputByValue(wrapper, 'pocket-id').setValue('new-slug')
+    await vi.waitFor(() => expect(saveButton(wrapper).attributes('disabled')).toBeUndefined())
+    await saveButton(wrapper).trigger('click')
+
+    await vi.waitFor(() => expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'p1',
+      slug: 'new-slug',
+    })))
   })
 })

--- a/web/app/features/oidc/components/Card/Category/Informations.vue
+++ b/web/app/features/oidc/components/Card/Category/Informations.vue
@@ -84,6 +84,9 @@ const isFormValid = computed(() => isValid.value && hasChanged.value)
     :title="$t('settings.oidc.category.providerInfos.title')"
     icon="fa6-regular:address-card"
   >
+    <template #subtitle>
+      <span class="text-body-medium text-secondary opacity-70">{{ $t('settings.oidc.startUrl', { slug: provider?.slug }) }}</span>
+    </template>
     <div class="provider-informations-grid">
       <VTextField v-bind="field('displayName').props" class="h-fit" />
       <VTextField

--- a/web/app/features/oidc/components/Card/Category/Informations.vue
+++ b/web/app/features/oidc/components/Card/Category/Informations.vue
@@ -10,7 +10,7 @@ defineProps<{
 const { t } = useI18n()
 const { provider, update, updateLoading } = useOidcProvider()
 
-type Form = Pick<UpdateOidcProviderRequest, 'displayName' | 'issuerUrl' | 'clientId' | 'autoProvision'>
+type Form = Pick<UpdateOidcProviderRequest, 'displayName' | 'slug' | 'issuerUrl' | 'clientId' | 'autoProvision'>
 
 async function onSubmit(values: Form): Promise<void> {
   if (!provider.value) {
@@ -25,12 +25,18 @@ async function onSubmit(values: Form): Promise<void> {
 const { field, handleSubmit, reset, isValid } = useForm({
   schema: object({
     displayName: string().required().label(t('settings.oidc.fields.displayName.label')),
+    slug: string()
+      .required()
+      .max(64)
+      .matches(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+      .label(t('settings.oidc.fields.slug.label')),
     issuerUrl: string().required().url().label(t('settings.oidc.fields.issuerUrl.label')),
     clientId: string().required().label(t('settings.oidc.fields.clienId.label')),
     autoProvision: boolean().required().label(t('settings.oidc.fields.autoProvision.label')),
   }),
   initialValues: {
     displayName: '',
+    slug: '',
     issuerUrl: '',
     clientId: '',
     autoProvision: false,
@@ -42,6 +48,7 @@ watch(provider, (value?: OidcProvider) => {
   if (value) {
     reset({
       displayName: value.displayName,
+      slug: value.slug,
       issuerUrl: value.issuerUrl,
       clientId: value.clientId,
       autoProvision: value.autoProvision,
@@ -55,6 +62,7 @@ const hasChanged = computed(() => {
   }
 
   return provider.value.displayName !== field('displayName').props.modelValue
+    || provider.value.slug !== field('slug').props.modelValue
     || provider.value.issuerUrl !== field('issuerUrl').props.modelValue
     || provider.value.clientId !== field('clientId').props.modelValue
     || provider.value.autoProvision !== field('autoProvision').props.modelValue
@@ -78,6 +86,10 @@ const isFormValid = computed(() => isValid.value && hasChanged.value)
   >
     <div class="provider-informations-grid">
       <VTextField v-bind="field('displayName').props" />
+      <VTextField
+        v-bind="field('slug').props"
+        :messages="[$t('settings.oidc.fields.slug.hint')]"
+      />
       <VTextField v-bind="field('clientId').props" />
       <VTextField v-bind="field('issuerUrl').props" style="height: fit-content">
         <template #append>

--- a/web/app/features/oidc/components/Card/Category/Informations.vue
+++ b/web/app/features/oidc/components/Card/Category/Informations.vue
@@ -85,7 +85,7 @@ const isFormValid = computed(() => isValid.value && hasChanged.value)
     icon="fa6-regular:address-card"
   >
     <div class="provider-informations-grid">
-      <VTextField v-bind="field('displayName').props" />
+      <VTextField v-bind="field('displayName').props" class="h-fit" />
       <VTextField
         v-bind="field('slug').props"
         :messages="[$t('settings.oidc.fields.slug.hint')]"

--- a/web/app/features/oidc/components/Card/Category/Users.test.ts
+++ b/web/app/features/oidc/components/Card/Category/Users.test.ts
@@ -22,6 +22,7 @@ vi.mock('~/features/oidc/composables/oidc-provider.composable', () => ({
 const base = {
   id: 'p1',
   displayName: 'PocketID',
+  slug: 'pocket-id',
   issuerUrl: 'https://id.example.org',
   clientId: 'client',
   usernameClaim: 'preferred_username',

--- a/web/app/features/oidc/components/Modal/Create.test.ts
+++ b/web/app/features/oidc/components/Modal/Create.test.ts
@@ -136,6 +136,7 @@ describe('oidcModalCreate', () => {
 
     await vi.waitFor(() => expect(create).toHaveBeenCalledWith(expect.objectContaining({
       displayName: 'PocketID',
+      slug: 'pocketid',
       clientId: 'client',
       clientSecret: 'secret',
       issuerUrl: 'https://id.example.org',
@@ -212,5 +213,36 @@ describe('oidcModalCreate', () => {
     show.value = true
 
     await vi.waitFor(() => expect(fieldByLabel(wrapper, 'Display name').element.value).toBe(''))
+  })
+
+  it('prefills the slug from the display name', async () => {
+    const { wrapper } = await mount()
+
+    await fieldByLabel(wrapper, 'Display name').setValue('PocketID')
+
+    await vi.waitFor(() => expect(fieldByLabel(wrapper, 'Slug').element.value).toBe('pocketid'))
+  })
+
+  it('stops resyncing the slug once it has been edited', async () => {
+    const { wrapper } = await mount()
+
+    await fieldByLabel(wrapper, 'Display name').setValue('PocketID')
+    await vi.waitFor(() => expect(fieldByLabel(wrapper, 'Slug').element.value).toBe('pocketid'))
+
+    await fieldByLabel(wrapper, 'Slug').setValue('custom')
+    await fieldByLabel(wrapper, 'Display name').setValue('Other Name')
+
+    await vi.waitFor(() => expect(fieldByLabel(wrapper, 'Slug').element.value).toBe('custom'))
+  })
+
+  it('stays incomplete when the display name yields no valid slug', async () => {
+    const { wrapper } = await mount()
+
+    await fieldByLabel(wrapper, 'Display name').setValue('!!!')
+
+    await vi.waitFor(() => {
+      expect(fieldByLabel(wrapper, 'Slug').element.value).toBe('')
+      expect(isFormComplete(wrapper)).toBe(false)
+    })
   })
 })

--- a/web/app/features/oidc/components/Modal/Create.vue
+++ b/web/app/features/oidc/components/Modal/Create.vue
@@ -68,6 +68,7 @@ watch(() => field('displayName').props.modelValue, (name: string) => {
   if (slugDirty.value) {
     return
   }
+
   field('slug').props['onUpdate:modelValue'](slugFromDisplayName(name))
 })
 

--- a/web/app/features/oidc/components/Modal/Create.vue
+++ b/web/app/features/oidc/components/Modal/Create.vue
@@ -1,6 +1,7 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script setup lang="ts">
 import { array, boolean, object, string } from 'yup'
+import { slugFromDisplayName } from '~/features/oidc/utils/slug-from-display-name'
 import { useForm } from '~/utils/forms/use-form'
 
 const show = defineModel<boolean>({ required: true })
@@ -14,9 +15,16 @@ async function onSubmit(values: CreateOidcProviderRequest): Promise<void> {
   show.value = false
 }
 
+const slugDirty = ref(false)
+
 const { field, handleSubmit, reset, isValid } = useForm({
   schema: object({
     displayName: string().required().label(t('settings.oidc.fields.displayName.label')),
+    slug: string()
+      .required()
+      .max(64)
+      .matches(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+      .label(t('settings.oidc.fields.slug.label')),
     issuerUrl: string().required().url().label(t('settings.oidc.fields.issuerUrl.label')),
     clientId: string().required().label(t('settings.oidc.fields.clienId.label')),
     clientSecret: string().required().label(t('settings.oidc.fields.clientSecret.label')),
@@ -29,6 +37,7 @@ const { field, handleSubmit, reset, isValid } = useForm({
   }),
   initialValues: {
     displayName: '',
+    slug: '',
     issuerUrl: '',
     clientId: '',
     clientSecret: '',
@@ -50,8 +59,16 @@ const autoProvisionProps = computed(() => {
 
 watch(show, (val: boolean): void => {
   if (val) {
+    slugDirty.value = false
     reset()
   }
+})
+
+watch(() => field('displayName').props.modelValue, (name: string) => {
+  if (slugDirty.value) {
+    return
+  }
+  field('slug').props['onUpdate:modelValue'](slugFromDisplayName(name))
 })
 
 watch(() => field('roleClaim').props.modelValue, (value: string) => {
@@ -79,6 +96,11 @@ watch(() => field('roleClaim').props.modelValue, (value: string) => {
       <span class="text-title-large font-title text-truncate">{{ $t('settings.oidc.category.providerInfos.title') }}</span>
     </div>
     <VTextField v-bind="field('displayName').props" />
+    <VTextField
+      v-bind="field('slug').props"
+      :messages="[$t('settings.oidc.fields.slug.hint')]"
+      @update:model-value="slugDirty = true; field('slug').props['onUpdate:modelValue']($event ?? '')"
+    />
     <VTextField v-bind="field('clientId').props" />
     <AtomInputPassword v-bind="field('clientSecret').props" />
     <VTextField v-bind="field('issuerUrl').props">

--- a/web/app/features/oidc/components/Modal/Delete.test.ts
+++ b/web/app/features/oidc/components/Modal/Delete.test.ts
@@ -34,6 +34,7 @@ const ConfirmationStub = defineComponent({
 const base = {
   id: 'p1',
   displayName: 'PocketID',
+  slug: 'pocket-id',
   issuerUrl: 'https://id.example.org',
   clientId: 'client',
   usernameClaim: 'preferred_username',

--- a/web/app/features/oidc/composables/oidc-provider.composable.test.ts
+++ b/web/app/features/oidc/composables/oidc-provider.composable.test.ts
@@ -35,6 +35,7 @@ mockNuxtImport('navigateTo', () => navigateTo)
 const provider = {
   id: 'p1',
   displayName: 'PocketID',
+  slug: 'pocket-id',
   issuerUrl: 'https://id.example.org',
   clientId: 'client',
   usernameClaim: 'preferred_username',
@@ -130,6 +131,7 @@ describe('useOidcProvider().update', () => {
 
     expect(updateById).toHaveBeenCalledWith('p1', {
       displayName: 'Renamed',
+      slug: provider.slug,
       issuerUrl: provider.issuerUrl,
       clientId: provider.clientId,
       usernameClaim: provider.usernameClaim,

--- a/web/app/features/oidc/composables/oidc.api.test.ts
+++ b/web/app/features/oidc/composables/oidc.api.test.ts
@@ -16,6 +16,7 @@ const UPDATED_AT = '2026-02-03T04:05:06.000Z'
 const payload = {
   id: 'p1',
   displayName: 'PocketID',
+  slug: 'pocket-id',
   issuerUrl: 'https://id.example.org',
   clientId: 'client',
   usernameClaim: 'preferred_username',
@@ -30,6 +31,7 @@ const payload = {
 
 const request = {
   displayName: 'PocketID',
+  slug: 'pocket-id',
   issuerUrl: 'https://id.example.org',
   clientId: 'client',
   clientSecret: 'secret',
@@ -158,6 +160,7 @@ describe('createOidcApi().create', () => {
       data: {
         id: 'p1',
         displayName: 'PocketID',
+        slug: 'pocket-id',
         issuerUrl: 'https://id.example.org',
         clientId: 'client',
         usernameClaim: 'preferred_username',

--- a/web/app/features/oidc/composables/oidc.api.ts
+++ b/web/app/features/oidc/composables/oidc.api.ts
@@ -14,6 +14,7 @@ export interface OidcApi {
 
 export interface CreateOidcProviderRequest {
   displayName: string
+  slug: string
   issuerUrl: string
   clientId: string
   clientSecret: string

--- a/web/app/features/oidc/composables/oidc.composable.test.ts
+++ b/web/app/features/oidc/composables/oidc.composable.test.ts
@@ -34,6 +34,7 @@ const provider = {
 
 const request = {
   displayName: 'PocketID',
+  slug: 'pocket-id',
   issuerUrl: 'https://id.example.org',
   clientId: 'client',
   clientSecret: 'secret',

--- a/web/app/features/oidc/stores/oidc.store.test.ts
+++ b/web/app/features/oidc/stores/oidc.store.test.ts
@@ -8,6 +8,7 @@ import { useOidcProviderStore } from './oidc.store'
 const provider = {
   id: 'p1',
   displayName: 'PocketID',
+  slug: 'pocket-id',
   issuerUrl: 'https://id.example.org',
   clientId: 'client',
   usernameClaim: 'preferred_username',

--- a/web/app/features/oidc/utils/slug-from-display-name.test.ts
+++ b/web/app/features/oidc/utils/slug-from-display-name.test.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it } from 'vitest'
+import { slugFromDisplayName } from './slug-from-display-name'
+
+describe('slugFromDisplayName', () => {
+  it('slugifies a simple name', () => {
+    expect(slugFromDisplayName('Acme SSO')).toBe('acme-sso')
+  })
+
+  it('returns empty when nothing valid remains', () => {
+    expect(slugFromDisplayName('日本語')).toBe('')
+  })
+
+  it('returns empty when longer than 64', () => {
+    expect(slugFromDisplayName('A'.repeat(65))).toBe('')
+  })
+})

--- a/web/app/features/oidc/utils/slug-from-display-name.ts
+++ b/web/app/features/oidc/utils/slug-from-display-name.ts
@@ -6,8 +6,8 @@ const SLUG_MAX = 64
 export function slugFromDisplayName(name: string): string {
   const slug = name
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
+    .replaceAll(/[^a-z0-9]+/g, '-')
+    .replaceAll(/^-+|-+$/g, '')
 
   if (slug.length === 0 || slug.length > SLUG_MAX || !SLUG_RE.test(slug)) {
     return ''

--- a/web/app/features/oidc/utils/slug-from-display-name.ts
+++ b/web/app/features/oidc/utils/slug-from-display-name.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+const SLUG_MAX = 64
+
+export function slugFromDisplayName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+  if (slug.length === 0 || slug.length > SLUG_MAX || !SLUG_RE.test(slug)) {
+    return ''
+  }
+
+  return slug
+}

--- a/web/app/pages/settings/oidc/[id].test.ts
+++ b/web/app/pages/settings/oidc/[id].test.ts
@@ -50,6 +50,7 @@ const DeleteModalStub = defineComponent({
 const base = {
   id: 'p1',
   displayName: 'PocketID',
+  slug: 'pocket-id',
   issuerUrl: 'https://id.example.org',
   clientId: 'client',
   usernameClaim: 'preferred_username',

--- a/web/i18n/locales/en.json
+++ b/web/i18n/locales/en.json
@@ -102,6 +102,10 @@
         "displayName": {
           "label": "Display name"
         },
+        "slug": {
+          "label": "Slug",
+          "hint": "Lowercase letters, numbers, and hyphens"
+        },
         "issuerUrl": {
           "label": "Issuer URL"
         },

--- a/web/i18n/locales/en.json
+++ b/web/i18n/locales/en.json
@@ -189,7 +189,8 @@
       "update": {
         "success": "Provider updated !"
       },
-      "description": "Manage OIDC providers"
+      "description": "Manage OIDC providers",
+      "startUrl": "Start URL: /api/auth/oidc/{slug}/start"
     },
     "reader": {
       "title": "Reader",

--- a/web/i18n/locales/fr.json
+++ b/web/i18n/locales/fr.json
@@ -102,6 +102,10 @@
         "displayName": {
           "label": "Nom d'affichage"
         },
+        "slug": {
+          "label": "Slug",
+          "hint": "Lettres minuscules, chiffres et tirets"
+        },
         "issuerUrl": {
           "label": "URL de l'émetteur"
         },

--- a/web/i18n/locales/fr.json
+++ b/web/i18n/locales/fr.json
@@ -189,7 +189,8 @@
         "noProviders": "Aucun fournisseur n'est défini",
         "notFound": "Fournisseur introuvable"
       },
-      "description": "Gérer les fournisseurs OIDC"
+      "description": "Gérer les fournisseurs OIDC",
+      "startUrl": "Start URL: /api/auth/oidc/{slug}/start"
     },
     "reader": {
       "title": "Lecteur",


### PR DESCRIPTION
## Summary
- Add a unique OIDC provider slug (lowercase, hyphenated, max 64) on create/update, persisted and required by the admin API and settings forms.
- Start login at `GET /api/auth/oidc/{slug}/start` instead of the UUID route; public `GET /api/auth/providers` now returns `{ id, slug, displayName }` so login buttons use the slug.
- Prefill slug from display name once on create only; later display-name edits do not overwrite it. Duplicate or invalid slugs are validation errors; unknown slugs redirect to `/login?error=oidcUnavailable`.
- Admin CRUD and `/settings/oidc/:id` keep using the provider UUID. Glossary updated in `CONTEXT.md`.

Closes #111

## Test plan
- [x] Create a provider: slug is required, can be prefilled from display name, and invalid/duplicate values show a validation error.
- [x] Edit slug on the provider informations card; login still works with the new slug and the old slug is unavailable (redirect to `/login?error=oidcUnavailable`).
- [x] On `/login`, “Sign in with …” hits `/api/auth/oidc/{slug}/start?redirect=` (not a UUID).
- [x] Admin settings still open `/settings/oidc/:id` by UUID.
- [x] `go build ./...`, `go test ./...`, `golangci-lint run ./...`
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm knip`