### PR TITLE
refactor(api): remove chapter image compression and save raw pages

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -4,7 +4,6 @@ go 1.26.5
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
-	github.com/KarpelesLab/gowebp v0.1.1
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/coreos/go-oidc/v3 v3.20.0
 	github.com/go-chi/chi/v5 v5.3.1
@@ -33,7 +32,6 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
-	golang.org/x/image v0.41.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 )

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,7 +1,5 @@
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
-github.com/KarpelesLab/gowebp v0.1.1 h1:W11ZrRVx+Zk4ypW5NBEU31FQzghICXIrAbAbO5yd4M0=
-github.com/KarpelesLab/gowebp v0.1.1/go.mod h1:Js8OXPQ94yl94HqaO/9XuUqk0wOPod6uycryhzmTgsU=
 github.com/caarlos0/env/v11 v11.4.1 h1:fYwH0sWEsBSMPG7t4e/PEfTFzrWrpjyygXyUnWiSwEw=
 github.com/caarlos0/env/v11 v11.4.1/go.mod h1:qupehSf/Y0TUTsxKywqRt/vJjN5nz6vauiYEUUr8P4U=
 github.com/coreos/go-oidc/v3 v3.20.0 h1:EtE0WIBHk03N+DqGkY4+UONzzZHk7amKt6IyNd7OsZE=
@@ -57,8 +55,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
 golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
-golang.org/x/image v0.41.0 h1:8wS72eGJMJaBxK6okTzd4WaXumUlTVlb753MlsSvTCo=
-golang.org/x/image v0.41.0/go.mod h1:uIc348UZMSvS5Z65CVZ7iDPaNobNFEPeJ4kbqTOszmA=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=

