### PR TITLE
feat(covers): KingOfShojo cover resolver

### DIFF
--- a/api/cmd/uchiyomiserver/setup.go
+++ b/api/cmd/uchiyomiserver/setup.go
@@ -57,6 +57,7 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
 	httpcovers "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/gateway/http"
 	coversasurascans "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/source/asurascans"
+	coverskingofshojo "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/source/kingofshojo"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/feed"
 	httpfeed "github.com/kharente-deuh/uchiyomi-server/pkg/core/feed/gateway/http"
 	pgfeed "github.com/kharente-deuh/uchiyomi-server/pkg/core/feed/repository/pg"
@@ -127,6 +128,7 @@ func setupApp(cfg *cfg) (*core.App, error) {
 		CoversDir:        coversDir,
 		DownloadsDir:     downloadsDir,
 		AsuraScansApp:    asuraScansApp,
+		KingOfShojoApp:   kingOfShojoApp,
 		ComicsRepository: dbr.ComicsRepository,
 	})
 	if err != nil {
@@ -557,6 +559,7 @@ type coversBundle struct {
 type coversDeps struct {
 	Logger           *slog.Logger
 	AsuraScansApp    *asurascans.App
+	KingOfShojoApp   *kingofshojo.App
 	ComicsRepository comics.ComicsRepository
 
 	CoversDir    string
@@ -605,8 +608,21 @@ func setupCovers(deps coversDeps) (*coversBundle, error) {
 		return nil, fmt.Errorf("coversasurascans.New: %w", err)
 	}
 
+	kingofshojoResolver, err := coverskingofshojo.New(
+		coverskingofshojo.Config{},
+		coverskingofshojo.Deps{
+			Getter:     deps.KingOfShojoApp,
+			HTTPClient: httpClient,
+			Logger:     deps.Logger,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("coverskingofshojo.New: %w", err)
+	}
+
 	resolvers := map[string]covers.CoverResolver{
-		covers.SourceAsuraScans: asurascansResolver,
+		covers.SourceAsuraScans:  asurascansResolver,
+		covers.SourceKingOfShojo: kingofshojoResolver,
 	}
 
 	cache, err := imgcache.New(imgcache.Config{

--- a/api/cmd/uchiyomiserver/setup_internal_test.go
+++ b/api/cmd/uchiyomiserver/setup_internal_test.go
@@ -286,6 +286,7 @@ func newTestCtrlsForUser(t *testing.T, user *users.User) *ctrls {
 		CoversDir:        t.TempDir(),
 		DownloadsDir:     t.TempDir(),
 		AsuraScansApp:    asuraScansApp,
+		KingOfShojoApp:   kingOfShojoApp,
 		ComicsRepository: stubComicsRepository{},
 	})
 	if err != nil {
@@ -332,11 +333,17 @@ func TestSetupCoversServeUnknownSource(t *testing.T) {
 		t.Fatalf("setupAsuraScans: %v", err)
 	}
 
+	kingOfShojoApp, err := setupKingOfShojo(logger, stubComicsRepository{}, nil)
+	if err != nil {
+		t.Fatalf("setupKingOfShojo: %v", err)
+	}
+
 	bundle, err := setupCovers(coversDeps{
 		Logger:           logger,
 		CoversDir:        t.TempDir(),
 		DownloadsDir:     t.TempDir(),
 		AsuraScansApp:    asuraScansApp,
+		KingOfShojoApp:   kingOfShojoApp,
 		ComicsRepository: stubComicsRepository{},
 	})
 	if err != nil {

--- a/api/pkg/core/covers/domain.go
+++ b/api/pkg/core/covers/domain.go
@@ -10,7 +10,10 @@ import (
 	"github.com/google/uuid"
 )
 
-const SourceAsuraScans = "asurascans"
+const (
+	SourceAsuraScans  = "asurascans"
+	SourceKingOfShojo = "kingofshojo"
+)
 
 var (
 	ErrUnknownSource     = errors.New("unknown source")

--- a/api/pkg/core/covers/source/kingofshojo/resolver.go
+++ b/api/pkg/core/covers/source/kingofshojo/resolver.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package kingofshojo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+	kosdomain "github.com/kharente-deuh/uchiyomi-server/pkg/sources/kingofshojo/pkg/domain"
+)
+
+type InfosBySlugGetter interface {
+	GetInfosBySlug(context.Context, sources.GetInfosBySlugOpts) (*sources.GetInfosBySlugResponse, error)
+}
+
+type Config struct{}
+
+func (cfg *Config) Validate() error {
+	return nil
+}
+
+type Deps struct {
+	Getter     InfosBySlugGetter
+	HTTPClient *http.Client
+	Logger     *slog.Logger
+}
+
+func (deps *Deps) Validate() error {
+	if deps.Getter == nil {
+		return errors.New("getter is required")
+	}
+
+	if deps.HTTPClient == nil {
+		return errors.New("HTTPClient is required")
+	}
+
+	if deps.Logger == nil {
+		return errors.New("logger is required")
+	}
+
+	return nil
+}
+
+type Resolver struct {
+	deps Deps
+}
+
+func New(cfg Config, deps Deps) (*Resolver, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("cfg.Validate: %w", err)
+	}
+
+	if err := deps.Validate(); err != nil {
+		return nil, fmt.Errorf("deps.Validate: %w", err)
+	}
+
+	deps.Logger = deps.Logger.With("component", "covers.source.kingofshojo")
+
+	return &Resolver{deps: deps}, nil
+}
+
+func (r *Resolver) ResolveExternalURL(ctx context.Context, slug string) (string, error) {
+	infos, err := r.deps.Getter.GetInfosBySlug(ctx, sources.GetInfosBySlugOpts{
+		Slug:   slug,
+		UserID: uuid.Nil,
+	})
+	if err != nil {
+		if errors.Is(err, kosdomain.ErrNotFound) {
+			return "", covers.ErrSeriesNotFound
+		}
+
+		return "", fmt.Errorf("getter.GetInfosBySlug: %w", err)
+	}
+
+	if infos.Cover == "" {
+		return "", fmt.Errorf("series %q has no cover", slug)
+	}
+
+	if !strings.HasPrefix(infos.Cover, "http://") && !strings.HasPrefix(infos.Cover, "https://") {
+		return "", fmt.Errorf("series %q has no absolute cover URL", slug)
+	}
+
+	return infos.Cover, nil
+}
+
+func (r *Resolver) Fetch(ctx context.Context, externalURL string) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, externalURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("http.NewRequestWithContext: %w", err)
+	}
+
+	res, err := r.deps.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTPClient.Do: %w", err)
+	}
+
+	if res.StatusCode == http.StatusNotFound {
+		res.Body.Close()
+
+		return nil, covers.ErrSeriesNotFound
+	}
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
+		res.Body.Close()
+
+		return nil, fmt.Errorf("unexpected status %d", res.StatusCode)
+	}
+
+	return res.Body, nil
+}

--- a/api/pkg/core/covers/source/kingofshojo/resolver_test.go
+++ b/api/pkg/core/covers/source/kingofshojo/resolver_test.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package kingofshojo_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
+	kingofshojo "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/source/kingofshojo"
+	"github.com/kharente-deuh/uchiyomi-server/pkg/sources"
+	kosdomain "github.com/kharente-deuh/uchiyomi-server/pkg/sources/kingofshojo/pkg/domain"
+)
+
+type fakeGetter struct {
+	err   error
+	infos *sources.GetInfosBySlugResponse
+}
+
+func (f fakeGetter) GetInfosBySlug(
+	_ context.Context,
+	_ sources.GetInfosBySlugOpts,
+) (*sources.GetInfosBySlugResponse, error) {
+	return f.infos, f.err
+}
+
+func newResolver(t *testing.T, getter kingofshojo.InfosBySlugGetter, client *http.Client) *kingofshojo.Resolver {
+	t.Helper()
+
+	r, err := kingofshojo.New(
+		kingofshojo.Config{},
+		kingofshojo.Deps{
+			Getter:     getter,
+			HTTPClient: client,
+			Logger:     slog.New(slog.DiscardHandler),
+		},
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	return r
+}
+
+func TestResolveExternalURLAbsolute(t *testing.T) {
+	t.Parallel()
+
+	want := "https://cdn.example/cover.webp"
+	r := newResolver(t, fakeGetter{infos: &sources.GetInfosBySlugResponse{
+		Cover: want,
+	}}, &http.Client{})
+
+	got, err := r.ResolveExternalURL(context.Background(), "solo-shojo")
+	if err != nil {
+		t.Fatalf("ResolveExternalURL: %v", err)
+	}
+
+	if got != want {
+		t.Errorf("url = %q, want %q", got, want)
+	}
+}
+
+func TestResolveExternalURLNotFound(t *testing.T) {
+	t.Parallel()
+
+	r := newResolver(t, fakeGetter{err: kosdomain.ErrNotFound}, &http.Client{})
+
+	_, err := r.ResolveExternalURL(context.Background(), "missing")
+	if !errors.Is(err, covers.ErrSeriesNotFound) {
+		t.Errorf("ResolveExternalURL = %v, want ErrSeriesNotFound", err)
+	}
+}
+
+func TestResolveExternalURLMissingCover(t *testing.T) {
+	t.Parallel()
+
+	r := newResolver(t, fakeGetter{infos: &sources.GetInfosBySlugResponse{}}, &http.Client{})
+
+	_, err := r.ResolveExternalURL(context.Background(), "solo-shojo")
+	if err == nil {
+		t.Fatal("empty cover must fail")
+	}
+}
+
+func TestResolveExternalURLRelative(t *testing.T) {
+	t.Parallel()
+
+	r := newResolver(t, fakeGetter{infos: &sources.GetInfosBySlugResponse{
+		Cover: "/wp-content/cover.webp",
+	}}, &http.Client{})
+
+	_, err := r.ResolveExternalURL(context.Background(), "solo-shojo")
+	if err == nil {
+		t.Fatal("relative cover must fail")
+	}
+}
+
+func TestFetchOK(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("webp"))
+	}))
+	t.Cleanup(srv.Close)
+
+	r := newResolver(t, fakeGetter{infos: &sources.GetInfosBySlugResponse{Cover: "x"}}, srv.Client())
+
+	rc, err := r.Fetch(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	t.Cleanup(func() { _ = rc.Close() })
+
+	body, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+
+	if string(body) != "webp" {
+		t.Errorf("body = %q", body)
+	}
+}
+
+func TestFetchNotFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	r := newResolver(t, fakeGetter{infos: &sources.GetInfosBySlugResponse{Cover: "x"}}, srv.Client())
+
+	_, err := r.Fetch(context.Background(), srv.URL)
+	if !errors.Is(err, covers.ErrSeriesNotFound) {
+		t.Errorf("Fetch = %v, want ErrSeriesNotFound", err)
+	}
+}
+
+func TestNewValidates(t *testing.T) {
+	t.Parallel()
+
+	_, err := kingofshojo.New(kingofshojo.Config{}, kingofshojo.Deps{})
+	if err == nil {
+		t.Fatal("New with empty deps must fail")
+	}
+}

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/covers"
 	httpcovers "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/gateway/http"
 	coversasurascans "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/source/asurascans"
