### PR TITLE
fix(pwa): keep field font at 16px in standalone to avoid iOS focus zoom

### DIFF
--- a/web/app/assets/styles/vuetify-overrides.scss
+++ b/web/app/assets/styles/vuetify-overrides.scss
@@ -103,6 +103,25 @@
   }
 }
 
+@media (display-mode: standalone) {
+  .text-field-override {
+    .v-input__control {
+      .v-field {
+        .v-field__field {
+          input,
+          textarea {
+            font-size: 16px;
+          }
+        }
+      }
+
+      .v-field__input {
+        font-size: 16px;
+      }
+    }
+  }
+}
+
 .v-input--density-compact {
   --v-input-control-height: 30px;
   --v-input-padding-top: 4px;

--- a/web/app/features/reader/components/Overlay/Header.vue
+++ b/web/app/features/reader/components/Overlay/Header.vue
@@ -18,12 +18,10 @@ const { smAndDown } = useDisplay()
   >
     <div
       class="d-flex ga-4 justify-space-between align-center w-100 mx-auto "
+      :style="smAndDown ? 'padding-top: env(safe-area-inset-top, 0px);' : ''"
       style="max-width: 80rem;"
     >
-      <div
-        class="d-flex ga-4 align-center text-truncate"
-        :style="smAndDown ? 'padding-top: var(--page-header-padding-top);' : ''"
-      >
+      <div class="d-flex ga-4 align-center text-truncate">
         <AtomLink :to="`/comic/${comic.id}`">
           <VBtn
             icon="fa6-solid:angle-left"


### PR DESCRIPTION
## Summary
- Enforce 16px font size on form inputs (`input`, `textarea`, `.v-field__input`) within `.text-field-override` in standalone display mode (`@media (display-mode: standalone)`).
- Prevents iOS Safari from auto-zooming into `VTextField`, `VAutocomplete`, and `VSelect` fields on focus in the installed PWA.
- Adjust reader overlay header safe area top padding.
- Closes #117

## Test plan
- [ ] Open the PWA on an iOS device (or simulator in standalone mode)
- [ ] Focus on `VTextField`, `VAutocomplete`, and `VSelect` inputs
- [ ] Verify that the viewport scale remains at 1x and does not zoom in
- [ ] Verify that field layouts and compact density still render properly
- [ ] Check reader overlay header padding on mobile