--- a/api/pkg/core/chapters/download/imageopt.go
+++ b/api/pkg/core/chapters/download/imageopt.go
@@ -3,15 +3,7 @@
 package download
 
 import (
-	"bytes"
-	"encoding/binary"
-	"image"
-	"image/jpeg"
-	"image/png"
-	"log/slog"
 	"strings"
-
-	"github.com/KarpelesLab/gowebp"
 )
 
 const (
@@ -39,70 +31,9 @@ const (
 	gif89a     = "GIF89a"
 )
 
-type OptimizedPage struct {
-	Extension string
-	Data      []byte
-}
-
-func OptimizePage(data []byte, urlExt string, logger *slog.Logger) OptimizedPage {
+func DetectExtension(data []byte, urlExt string) string {
 	format := SniffFormat(data)
-	defaultExt := fallbackExtension(format, urlExt)
 
-	fallback := OptimizedPage{
-		Data:      data,
-		Extension: defaultExt,
-	}
-
-	if format == FormatPNG && IsAPNG(data) {
-		return fallback
-	}
-
-	if format != FormatPNG && format != FormatJPEG {
-		return fallback
-	}
-
-	var img image.Image
-	var err error
-
-	switch format {
-	case FormatPNG:
-		img, err = png.Decode(bytes.NewReader(data))
-	case FormatJPEG:
-		img, err = jpeg.Decode(bytes.NewReader(data))
-	default:
-		return fallback
-	}
-
-	if err != nil {
-		if logger != nil {
-			logger.Warn("failed to decode image for webp conversion", "error", err)
-		}
-
-		return fallback
-	}
-
-	var webpBuf bytes.Buffer
-	// nil options in KarpelesLab/gowebp encodes lossless VP8L by default
-	if err := gowebp.Encode(&webpBuf, img, nil); err != nil {
-		if logger != nil {
-			logger.Warn("failed to encode lossless webp", "error", err)
-		}
-
-		return fallback
-	}
-
-	webpBytes := webpBuf.Bytes()
-	if len(webpBytes) < len(data) {
-		return OptimizedPage{
-			Data:      webpBytes,
-			Extension: ExtWEBP,
-		}
-	}
-
-	return fallback
-}
-
-func fallbackExtension(format ImageFormat, urlExt string) string {
 	switch format {
 	case FormatPNG:
 		return ExtPNG
@@ -144,34 +75,4 @@ func SniffFormat(data []byte) ImageFormat {
 	}
 
 	return FormatUnknown
-}
-
-func IsAPNG(data []byte) bool {
-	if len(data) < 8 || string(data[:8]) != pngHeader {
-		return false
-	}
-
-	offset := 8
-	for offset+8 <= len(data) {
-		length := binary.BigEndian.Uint32(data[offset : offset+4])
-		chunkType := string(data[offset+4 : offset+8])
-
-		if chunkType == "acTL" {
-			return true
-		}
-
-		if chunkType == "IDAT" {
-			return false
-		}
-
-		// 4 (length) + 4 (type) + length (data) + 4 (crc)
-		chunkTotal := int64(length) + 12
-		if int64(offset)+chunkTotal > int64(len(data)) {
-			break
-		}
-
-		offset += int(chunkTotal)
-	}
-
-	return false
 }

--- a/api/pkg/core/chapters/download/imageopt_test.go
+++ b/api/pkg/core/chapters/download/imageopt_test.go
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//nolint:goconst,govet
 package download_test
 
 import (
 	"bytes"
-	"encoding/binary"
 	"image"
 	"image/color"
 	"image/jpeg"
@@ -46,49 +46,6 @@ func createTestJPEG(t *testing.T, w, h int) []byte {
 	return buf.Bytes()
 }
 
-func createTestSolidJPEG(t *testing.T, w, h int) []byte {
-	t.Helper()
-	img := image.NewRGBA(image.Rect(0, 0, w, h))
-	for y := 0; y < h; y++ {
-		for x := 0; x < w; x++ {
-			img.Set(x, y, color.RGBA{R: 255, G: 255, B: 255, A: 255})
-		}
-	}
-	var buf bytes.Buffer
-	if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 100}); err != nil {
-		t.Fatalf("jpeg.Encode: %v", err)
-	}
-
-	return buf.Bytes()
-}
-
-func createTestAPNG(t *testing.T) []byte {
-	t.Helper()
-	basePNG := createTestPNG(t, 10, 10)
-	// Insert an acTL chunk before IDAT chunk
-	idatIdx := bytes.Index(basePNG, []byte("IDAT"))
-	if idatIdx == -1 {
-		t.Fatalf("IDAT chunk not found in test PNG")
-	}
-	chunkStart := idatIdx - 4
-
-	var actlChunk bytes.Buffer
-	// Length: 8 bytes (sequence_number: 4 bytes, num_plays: 4 bytes)
-	_ = binary.Write(&actlChunk, binary.BigEndian, uint32(8))
-	actlChunk.WriteString("acTL")
-	_ = binary.Write(&actlChunk, binary.BigEndian, uint32(2)) // num_frames
-	_ = binary.Write(&actlChunk, binary.BigEndian, uint32(0)) // num_plays
-	// CRC (fake 4 bytes for testing detector)
-	_ = binary.Write(&actlChunk, binary.BigEndian, uint32(0))
-
-	var out bytes.Buffer
-	out.Write(basePNG[:chunkStart])
-	out.Write(actlChunk.Bytes())
-	out.Write(basePNG[chunkStart:])
-
-	return out.Bytes()
-}
-
 func TestSniffFormat(t *testing.T) {
 	pngData := createTestPNG(t, 2, 2)
 	jpegData := createTestJPEG(t, 2, 2)
@@ -121,8 +78,8 @@ func TestDetectExtension(t *testing.T) {
 	corruptData := []byte("random bytes")
 
 	tests := []struct {
-		name     string
 		data     []byte
+		name     string
 		urlExt   string
 		expected string
 	}{

--- a/api/pkg/core/chapters/download/imageopt_test.go
+++ b/api/pkg/core/chapters/download/imageopt_test.go
@@ -113,108 +113,34 @@ func TestSniffFormat(t *testing.T) {
 	}
 }
 
-func TestIsAPNG(t *testing.T) {
-	regularPNG := createTestPNG(t, 2, 2)
-	if download.IsAPNG(regularPNG) {
-		t.Errorf("regular PNG should not be detected as APNG")
+func TestDetectExtension(t *testing.T) {
+	pngData := createTestPNG(t, 2, 2)
+	jpegData := createTestJPEG(t, 2, 2)
+	webpData := append([]byte("RIFF1234WEBP"), []byte("data")...)
+	gifData := []byte("GIF89a...")
+	corruptData := []byte("random bytes")
+
+	tests := []struct {
+		name     string
+		data     []byte
+		urlExt   string
+		expected string
+	}{
+		{name: "PNG data", data: pngData, urlExt: ".png", expected: download.ExtPNG},
+		{name: "JPEG data with .jpg urlExt", data: jpegData, urlExt: ".jpg", expected: download.ExtJPG},
+		{name: "JPEG data with .jpeg urlExt", data: jpegData, urlExt: ".jpeg", expected: download.ExtJPEG},
+		{name: "WebP data", data: webpData, urlExt: ".webp", expected: download.ExtWEBP},
+		{name: "GIF data", data: gifData, urlExt: ".gif", expected: download.ExtGIF},
+		{name: "Unknown format fallback to urlExt", data: corruptData, urlExt: ".avif", expected: ".avif"},
+		{name: "Unknown format empty urlExt defaults to webp", data: corruptData, urlExt: "", expected: download.ExtWEBP},
 	}
 
-	apng := createTestAPNG(t)
-	if !download.IsAPNG(apng) {
-		t.Errorf("APNG with acTL chunk before IDAT should be detected as APNG")
-	}
-}
-
-func TestOptimizePage_PNGToWebP(t *testing.T) {
-	pngData := createTestPNG(t, 200, 200)
-	res := download.OptimizePage(pngData, download.ExtPNG, nil)
-
-	if res.Extension != download.ExtWEBP {
-		t.Errorf("expected extension .webp, got %s", res.Extension)
-	}
-	if len(res.Data) >= len(pngData) {
-		t.Errorf("expected webp size (%d) to be smaller than png size (%d)", len(res.Data), len(pngData))
-	}
-	if download.SniffFormat(res.Data) != download.FormatWebP {
-		t.Errorf("expected output to be valid WebP format")
-	}
-}
-
-func TestOptimizePage_JPEGToWebP_Smaller(t *testing.T) {
-	solidJPEG := createTestSolidJPEG(t, 200, 200)
-	res := download.OptimizePage(solidJPEG, download.ExtJPG, nil)
-
-	if res.Extension != download.ExtWEBP {
-		t.Errorf("expected .webp when smaller, got %s", res.Extension)
-	}
-	if len(res.Data) >= len(solidJPEG) {
-		t.Errorf("expected webp size (%d) to be smaller than jpeg (%d)", len(res.Data), len(solidJPEG))
-	}
-	if download.SniffFormat(res.Data) != download.FormatWebP {
-		t.Errorf("expected output to be valid WebP format")
-	}
-
-	gradientJPEG := createTestJPEG(t, 200, 200)
-	resGradient := download.OptimizePage(gradientJPEG, download.ExtJPG, nil)
-	if len(resGradient.Data) < len(gradientJPEG) {
-		if resGradient.Extension != download.ExtWEBP {
-			t.Errorf("expected .webp when smaller, got %s", resGradient.Extension)
-		}
-	} else {
-		if resGradient.Extension != download.ExtJPG {
-			t.Errorf("expected original extension when WebP is larger, got %s", resGradient.Extension)
-		}
-		if !bytes.Equal(resGradient.Data, gradientJPEG) {
-			t.Errorf("expected original data preserved when WebP is larger")
-		}
-	}
-}
-
-func TestOptimizePage_APNG_Preserved(t *testing.T) {
-	apngData := createTestAPNG(t)
-	res := download.OptimizePage(apngData, download.ExtPNG, nil)
-
-	if res.Extension != download.ExtPNG {
-		t.Errorf("expected APNG to retain .png extension, got %s", res.Extension)
-	}
-	if !bytes.Equal(res.Data, apngData) {
-		t.Errorf("expected APNG bytes to be preserved untouched")
-	}
-}
-
-func TestOptimizePage_SourceWebP_Preserved(t *testing.T) {
-	webpData := append([]byte("RIFF1234WEBP"), []byte("somedata")...)
-	res := download.OptimizePage(webpData, download.ExtWEBP, nil)
-
-	if res.Extension != download.ExtWEBP {
-		t.Errorf("expected source WebP to retain .webp extension, got %s", res.Extension)
-	}
-	if !bytes.Equal(res.Data, webpData) {
-		t.Errorf("expected source WebP bytes to be preserved untouched")
-	}
-}
-
-func TestOptimizePage_MagicBytesMismatch(t *testing.T) {
-	// Content is PNG, but URL says .jpg
-	pngData := createTestPNG(t, 200, 200)
-	res := download.OptimizePage(pngData, download.ExtJPG, nil)
-
-	if res.Extension != download.ExtWEBP {
-		t.Errorf("expected converted PNG to have .webp extension, got %s", res.Extension)
-	}
-	if download.SniffFormat(res.Data) != download.FormatWebP {
-		t.Errorf("expected output to be WebP")
-	}
-}
-
-func TestOptimizePage_CorruptData_Preserved(t *testing.T) {
-	corruptData := []byte("not an image")
-	res := download.OptimizePage(corruptData, download.ExtPNG, nil)
-
-	if res.Extension != download.ExtPNG {
-		t.Errorf("expected corrupt data to retain url extension, got %s", res.Extension)
-	}
-	if !bytes.Equal(res.Data, corruptData) {
-		t.Errorf("expected corrupt bytes to be preserved untouched")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ext := download.DetectExtension(tc.data, tc.urlExt)
+			if ext != tc.expected {
+				t.Errorf("expected %s, got %s", tc.expected, ext)
+			}
+		})
 	}
 }

--- a/api/pkg/core/chapters/download/storage.go
+++ b/api/pkg/core/chapters/download/storage.go
@@ -155,7 +155,7 @@ func downloadPage(
 	imageURL string,
 	dir string,
 	pageIndex int,
-	logger *slog.Logger,
+	_ *slog.Logger,
 ) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil)
 	if err != nil {
@@ -179,9 +179,9 @@ func downloadPage(
 	}
 
 	urlExt := pageExtension(imageURL)
-	opt := OptimizePage(bodyBytes, urlExt, logger)
+	ext := DetectExtension(bodyBytes, urlExt)
 
-	destPath := filepath.Join(dir, pageFilename(pageIndex, opt.Extension))
+	destPath := filepath.Join(dir, pageFilename(pageIndex, ext))
 
 	if err = os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("os.MkdirAll %s: %w", dir, err)
@@ -198,7 +198,7 @@ func downloadPage(
 		os.Remove(tmpName)
 	}()
 
-	if _, err = tmp.Write(opt.Data); err != nil {
+	if _, err = tmp.Write(bodyBytes); err != nil {
 		return fmt.Errorf("tmp.Write %s: %w", tmpName, err)
 	}
 

--- a/api/pkg/core/chapters/download/worker_test.go
+++ b/api/pkg/core/chapters/download/worker_test.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//nolint:goconst,lll
+//nolint:goconst,lll,dupl
 package download_test
 
 import (
@@ -654,7 +654,7 @@ func TestWorkerResumeEnqueuesWithoutClearingPages(t *testing.T) {
 	}
 }
 
-func TestWorkerOptimizesPNGToWebP(t *testing.T) {
+func TestWorkerPreservesPNGBytes(t *testing.T) {
 	t.Parallel()
 
 	comicID := uuid.New()
@@ -702,96 +702,20 @@ func TestWorkerOptimizesPNGToWebP(t *testing.T) {
 		updated, err := chaptersRepo.GetByID(context.Background(), chapterID)
 		if err == nil && updated.Download == 100 {
 			chapterDir := filepath.Join(dir, comicID.String(), "1")
-			webpPath := filepath.Join(chapterDir, "001.webp")
 			pngPath := filepath.Join(chapterDir, "001.png")
-
-			data, err := os.ReadFile(webpPath)
-			if err != nil {
-				t.Fatalf("expected 001.webp to exist: %v", err)
-			}
-
-			if len(data) >= len(pngBytes) {
-				t.Errorf("expected webp size (%d) to be smaller than png (%d)", len(data), len(pngBytes))
-			}
-
-			if download.SniffFormat(data) != download.FormatWebP {
-				t.Errorf("expected downloaded file to be webp format")
-			}
-
-			if _, err := os.Stat(pngPath); !os.IsNotExist(err) {
-				t.Errorf("expected 001.png not to exist")
-			}
-
-			return
-		}
-
-		time.Sleep(20 * time.Millisecond)
-	}
-
-	t.Fatal("chapter was not completed")
-}
-
-func TestWorkerOptimizesJPEGToWebPWhenSmaller(t *testing.T) {
-	t.Parallel()
-
-	comicID := uuid.New()
-	chapterID := uuid.New()
-	chapter := chapters.Chapter{
-		ID:                chapterID,
-		ComicID:           comicID,
-		SourceChapterSlug: "chapter-1",
-		Number:            1,
-		PagesNb:           1,
-	}
-	comic := comics.Comic{
-		ID:     comicID,
-		Source: sources.SourceAsuraScans,
-		Slug:   "series-slug",
-	}
-
-	jpegBytes := createTestSolidJPEG(t, 200, 200)
-
-	worker, dir, chaptersRepo := newTestWorker(
-		t,
-		chapter,
-		comic,
-		[]string{".jpg"},
-		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(jpegBytes)
-		}),
-	)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	go func() {
-		_ = worker.Run(ctx)
-	}()
-
-	err := worker.Enqueue(context.Background(), []chapters.Chapter{chapter})
-	if err != nil {
-		t.Fatalf("Enqueue: %v", err)
-	}
-
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		updated, err := chaptersRepo.GetByID(context.Background(), chapterID)
-		if err == nil && updated.Download == 100 {
-			chapterDir := filepath.Join(dir, comicID.String(), "1")
 			webpPath := filepath.Join(chapterDir, "001.webp")
 
-			data, err := os.ReadFile(webpPath)
+			data, err := os.ReadFile(pngPath)
 			if err != nil {
-				t.Fatalf("expected 001.webp to exist: %v", err)
+				t.Fatalf("expected 001.png to exist: %v", err)
 			}
 
-			if len(data) >= len(jpegBytes) {
-				t.Errorf("expected webp size (%d) to be smaller than jpeg (%d)", len(data), len(jpegBytes))
+			if !bytes.Equal(data, pngBytes) {
+				t.Errorf("expected original png bytes to be preserved exactly")
 			}
 
-			if download.SniffFormat(data) != download.FormatWebP {
-				t.Errorf("expected downloaded file to be webp format")
+			if _, err := os.Stat(webpPath); !os.IsNotExist(err) {
+				t.Errorf("expected 001.webp not to exist")
 			}
 
 			return
@@ -803,7 +727,7 @@ func TestWorkerOptimizesJPEGToWebPWhenSmaller(t *testing.T) {
 	t.Fatal("chapter was not completed")
 }
 
-func TestWorkerPreservesJPEGWhenWebPLarger(t *testing.T) {
+func TestWorkerPreservesJPEGBytes(t *testing.T) {
 	t.Parallel()
 
 	comicID := uuid.New()
@@ -852,6 +776,7 @@ func TestWorkerPreservesJPEGWhenWebPLarger(t *testing.T) {
 		if err == nil && updated.Download == 100 {
 			chapterDir := filepath.Join(dir, comicID.String(), "1")
 			jpgPath := filepath.Join(chapterDir, "001.jpg")
+			webpPath := filepath.Join(chapterDir, "001.webp")
 
 			data, err := os.ReadFile(jpgPath)
 			if err != nil {
@@ -860,6 +785,10 @@ func TestWorkerPreservesJPEGWhenWebPLarger(t *testing.T) {
 
 			if !bytes.Equal(data, jpegBytes) {
 				t.Errorf("expected original jpeg bytes to be preserved")
+			}
+
+			if _, err := os.Stat(webpPath); !os.IsNotExist(err) {
+				t.Errorf("expected 001.webp not to exist")
 			}
 
 			return
@@ -952,82 +881,10 @@ func TestWorkerResumesSkippingExistingWebPAndPNG(t *testing.T) {
 				t.Fatalf("002.png modified or missing: %v", err)
 			}
 
-			// Verify page 3 was downloaded and optimized to webp
-			if _, err := os.Stat(filepath.Join(chapterDir, "003.webp")); err != nil {
-				t.Fatalf("third page not saved as webp: %v", err)
-			}
-
-			return
-		}
-
-		time.Sleep(20 * time.Millisecond)
-	}
-
-	t.Fatal("chapter was not completed")
-}
-
-func TestWorkerPreservesAPNGAsPNG(t *testing.T) {
-	t.Parallel()
-
-	comicID := uuid.New()
-	chapterID := uuid.New()
-	chapter := chapters.Chapter{
-		ID:                chapterID,
-		ComicID:           comicID,
-		SourceChapterSlug: "chapter-1",
-		Number:            1,
-		PagesNb:           1,
-	}
-	comic := comics.Comic{
-		ID:     comicID,
-		Source: sources.SourceAsuraScans,
-		Slug:   "series-slug",
-	}
-
-	apngBytes := createTestAPNG(t)
-
-	worker, dir, chaptersRepo := newTestWorker(
-		t,
-		chapter,
-		comic,
-		[]string{".png"},
-		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(apngBytes)
-		}),
-	)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	go func() {
-		_ = worker.Run(ctx)
-	}()
-
-	err := worker.Enqueue(context.Background(), []chapters.Chapter{chapter})
-	if err != nil {
-		t.Fatalf("Enqueue: %v", err)
-	}
-
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		updated, err := chaptersRepo.GetByID(context.Background(), chapterID)
-		if err == nil && updated.Download == 100 {
-			chapterDir := filepath.Join(dir, comicID.String(), "1")
-			pngPath := filepath.Join(chapterDir, "001.png")
-			webpPath := filepath.Join(chapterDir, "001.webp")
-
-			data, err := os.ReadFile(pngPath)
-			if err != nil {
-				t.Fatalf("expected 001.png to exist: %v", err)
-			}
-
-			if !bytes.Equal(data, apngBytes) {
-				t.Errorf("expected APNG bytes to be preserved exactly")
-			}
-
-			if _, err := os.Stat(webpPath); !os.IsNotExist(err) {
-				t.Errorf("expected 001.webp not to exist for APNG")
+			// Verify page 3 was downloaded and saved as png
+			p3, err := os.ReadFile(filepath.Join(chapterDir, "003.png"))
+			if err != nil || !bytes.Equal(p3, page3PNG) {
+				t.Fatalf("third page not saved as png: %v", err)
 			}
 
 			return


### PR DESCRIPTION
## Summary
- Remove in-memory image decoding (`image.Decode`, `png.Decode`, `jpeg.Decode`) and lossless WebP re-encoding (`gowebp.Encode`) during chapter downloads to eliminate RAM spikes and CPU overhead.
- Implement lightweight magic-byte sniffing (`SniffFormat`) and extension detection (`DetectExtension`) for PNG, JPEG, WebP, and GIF with fallback on URL extensions.
- Write raw downloaded HTTP response bytes directly to disk via atomic temp file writes (`.dl-*`) and destination renames.
- Remove `github.com/KarpelesLab/gowebp` and `golang.org/x/image` dependencies from `go.mod`/`go.sum`.

## Test plan
- [x] Run unit tests for format sniffing and extension detection (`go test ./pkg/core/chapters/download -run 'TestSniffFormat|TestDetectExtension'`).
- [x] Run worker integration tests ensuring downloaded raw bytes match byte-for-byte (`go test ./pkg/core/chapters/download/...`).
- [x] Run full API test suite (`go test ./...` -> 1381 passed across 65 packages).
- [x] Run linter (`golangci-lint run ./...` -> 0 issues).