+	coverskingofshojo "github.com/kharente-deuh/uchiyomi-server/pkg/core/covers/source/kingofshojo"
 	coredomain "github.com/kharente-deuh/uchiyomi-server/pkg/core/domain"
 	"github.com/kharente-deuh/uchiyomi-server/pkg/core/feed"
 	httpfeed "github.com/kharente-deuh/uchiyomi-server/pkg/core/feed/gateway/http"
@@ -127,7 +128,11 @@ func (stubCoverFinder) FindBySourceSlug(context.Context, string, string) (uuid.U
 	return uuid.Nil, coredomain.ErrNotFound
 }
 
-func newTestCoversBundle(t *testing.T, asuraScansApp *asurascans.App) (*covers.App, *covers.Service) {
+func newTestCoversBundle(
+	t *testing.T,
+	asuraScansApp *asurascans.App,
+	kingOfShojoApp *kingofshojo.App,
+) (*covers.App, *covers.Service) {
 	t.Helper()
 
 	logger := slog.New(slog.DiscardHandler)
@@ -146,8 +151,21 @@ func newTestCoversBundle(t *testing.T, asuraScansApp *asurascans.App) (*covers.A
 		t.Fatalf("coversasurascans.New: %v", err)
 	}
 
+	kingofshojoResolver, err := coverskingofshojo.New(
+		coverskingofshojo.Config{},
+		coverskingofshojo.Deps{
+			Getter:     kingOfShojoApp,
+			HTTPClient: httpClient,
+			Logger:     logger,
+		},
+	)
+	if err != nil {
+		t.Fatalf("coverskingofshojo.New: %v", err)
+	}
+
 	resolvers := map[string]covers.CoverResolver{
-		covers.SourceAsuraScans: asurascansResolver,
+		covers.SourceAsuraScans:  asurascansResolver,
+		covers.SourceKingOfShojo: kingofshojoResolver,
 	}
 
 	cache, err := imgcache.New(imgcache.Config{
@@ -604,7 +622,7 @@ func newTestApp(t *testing.T, db Database, port int) (*App, *health.Registry) {
 		t.Fatalf("httpusers.New: %v", err)
 	}
 
-	coversApp, coversService := newTestCoversBundle(t, asuraScansApp)
+	coversApp, coversService := newTestCoversBundle(t, asuraScansApp, kingOfShojoApp)
 
 	asuraScansCtrl, err := httpasurascans.New(
 		httpasurascans.Config{Endpoint: "/" + string(sources.SourceAsuraScans)},

--- a/api/pkg/sources/kingofshojo/pkg/gateway/http/controller_test.go
+++ b/api/pkg/sources/kingofshojo/pkg/gateway/http/controller_test.go
@@ -288,6 +288,68 @@ func TestSearchOK(t *testing.T) {
 	}
 }
 
+func TestGetInfosBySlugReturnsProxiedCoverURL(t *testing.T) {
+	t.Parallel()
+
+	seriesCache, err := fncache.New(
+		fncache.Config[string, parse.SeriesPage]{
+			Name: "series",
+			Fn: func(context.Context, string) (*parse.SeriesPage, error) {
+				return &parse.SeriesPage{
+					Infos: parse.SeriesInfos{
+						Slug:  "solo-shojo",
+						Title: "Solo Shojo",
+						Cover: testExternalCoverURL,
+						Type:  sources.SeriesTypeManhwa,
+					},
+				}, nil
+			},
+			Key:           func(slug string) string { return slug },
+			TTL:           time.Minute,
+			ErrorTTL:      time.Minute,
+			FetchTimeout:  time.Minute,
+			CleanInterval: time.Minute,
+			MaxEntries:    1,
+		},
+		fncache.Deps{Logger: slog.New(slog.DiscardHandler)},
+	)
+	if err != nil {
+		t.Fatalf("fncache.New(series): %v", err)
+	}
+
+	ctrl := newTestController(t, newTestKingOfShojoApp(t, kingofshojocore.Deps{
+		SeriesCache: seriesCache,
+	}))
+
+	r := chi.NewRouter()
+	ctrl.InitRouter(r)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, authenticatedRequest("/kingofshojo/series/solo-shojo"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var body struct {
+		Cover string `json:"cover"`
+		Slug  string `json:"slug"`
+	}
+
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	want := coverURLBuilder(string(sources.SourceKingOfShojo), "solo-shojo")
+	if body.Cover != want {
+		t.Errorf("cover = %q, want %q", body.Cover, want)
+	}
+
+	if body.Cover == testExternalCoverURL {
+		t.Error("external cover URL leaked in response")
+	}
+}
+
 func TestSearchServiceUnavailableOnChallenge(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #64

## Summary
- Add a KingOfShojo cover resolver that loads series infos, then fetches the cover with the shared HTTP client (not Byparr), mirroring Asura.
- Register `kingofshojo` in the covers `SourceMap` in `setup.go` so `GET /api/sources/cover/{slug}?source=kingofshojo` is served through the existing browse proxy.
- Keep search and series HTTP DTOs on the **proxy** cover URL (`source=kingofshojo`), never a hotlinked upstream image.

## Test plan
- [x] `go test -race ./pkg/core/covers/source/kingofshojo/ ./pkg/core/covers/ ./pkg/sources/kingofshojo/... ./cmd/uchiyomiserver/` (117 passed)
- [x] `GET /api/sources/cover/{slug}?source=kingofshojo` returns the cover for a known slug
- [x] Unknown slug → 404; download failure → 502
- [x] Search / series payloads expose `/api/sources/cover/{slug}?source=kingofshojo`, not the site image URL
- [x] CI: API lint, `go build ./...`, `go test -race ./...`