### PR TITLE
feat(kingofshojo): add browse page

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -108,7 +108,7 @@ Search and explore comics on an external source before adding them. The AsuraSca
 Lists all available sources as cards. Each card links to that source's browse page. Only AsuraScans for now.
 
 **Search pagination**:
-Mobile: infinite scroll — next page loads when the user reaches the bottom, previous results stay visible. Desktop: classic pagination footer with page numbers. Applies to source browse, library, and feed.
+Mobile: infinite scroll — next page loads when the user reaches the bottom, previous results stay visible. Desktop: a pagination footer. Source browse uses a 1-based page and a next-page flag from the source; there is no result total, and page size is whatever that source returns. Library and feed use offset, limit, and a counted total, with page numbers on desktop.
 
 **Chapter**:
 A single instalment of a comic, stored in the database and linked to one comic. Chapters are created when a comic is added to a library, and when a chapter list refresh finds source chapters with no matching source chapter slug. Each chapter tracks its download progress independently. The expected page count (`pagesNb`) is initialized from the source chapter list and updated when page URLs are fetched if the source reports a different count.

--- a/api/cmd/uchiyomiserver/setup.go
+++ b/api/cmd/uchiyomiserver/setup.go
@@ -699,7 +699,7 @@ func setupAsuraScans(logger *slog.Logger, comicsRepo comics.ComicsRepository) (*
 			Name:          "asurascans.search",
 			Key: func(opts asurascansdomain.SearchCacheOpts) string {
 				return fmt.Sprintf(
-					"%s %s %s %s %s %s %v %d %d %d",
+					"%s %s %s %s %s %s %v %d %d",
 					opts.Search,
 					opts.Sort,
 					opts.SortOrder,
@@ -707,8 +707,7 @@ func setupAsuraScans(logger *slog.Logger, comicsRepo comics.ComicsRepository) (*
 					opts.Type,
 					opts.Artist,
 					opts.Genres,
-					opts.Offset,
-					opts.Limit,
+					opts.Page,
 					opts.MinChapters,
 				)
 			},

--- a/api/pkg/sources/asurascans/pkg/core/app.go
+++ b/api/pkg/sources/asurascans/pkg/core/app.go
@@ -125,8 +125,7 @@ func (a *App) Search(ctx context.Context, opts domain.SearchOpts) (*domain.Searc
 		Type:        opts.Type,
 		Artist:      opts.Artist,
 		Genres:      opts.Genres,
-		Offset:      opts.Offset,
-		Limit:       opts.Limit,
+		Page:        opts.Page,
 		MinChapters: opts.MinChapters,
 	})
 

--- a/api/pkg/sources/asurascans/pkg/core/app_test.go
+++ b/api/pkg/sources/asurascans/pkg/core/app_test.go
@@ -267,8 +267,7 @@ func searchCacheKey(opts domain.SearchCacheOpts) string {
 		Type:        opts.Type,
 		Artist:      opts.Artist,
 		Genres:      opts.Genres,
-		Offset:      opts.Offset,
-		Limit:       opts.Limit,
+		Page:        opts.Page,
 		MinChapters: opts.MinChapters,
 	}.CacheKey()
 }
@@ -400,7 +399,7 @@ func TestAppSearchDelegatesToCache(t *testing.T) {
 		func(_ context.Context, opts domain.SearchCacheOpts) (*domain.SearchCacheResult, error) {
 			called <- opts
 
-			return &domain.SearchCacheResult{Meta: domain.SearchResultMeta{Total: 3}}, nil
+			return &domain.SearchCacheResult{Meta: domain.SearchResultMeta{HasNextPage: true}}, nil
 		})
 
 	app, err := core.New(testConfig(), deps)
@@ -413,7 +412,7 @@ func TestAppSearchDelegatesToCache(t *testing.T) {
 		t.Fatalf("Search: %v", err)
 	}
 
-	if res == nil || res.Meta.Total != 3 {
+	if res == nil || !res.Meta.HasNextPage {
 		t.Errorf("result = %+v", res)
 	}
 

--- a/api/pkg/sources/asurascans/pkg/domain/apiclient.go
+++ b/api/pkg/sources/asurascans/pkg/domain/apiclient.go
@@ -69,8 +69,7 @@ type SearchCacheOpts struct {
 	Type        sources.SeriesType
 	Artist      string
 	Genres      []string
-	Offset      int
-	Limit       int
+	Page        int
 	MinChapters int
 }
 
@@ -82,8 +81,7 @@ type SearchOpts struct {
 	Type        sources.SeriesType
 	Artist      string
 	Genres      []string
-	Offset      int
-	Limit       int
+	Page        int
 	MinChapters int
 	UserID      uuid.UUID
 }
@@ -99,9 +97,7 @@ type SearchResult struct {
 }
 
 type SearchResultMeta struct {
-	Total   int
-	PerPage int
-	HasMore bool
+	HasNextPage bool
 }
 
 type SearchResultItem struct {

--- a/api/pkg/sources/asurascans/pkg/domain/cachekey.go
+++ b/api/pkg/sources/asurascans/pkg/domain/cachekey.go
@@ -13,8 +13,8 @@ func (o SearchOpts) CacheKey() string {
 	genres = slices.Compact(genres)
 
 	return fmt.Sprintf(
-		"offset=%d limit=%d search=%q sort=%q order=%q status=%q type=%q artist=%q genres=%q minchapters=%d",
-		o.Offset, o.Limit, o.Search, o.Sort, o.SortOrder,
+		"page=%d search=%q sort=%q order=%q status=%q type=%q artist=%q genres=%q minchapters=%d",
+		o.Page, o.Search, o.Sort, o.SortOrder,
 		o.Status, o.Type, o.Artist, genres, o.MinChapters,
 	)
 }

--- a/api/pkg/sources/asurascans/pkg/domain/cachekey_test.go
+++ b/api/pkg/sources/asurascans/pkg/domain/cachekey_test.go
@@ -85,14 +85,13 @@ func TestSearchOptsCacheKeyDistinguishesEveryField(t *testing.T) {
 	t.Parallel()
 
 	base := domain.SearchOpts{
-		Offset: 1, Limit: 2, Search: "s", Sort: domain.SortTypeLatest,
+		Page: 1, Search: "s", Sort: domain.SortTypeLatest,
 		SortOrder: domain.SortOrderAsc, Status: "st", Type: "ty", Artist: "ar",
 		Genres: []string{"g"}, MinChapters: 3,
 	}
 
 	variants := map[string]domain.SearchOpts{
-		"Offset":      {Offset: 9},
-		"Limit":       {Limit: 9},
+		"Page":        {Page: 9},
 		"Search":      {Search: testValueAutre},
 		"Sort":        {Sort: domain.SortTypeRating},
 		"SortOrder":   {SortOrder: domain.SortOrderDesc},
@@ -111,10 +110,8 @@ func TestSearchOptsCacheKeyDistinguishesEveryField(t *testing.T) {
 			opts := base
 
 			switch field {
-			case "Offset":
-				opts.Offset = variant.Offset
-			case "Limit":
-				opts.Limit = variant.Limit
+			case "Page":
+				opts.Page = variant.Page
 			case "Search":
 				opts.Search = variant.Search
 			case "Sort":

--- a/api/pkg/sources/asurascans/pkg/gateway/http/controller.go
+++ b/api/pkg/sources/asurascans/pkg/gateway/http/controller.go
@@ -140,7 +140,7 @@ func (c *Controller) search(w http.ResponseWriter, r *http.Request) {
 	buildCover := c.deps.CoverURLBuilder
 
 	dto := searchResDTO{
-		Total: res.Meta.Total,
+		HasNextPage: res.Meta.HasNextPage,
 		Items: utils.MapSlice(res.Items, func(i domain.SearchResultItem) searchResItemDTO {
 			return searchResItemDTO{
 				LastChapterAt: utils.OptionalTime(i.LastChapterAt),

--- a/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
+++ b/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
@@ -357,7 +357,7 @@ func TestSearchRejectsNonIntegerPage(t *testing.T) {
 	ctrl.InitRouter(r)
 
 	rec := httptest.NewRecorder()
-	r.ServeHTTP(rec, authenticatedRequest(http.MethodGet, endpoint+"/search?page=x"))
+	r.ServeHTTP(rec, authenticatedRequest(http.MethodGet, endpoint+"/search?page=x&sort=popular&order=desc"))
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)

--- a/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
+++ b/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
@@ -187,101 +187,137 @@ func (s libraryChaptersService) ServePage(context.Context, chapters.ServePageOpt
 	return "", "", nil
 }
 
-func newTestAsuraScansApp(t *testing.T) *asurascans.App {
+func newTestAsuraScansApp(t *testing.T, deps ...asurascans.Deps) *asurascans.App {
 	t.Helper()
 
-	searchCache, err := fncache.New(
-		fncache.Config[domain.SearchCacheOpts, domain.SearchCacheResult]{
-			Name: "search",
-			Fn: func(context.Context, domain.SearchCacheOpts) (*domain.SearchCacheResult, error) {
-				return &domain.SearchCacheResult{
-					Meta: domain.SearchResultMeta{Total: 1},
-					Items: []domain.SearchCacheResultItem{{
-						Slug:  "solo-leveling",
+	var partial asurascans.Deps
+	if len(deps) > 0 {
+		partial = deps[0]
+	}
+
+	searchCache := partial.SearchCache
+	if searchCache == nil {
+		var err error
+
+		searchCache, err = fncache.New(
+			fncache.Config[domain.SearchCacheOpts, domain.SearchCacheResult]{
+				Name: "search",
+				Fn: func(context.Context, domain.SearchCacheOpts) (*domain.SearchCacheResult, error) {
+					return &domain.SearchCacheResult{
+						Meta: domain.SearchResultMeta{HasNextPage: true},
+						Items: []domain.SearchCacheResultItem{{
+							Slug:  "solo-leveling",
+							Title: "Solo Leveling",
+							Cover: testExternalCoverURL,
+						}},
+					}, nil
+				},
+				Key:           func(domain.SearchCacheOpts) string { return "k" },
+				TTL:           time.Minute,
+				ErrorTTL:      time.Minute,
+				FetchTimeout:  time.Minute,
+				CleanInterval: time.Minute,
+				MaxEntries:    1,
+			},
+			fncache.Deps{Logger: slog.New(slog.DiscardHandler)},
+		)
+		if err != nil {
+			t.Fatalf("fncache.New(search): %v", err)
+		}
+	}
+
+	infosCache := partial.GetInfosBySlugCache
+	if infosCache == nil {
+		var err error
+
+		infosCache, err = fncache.New(
+			fncache.Config[string, domain.GetInfosBySlugResponse]{
+				Name: "infos",
+				Fn: func(_ context.Context, slug string) (*domain.GetInfosBySlugResponse, error) {
+					return &domain.GetInfosBySlugResponse{
+						Slug:  slug,
 						Title: "Solo Leveling",
 						Cover: testExternalCoverURL,
-					}},
-				}, nil
+					}, nil
+				},
+				Key:           func(slug string) string { return slug },
+				TTL:           time.Minute,
+				ErrorTTL:      time.Minute,
+				FetchTimeout:  time.Minute,
+				CleanInterval: time.Minute,
+				MaxEntries:    1,
 			},
-			Key:           func(domain.SearchCacheOpts) string { return "k" },
-			TTL:           time.Minute,
-			ErrorTTL:      time.Minute,
-			FetchTimeout:  time.Minute,
-			CleanInterval: time.Minute,
-			MaxEntries:    1,
-		},
-		fncache.Deps{Logger: slog.New(slog.DiscardHandler)},
-	)
-	if err != nil {
-		t.Fatalf("fncache.New(search): %v", err)
+			fncache.Deps{Logger: slog.New(slog.DiscardHandler)},
+		)
+		if err != nil {
+			t.Fatalf("fncache.New(infos): %v", err)
+		}
 	}
 
-	infosCache, err := fncache.New(
-		fncache.Config[string, domain.GetInfosBySlugResponse]{
-			Name: "infos",
-			Fn: func(_ context.Context, slug string) (*domain.GetInfosBySlugResponse, error) {
-				return &domain.GetInfosBySlugResponse{
-					Slug:  slug,
-					Title: "Solo Leveling",
-					Cover: testExternalCoverURL,
-				}, nil
+	chaptersCache := partial.GetChaptersListBySeriesCache
+	if chaptersCache == nil {
+		var err error
+
+		chaptersCache, err = fncache.New(
+			fncache.Config[string, []domain.Chapter]{
+				Name:          "chapters",
+				Fn:            func(context.Context, string) (*[]domain.Chapter, error) { return nil, errors.New("n/a") },
+				Key:           func(slug string) string { return slug },
+				TTL:           time.Minute,
+				ErrorTTL:      time.Minute,
+				FetchTimeout:  time.Minute,
+				CleanInterval: time.Minute,
+				MaxEntries:    1,
 			},
-			Key:           func(slug string) string { return slug },
-			TTL:           time.Minute,
-			ErrorTTL:      time.Minute,
-			FetchTimeout:  time.Minute,
-			CleanInterval: time.Minute,
-			MaxEntries:    1,
-		},
-		fncache.Deps{Logger: slog.New(slog.DiscardHandler)},
-	)
-	if err != nil {
-		t.Fatalf("fncache.New(infos): %v", err)
+			fncache.Deps{Logger: slog.New(slog.DiscardHandler)},
+		)
+		if err != nil {
+			t.Fatalf("fncache.New(chapters): %v", err)
+		}
 	}
 
-	chaptersCache, err := fncache.New(
-		fncache.Config[string, []domain.Chapter]{
-			Name:          "chapters",
-			Fn:            func(context.Context, string) (*[]domain.Chapter, error) { return nil, errors.New("n/a") },
-			Key:           func(slug string) string { return slug },
-			TTL:           time.Minute,
-			ErrorTTL:      time.Minute,
-			FetchTimeout:  time.Minute,
-			CleanInterval: time.Minute,
-			MaxEntries:    1,
-		},
-		fncache.Deps{Logger: slog.New(slog.DiscardHandler)},
-	)
-	if err != nil {
-		t.Fatalf("fncache.New(chapters): %v", err)
+	imagesCache := partial.GetImageURLsByChapter
+	if imagesCache == nil {
+		var err error
+
+		imagesCache, err = fncache.New(
+			fncache.Config[domain.GetImageURLsByChapterOpts, []string]{
+				Name: "images",
+				Fn: func(context.Context, domain.GetImageURLsByChapterOpts) (*[]string, error) {
+					return nil, errors.New("n/a")
+				},
+				Key:           func(domain.GetImageURLsByChapterOpts) string { return "k" },
+				TTL:           time.Minute,
+				ErrorTTL:      time.Minute,
+				FetchTimeout:  time.Minute,
+				CleanInterval: time.Minute,
+				MaxEntries:    1,
+			},
+			fncache.Deps{Logger: slog.New(slog.DiscardHandler)},
+		)
+		if err != nil {
+			t.Fatalf("fncache.New(images): %v", err)
+		}
 	}
 
-	imagesCache, err := fncache.New(
-		fncache.Config[domain.GetImageURLsByChapterOpts, []string]{
-			Name: "images",
-			Fn: func(context.Context, domain.GetImageURLsByChapterOpts) (*[]string, error) {
-				return nil, errors.New("n/a")
-			},
-			Key:           func(domain.GetImageURLsByChapterOpts) string { return "k" },
-			TTL:           time.Minute,
-			ErrorTTL:      time.Minute,
-			FetchTimeout:  time.Minute,
-			CleanInterval: time.Minute,
-			MaxEntries:    1,
-		},
-		fncache.Deps{Logger: slog.New(slog.DiscardHandler)},
-	)
-	if err != nil {
-		t.Fatalf("fncache.New(images): %v", err)
+	comicsRepo := partial.ComicsRepository
+	if comicsRepo == nil {
+		comicsRepo = stubComicsRepository{}
+	}
+
+	logger := partial.Logger
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
 	}
 
 	app, err := asurascans.New(asurascans.Config{SourceName: sources.SourceAsuraScans}, asurascans.Deps{
-		Logger:                       slog.New(slog.DiscardHandler),
+		Logger:                       logger,
 		SearchCache:                  searchCache,
 		GetInfosBySlugCache:          infosCache,
 		GetChaptersListBySeriesCache: chaptersCache,
 		GetImageURLsByChapter:        imagesCache,
-		ComicsRepository:             stubComicsRepository{},
+		ComicsRepository:             comicsRepo,
+		ChaptersService:              partial.ChaptersService,
 	})
 	if err != nil {
 		t.Fatalf("asurascans.New: %v", err)
@@ -299,6 +335,94 @@ func authenticatedRequest(method, target string) *http.Request {
 	user := &users.User{ID: uuid.New()}
 
 	return req.WithContext(sessionshttp.WithAuth(req.Context(), user, sessions.Session{}))
+}
+
+func TestSearchRejectsNonIntegerPage(t *testing.T) {
+	t.Parallel()
+
+	endpoint := "/" + string(sources.SourceAsuraScans)
+	ctrl, err := asurascanshttp.New(
+		asurascanshttp.Config{Endpoint: endpoint},
+		asurascanshttp.Deps{
+			AsuraScansApp:   newTestAsuraScansApp(t),
+			Logger:          slog.New(slog.DiscardHandler),
+			CoverURLBuilder: coverURLBuilder,
+		},
+	)
+	if err != nil {
+		t.Fatalf("asurascanshttp.New: %v", err)
+	}
+
+	r := chi.NewRouter()
+	ctrl.InitRouter(r)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, authenticatedRequest(http.MethodGet, endpoint+"/search?page=x"))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestSearchClampsPageBelowOne(t *testing.T) {
+	t.Parallel()
+
+	endpoint := "/" + string(sources.SourceAsuraScans)
+
+	for _, query := range []string{"?sort=popular&order=desc", "?sort=popular&order=desc&page=0", "?sort=popular&order=desc&page=-1"} {
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+
+			var got domain.SearchCacheOpts
+
+			searchCache, err := fncache.New(
+				fncache.Config[domain.SearchCacheOpts, domain.SearchCacheResult]{
+					Name: "search",
+					Fn: func(_ context.Context, opts domain.SearchCacheOpts) (*domain.SearchCacheResult, error) {
+						got = opts
+
+						return &domain.SearchCacheResult{}, nil
+					},
+					Key:           func(domain.SearchCacheOpts) string { return "k" },
+					TTL:           time.Minute,
+					ErrorTTL:      time.Minute,
+					FetchTimeout:  time.Minute,
+					CleanInterval: time.Minute,
+					MaxEntries:    1,
+				},
+				fncache.Deps{Logger: slog.New(slog.DiscardHandler)},
+			)
+			if err != nil {
+				t.Fatalf("fncache.New: %v", err)
+			}
+
+			ctrl, err := asurascanshttp.New(
+				asurascanshttp.Config{Endpoint: endpoint},
+				asurascanshttp.Deps{
+					AsuraScansApp:   newTestAsuraScansApp(t, asurascans.Deps{SearchCache: searchCache}),
+					Logger:          slog.New(slog.DiscardHandler),
+					CoverURLBuilder: coverURLBuilder,
+				},
+			)
+			if err != nil {
+				t.Fatalf("asurascanshttp.New: %v", err)
+			}
+
+			r := chi.NewRouter()
+			ctrl.InitRouter(r)
+
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, authenticatedRequest(http.MethodGet, endpoint+"/search"+query))
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+			}
+
+			if got.Page != 1 {
+				t.Errorf("page = %d, want 1", got.Page)
+			}
+		})
+	}
 }
 
 func TestSearchReturnsProxiedCoverURL(t *testing.T) {

--- a/api/pkg/sources/asurascans/pkg/gateway/http/dto.go
+++ b/api/pkg/sources/asurascans/pkg/gateway/http/dto.go
@@ -16,8 +16,8 @@ import (
 )
 
 type searchResDTO struct {
-	Items []searchResItemDTO `json:"items"`
-	Total int                `json:"total"`
+	Items       []searchResItemDTO `json:"items"`
+	HasNextPage bool               `json:"hasNextPage"`
 }
 
 type searchResItemDTO struct {
@@ -102,29 +102,17 @@ func parseSearchOpts(q url.Values) (domain.SearchOpts, error) {
 
 	opts.Genres = genres
 
-	for _, p := range []struct {
-		dst *int
-		key string
-	}{
-		{key: "offset", dst: &opts.Offset},
-		{key: "limit", dst: &opts.Limit},
-		{key: "min_chapters", dst: &opts.MinChapters},
-	} {
-		if *p.dst, err = parsePositiveInt(q.Get(p.key)); err != nil {
-			return domain.SearchOpts{}, fmt.Errorf("invalid %s: %w", p.key, err)
-		}
+	page, err := parseSearchPage(q.Get("page"))
+	if err != nil {
+		return domain.SearchOpts{}, fmt.Errorf("invalid page: %w", err)
 	}
 
-	if opts.Limit > 100 {
-		opts.Limit = 100
-	}
+	opts.Page = page
 
-	if opts.Limit <= 0 {
-		opts.Limit = 20
-	}
-
-	if opts.Offset < 0 {
-		opts.Offset = 0
+	if minChapters, err := parsePositiveInt(q.Get("min_chapters")); err != nil {
+		return domain.SearchOpts{}, fmt.Errorf("invalid min_chapters: %w", err)
+	} else {
+		opts.MinChapters = minChapters
 	}
 
 	if opts.MinChapters < 0 {
@@ -132,6 +120,23 @@ func parseSearchOpts(q url.Values) (domain.SearchOpts, error) {
 	}
 
 	return opts, nil
+}
+
+func parseSearchPage(raw string) (int, error) {
+	if raw == "" {
+		return 1, nil
+	}
+
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%q is not a number", raw)
+	}
+
+	if n < 1 {
+		return 1, nil
+	}
+
+	return n, nil
 }
 
 func parseGenres(raw string) ([]string, error) {

--- a/api/pkg/sources/asurascans/pkg/transport/http/client_test.go
+++ b/api/pkg/sources/asurascans/pkg/transport/http/client_test.go
@@ -127,7 +127,7 @@ func TestSearchRequestShape(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":[],"meta":{}}`))
 	})
 
-	if _, err := c.Search(context.Background(), domain.SearchCacheOpts{Offset: 1}); err != nil {
+	if _, err := c.Search(context.Background(), domain.SearchCacheOpts{Page: 1}); err != nil {
 		t.Fatalf("Search: %v", err)
 	}
 
@@ -170,8 +170,7 @@ func TestSearchQueryParameters(t *testing.T) {
 	}
 
 	opts := domain.SearchCacheOpts{
-		Offset:    40,
-		Limit:     5,
+		Page:      3,
 		Search:    "one piece",
 		Sort:      domain.SortTypeTitle,
 		SortOrder: domain.SortOrderAsc,
@@ -186,9 +185,8 @@ func TestSearchQueryParameters(t *testing.T) {
 	}
 
 	tests := map[string]string{
-		// Asura offset = items skipped; SearchCacheOpts.Offset is 1-based page → (40-1)*5
-		"offset": "195",
-		"limit":  "5",
+		"offset": "40",
+		"limit":  "20",
 		"search": "one piece",
 		"sort":   "title",
 		"order":  "asc",
@@ -276,7 +274,7 @@ func TestSearchDecodesResponse(t *testing.T) {
 		t.Fatalf("Search: %v", err)
 	}
 
-	if res.Meta.Total != 1 || res.Meta.PerPage != 20 || !res.Meta.HasMore {
+	if !res.Meta.HasNextPage {
 		t.Errorf("meta = %+v", res.Meta)
 	}
 

--- a/api/pkg/sources/asurascans/pkg/transport/http/search.go
+++ b/api/pkg/sources/asurascans/pkg/transport/http/search.go
@@ -17,6 +17,8 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils"
 )
 
+const SearchLimit = 20
+
 func (c *Client) Search(ctx context.Context, opts domain.SearchCacheOpts) (*domain.SearchCacheResult, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/series", c.cfg.AsuraURL), nil)
 	if err != nil {
@@ -56,8 +58,8 @@ func (c *Client) Search(ctx context.Context, opts domain.SearchCacheOpts) (*doma
 func (c *Client) builSearchQuery(opts domain.SearchCacheOpts) string {
 	withDefaults := c.getSearchOptsWithDefaults(opts)
 	q := url.Values{}
-	q.Add("offset", strconv.Itoa((withDefaults.Offset-1)*withDefaults.Limit))
-	q.Add("limit", strconv.Itoa(withDefaults.Limit))
+	q.Add("offset", strconv.Itoa((withDefaults.Page-1)*SearchLimit))
+	q.Add("limit", strconv.Itoa(SearchLimit))
 	q.Add("sort", string(withDefaults.Sort))
 	q.Add("order", string(withDefaults.SortOrder))
 
@@ -91,8 +93,9 @@ func (c *Client) builSearchQuery(opts domain.SearchCacheOpts) string {
 
 func (c *Client) getSearchOptsWithDefaults(opts domain.SearchCacheOpts) domain.SearchCacheOpts {
 	withDefaults := opts
-	if withDefaults.Limit == 0 {
-		withDefaults.Limit = 20
+
+	if withDefaults.Page < 1 {
+		withDefaults.Page = 1
 	}
 
 	if withDefaults.Sort == "" {
@@ -112,11 +115,7 @@ type searchHTTPResponse struct {
 }
 
 func (r *searchHTTPResponse) Domain() *domain.SearchCacheResult {
-	meta := domain.SearchResultMeta{
-		Total:   r.Meta.Total,
-		PerPage: r.Meta.PerPage,
-		HasMore: r.Meta.HasMore,
-	}
+	meta := domain.SearchResultMeta{HasNextPage: r.Meta.HasMore}
 
 	items := make([]domain.SearchCacheResultItem, len(r.Data))
 	for i, data := range r.Data {
@@ -174,14 +173,6 @@ type searchHTTPResponseMeta struct {
 	Total   int  `json:"total"`
 	PerPage int  `json:"per_page"`
 	HasMore bool `json:"has_more"`
-}
-
-func (meta *searchHTTPResponseMeta) Domain() domain.SearchResultMeta {
-	return domain.SearchResultMeta{
-		Total:   meta.Total,
-		PerPage: meta.PerPage,
-		HasMore: meta.HasMore,
-	}
 }
 
 type searchHTTPResponseData struct {

--- a/api/pkg/sources/kingofshojo/pkg/core/app.go
+++ b/api/pkg/sources/kingofshojo/pkg/core/app.go
@@ -126,8 +126,7 @@ func (a *App) Search(ctx context.Context, opts domain.SearchOpts) (*domain.Searc
 		Search:    opts.Search,
 		Sort:      opts.Sort,
 		SortOrder: opts.SortOrder,
-		Offset:    opts.Offset,
-		Limit:     opts.Limit,
+		Page:      opts.Page,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("a.deps.SearchCache.Get: %w", err)

--- a/api/pkg/sources/kingofshojo/pkg/core/app_test.go
+++ b/api/pkg/sources/kingofshojo/pkg/core/app_test.go
@@ -393,7 +393,7 @@ func TestAppSearchDelegatesToCache(t *testing.T) {
 		func(_ context.Context, opts domain.SearchCacheOpts) (*domain.SearchCacheResult, error) {
 			called <- opts
 
-			return &domain.SearchCacheResult{Meta: domain.SearchResultMeta{Total: 3}}, nil
+			return &domain.SearchCacheResult{Meta: domain.SearchResultMeta{HasNextPage: true}}, nil
 		})
 
 	app, err := core.New(testConfig(), deps)
@@ -406,7 +406,7 @@ func TestAppSearchDelegatesToCache(t *testing.T) {
 		t.Fatalf("Search: %v", err)
 	}
 
-	if res == nil || res.Meta.Total != 3 {
+	if res == nil || !res.Meta.HasNextPage {
 		t.Errorf("result = %+v", res)
 	}
 

--- a/api/pkg/sources/kingofshojo/pkg/domain/apiclient.go
+++ b/api/pkg/sources/kingofshojo/pkg/domain/apiclient.go
@@ -46,16 +46,14 @@ type SearchCacheOpts struct {
 	Search    string
 	Sort      SortType
 	SortOrder SortOrder
-	Offset    int
-	Limit     int
+	Page      int
 }
 
 type SearchOpts struct {
 	Search    string
 	Sort      SortType
 	SortOrder SortOrder
-	Offset    int
-	Limit     int
+	Page      int
 	UserID    uuid.UUID
 }
 
@@ -94,9 +92,7 @@ type SearchCacheResult struct {
 }
 
 type SearchResultMeta struct {
-	Total   int
-	PerPage int
-	HasMore bool
+	HasNextPage bool
 }
 
 type SearchCacheResultItem struct {

--- a/api/pkg/sources/kingofshojo/pkg/domain/cachekey.go
+++ b/api/pkg/sources/kingofshojo/pkg/domain/cachekey.go
@@ -5,10 +5,7 @@ package domain
 import "fmt"
 
 func (o SearchCacheOpts) CacheKey() string {
-	return fmt.Sprintf(
-		"offset=%d limit=%d search=%q sort=%q order=%q",
-		o.Offset, o.Limit, o.Search, o.Sort, o.SortOrder,
-	)
+	return fmt.Sprintf("page=%d search=%q sort=%q order=%q", o.Page, o.Search, o.Sort, o.SortOrder)
 }
 
 func (o GetImageURLsByChapterOpts) CacheKey() string {

--- a/api/pkg/sources/kingofshojo/pkg/gateway/http/controller.go
+++ b/api/pkg/sources/kingofshojo/pkg/gateway/http/controller.go
@@ -141,7 +141,7 @@ func (c *Controller) search(w http.ResponseWriter, r *http.Request) {
 	source := string(sources.SourceKingOfShojo)
 
 	dto := searchResDTO{
-		Total: res.Meta.Total,
+		HasNextPage: res.Meta.HasNextPage,
 		Items: utils.MapSlice(res.Items, func(i domain.SearchResultItem) searchResItemDTO {
 			return searchResItemDTO{
 				LastChapterAt: utils.OptionalTime(i.LastChapterAt),

--- a/api/pkg/sources/kingofshojo/pkg/gateway/http/controller_test.go
+++ b/api/pkg/sources/kingofshojo/pkg/gateway/http/controller_test.go
@@ -110,7 +110,7 @@ func newTestKingOfShojoApp(t *testing.T, deps kingofshojocore.Deps) *kingofshojo
 				Name: "search",
 				Fn: func(context.Context, domain.SearchCacheOpts) (*domain.SearchCacheResult, error) {
 					return &domain.SearchCacheResult{
-						Meta: domain.SearchResultMeta{Total: 1},
+						Meta: domain.SearchResultMeta{HasNextPage: true},
 						Items: []domain.SearchCacheResultItem{{
 							Slug:  "solo-shojo",
 							Title: "Solo Shojo",
@@ -262,16 +262,16 @@ func TestSearchOK(t *testing.T) {
 	}
 
 	var body struct {
-		Items []searchResponseItem `json:"items"`
-		Total int                  `json:"total"`
+		Items       []searchResponseItem `json:"items"`
+		HasNextPage bool                 `json:"hasNextPage"`
 	}
 
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("json.Unmarshal: %v", err)
 	}
 
-	if body.Total != 1 || len(body.Items) != 1 {
-		t.Fatalf("total/items = %d/%d, want 1/1", body.Total, len(body.Items))
+	if !body.HasNextPage || len(body.Items) != 1 {
+		t.Fatalf("hasNextPage/items = %v/%d, want true/1", body.HasNextPage, len(body.Items))
 	}
 
 	wantCover := coverURLBuilder(string(sources.SourceKingOfShojo), "solo-shojo")
@@ -285,6 +285,69 @@ func TestSearchOK(t *testing.T) {
 
 	if body.Items[0].Status != "" {
 		t.Errorf("status = %q, want empty", body.Items[0].Status)
+	}
+}
+
+func TestSearchRejectsNonIntegerPage(t *testing.T) {
+	t.Parallel()
+
+	ctrl := newTestController(t, newTestKingOfShojoApp(t, kingofshojocore.Deps{}))
+	r := chi.NewRouter()
+	ctrl.InitRouter(r)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, authenticatedRequest("/kingofshojo/search?page=x"))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestSearchClampsPageBelowOne(t *testing.T) {
+	t.Parallel()
+
+	for _, query := range []string{"", "?page=0", "?page=-1"} {
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+
+			var got domain.SearchCacheOpts
+
+			searchCache, err := fncache.New(
+				fncache.Config[domain.SearchCacheOpts, domain.SearchCacheResult]{
+					Name: "search",
+					Fn: func(_ context.Context, opts domain.SearchCacheOpts) (*domain.SearchCacheResult, error) {
+						got = opts
+
+						return &domain.SearchCacheResult{}, nil
+					},
+					Key:           func(domain.SearchCacheOpts) string { return "k" },
+					TTL:           time.Minute,
+					ErrorTTL:      time.Minute,
+					FetchTimeout:  time.Minute,
+					CleanInterval: time.Minute,
+					MaxEntries:    1,
+				},
+				fncache.Deps{Logger: slog.New(slog.DiscardHandler)},
+			)
+			if err != nil {
+				t.Fatalf("fncache.New: %v", err)
+			}
+
+			ctrl := newTestController(t, newTestKingOfShojoApp(t, kingofshojocore.Deps{SearchCache: searchCache}))
+			r := chi.NewRouter()
+			ctrl.InitRouter(r)
+
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, authenticatedRequest("/kingofshojo/search"+query))
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+			}
+
+			if got.Page != 1 {
+				t.Errorf("page = %d, want 1", got.Page)
+			}
+		})
 	}
 }
 

--- a/api/pkg/sources/kingofshojo/pkg/gateway/http/dto.go
+++ b/api/pkg/sources/kingofshojo/pkg/gateway/http/dto.go
@@ -17,8 +17,8 @@ import (
 )
 
 type searchResDTO struct {
-	Items []searchResItemDTO `json:"items"`
-	Total int                `json:"total"`
+	Items       []searchResItemDTO `json:"items"`
+	HasNextPage bool               `json:"hasNextPage"`
 }
 
 type searchResItemDTO struct {
@@ -99,31 +99,12 @@ func parseSearchOpts(q url.Values) (domain.SearchOpts, error) {
 
 	opts.SortOrder = domain.SortOrder(order)
 
-	var err error
-
-	for _, p := range []struct {
-		dst *int
-		key string
-	}{
-		{key: "offset", dst: &opts.Offset},
-		{key: "limit", dst: &opts.Limit},
-	} {
-		if *p.dst, err = parsePositiveInt(q.Get(p.key)); err != nil {
-			return domain.SearchOpts{}, fmt.Errorf("invalid %s: %w", p.key, err)
-		}
+	page, err := parseSearchPage(q.Get("page"))
+	if err != nil {
+		return domain.SearchOpts{}, fmt.Errorf("invalid page: %w", err)
 	}
 
-	if opts.Limit > 100 {
-		opts.Limit = 100
-	}
-
-	if opts.Limit <= 0 {
-		opts.Limit = 20
-	}
-
-	if opts.Offset < 0 {
-		opts.Offset = 0
-	}
+	opts.Page = page
 
 	if opts.Sort == "" {
 		opts.Sort = domain.SortTypePopular
@@ -140,9 +121,9 @@ func parseSearchOpts(q url.Values) (domain.SearchOpts, error) {
 	return opts, nil
 }
 
-func parsePositiveInt(raw string) (int, error) {
+func parseSearchPage(raw string) (int, error) {
 	if raw == "" {
-		return 0, nil
+		return 1, nil
 	}
 
 	n, err := strconv.Atoi(raw)
@@ -150,8 +131,8 @@ func parsePositiveInt(raw string) (int, error) {
 		return 0, fmt.Errorf("%q is not a number", raw)
 	}
 
-	if n < 0 {
-		return 0, fmt.Errorf("%d is negative", n)
+	if n < 1 {
+		return 1, nil
 	}
 
 	return n, nil

--- a/api/pkg/sources/kingofshojo/pkg/parse/search.go
+++ b/api/pkg/sources/kingofshojo/pkg/parse/search.go
@@ -26,6 +26,7 @@ type SearchCard struct {
 
 var (
 	chapterRe = regexp.MustCompile(`(?i)chapter\s+(\d+(?:\.\d+)?)`)
+	pageOfRe  = regexp.MustCompile(`(?i)page\s+(\d+)\s+of\s+(\d+)`)
 )
 
 func ParseSearch(html string) (SearchPage, error) {
@@ -35,7 +36,7 @@ func ParseSearch(html string) (SearchPage, error) {
 	}
 
 	page := SearchPage{
-		HasNext: doc.Find(".hpage a.r").Length() > 0,
+		HasNext: searchHasNext(doc),
 	}
 
 	cards := doc.Find(".listupd .bsx")
@@ -83,6 +84,26 @@ func ParseSearch(html string) (SearchPage, error) {
 	})
 
 	return page, nil
+}
+
+func searchHasNext(doc *goquery.Document) bool {
+	if doc.Find(".hpage a.r").Length() > 0 {
+		return true
+	}
+
+	hpage := strings.TrimSpace(doc.Find(".hpage").First().Text())
+	m := pageOfRe.FindStringSubmatch(hpage)
+	if len(m) != 3 {
+		return false
+	}
+
+	cur, errCur := strconv.Atoi(m[1])
+	last, errLast := strconv.Atoi(m[2])
+	if errCur != nil || errLast != nil {
+		return false
+	}
+
+	return cur < last
 }
 
 func mangaSlugFromHref(href string) string {

--- a/api/pkg/sources/kingofshojo/pkg/parse/search_test.go
+++ b/api/pkg/sources/kingofshojo/pkg/parse/search_test.go
@@ -50,6 +50,24 @@ func TestParseSearch(t *testing.T) {
 	}
 }
 
+func TestParseSearchPageOfImpliesHasNext(t *testing.T) {
+	t.Parallel()
+
+	page, err := parse.ParseSearch(`<!DOCTYPE html><html><body>
+<div class="listupd"><div class="bsx">
+  <a href="/manga/one/"><div class="tt">One</div></a>
+</div></div>
+<div class="hpage">Page 1 of 2</div>
+</body></html>`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !page.HasNext {
+		t.Fatal("HasNext = false, want true")
+	}
+}
+
 func TestParseSearchWithoutNext(t *testing.T) {
 	t.Parallel()
 

--- a/api/pkg/sources/kingofshojo/pkg/transport/http/client_internal_test.go
+++ b/api/pkg/sources/kingofshojo/pkg/transport/http/client_internal_test.go
@@ -4,7 +4,6 @@ package http
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -13,25 +12,6 @@ import (
 
 	"github.com/kharente-deuh/uchiyomi-server/pkg/sources/kingofshojo/pkg/domain"
 )
-
-func TestKosPage(t *testing.T) {
-	t.Parallel()
-
-	page, start := kosPage(0, 20)
-	if page != 1 || start != 0 {
-		t.Fatalf("offset 0: page=%d start=%d", page, start)
-	}
-
-	page, start = kosPage(40, 20)
-	if page != 2 || start != 0 {
-		t.Fatalf("offset 40: page=%d start=%d", page, start)
-	}
-
-	page, start = kosPage(38, 5)
-	if page != 1 || start != 38 {
-		t.Fatalf("offset 38: page=%d start=%d", page, start)
-	}
-}
 
 func TestKosOrder(t *testing.T) {
 	t.Parallel()
@@ -69,114 +49,33 @@ func pageHTML(cards string) string {
 		`</div><div class="hpage">Page 1 of 2</div></body></html>`
 }
 
-func TestSearchSpansTwoKoSPages(t *testing.T) {
+func TestSearchDoesNotFetchASecondHTMLPage(t *testing.T) {
 	t.Parallel()
 
-	page1Cards := strings.Repeat(cardHTML("a", "A"), 40)
-	page2Cards := cardHTML("b", "B") + cardHTML("c", "C") + cardHTML("last", "Last")
-
-	var gotPaths []string
+	var n int
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotPaths = append(gotPaths, r.URL.Path)
-
-		switch r.URL.Path {
-		case mangaPath:
-			_, _ = w.Write([]byte(pageHTML(page1Cards)))
-		case mangaPath + "page/2/":
-			_, _ = w.Write([]byte(pageHTML(page2Cards)))
-		default:
-			http.NotFound(w, r)
-		}
+		n++
+		_, _ = w.Write([]byte(pageHTML(strings.Repeat(cardHTML("a", "A"), 40))))
 	}))
 	t.Cleanup(srv.Close)
 
-	c, err := New(
-		Config{BaseURL: srv.URL},
-		Deps{HTTP: srv.Client(), Logger: discardLogger(), Solver: nil},
-	)
+	c, err := New(Config{BaseURL: srv.URL}, Deps{HTTP: srv.Client(), Logger: discardLogger(), Solver: nil})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
 
-	res, err := c.Search(context.Background(), domain.SearchCacheOpts{Offset: 38, Limit: 5})
+	res, err := c.Search(context.Background(), domain.SearchCacheOpts{Page: 1})
 	if err != nil {
 		t.Fatalf("Search: %v", err)
 	}
 
-	if len(res.Items) != 5 {
-		t.Fatalf("len(items) = %d, want 5", len(res.Items))
+	if n != 1 {
+		t.Fatalf("requests = %d, want 1", n)
 	}
 
-	if res.Items[0].Slug != "a" || res.Items[4].Slug != "last" {
-		t.Fatalf("items = %+v", res.Items)
-	}
-
-	if len(gotPaths) != 2 {
-		t.Fatalf("requests = %v, want 2 paths", gotPaths)
-	}
-}
-
-func TestSearchFetchesUntilLimit(t *testing.T) {
-	t.Parallel()
-
-	pageBody := func(page int) string {
-		var cards strings.Builder
-		for i := range kosPerPage {
-			n := (page-1)*kosPerPage + i
-			slug := fmt.Sprintf("s-%d", n)
-			cards.WriteString(cardHTML(slug, slug))
-		}
-
-		return `<!DOCTYPE html><html><body><div class="listupd">` + cards.String() +
-			`</div><div class="hpage">Page ` + fmt.Sprintf("%d", page) + ` of 10</div></body></html>`
-	}
-
-	var gotPaths []string
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotPaths = append(gotPaths, r.URL.Path)
-
-		switch r.URL.Path {
-		case mangaPath:
-			_, _ = w.Write([]byte(pageBody(1)))
-		case mangaPath + "page/2/":
-			_, _ = w.Write([]byte(pageBody(2)))
-		case mangaPath + "page/3/":
-			_, _ = w.Write([]byte(pageBody(3)))
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	t.Cleanup(srv.Close)
-
-	c, err := New(
-		Config{BaseURL: srv.URL},
-		Deps{HTTP: srv.Client(), Logger: discardLogger(), Solver: nil},
-	)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-
-	res, err := c.Search(context.Background(), domain.SearchCacheOpts{Offset: 0, Limit: 100})
-	if err != nil {
-		t.Fatalf("Search: %v", err)
-	}
-
-	if len(res.Items) <= 80 {
-		t.Fatalf("len(items) = %d, want more than 80", len(res.Items))
-	}
-
-	if len(res.Items) != 100 {
-		t.Fatalf("len(items) = %d, want 100", len(res.Items))
-	}
-
-	if res.Items[0].Slug != "s-0" || res.Items[99].Slug != "s-99" {
-		t.Fatalf("items[0]=%q items[99]=%q", res.Items[0].Slug, res.Items[99].Slug)
-	}
-
-	if len(gotPaths) != 3 {
-		t.Fatalf("requests = %v, want 3 paths", gotPaths)
+	if len(res.Items) != 40 {
+		t.Fatalf("len(items) = %d, want 40", len(res.Items))
 	}
 }
 

--- a/api/pkg/sources/kingofshojo/pkg/transport/http/client_test.go
+++ b/api/pkg/sources/kingofshojo/pkg/transport/http/client_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/challengesolver"
 )
 
+const KingOfShojoComicEndpoint = "/manga/"
+
 func discardLogger() *slog.Logger {
 	return slog.New(slog.DiscardHandler)
 }
@@ -58,7 +60,7 @@ func TestSearchReturnsItemsAndHasNextPage(t *testing.T) {
 	body := readFixture(t, "search.html")
 
 	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/manga/" {
+		if r.URL.Path != KingOfShojoComicEndpoint {
 			t.Errorf("path = %q, want /manga/", r.URL.Path)
 		}
 
@@ -98,7 +100,7 @@ func TestSearchPageTwoHitsMangaPageQuery(t *testing.T) {
 		t.Fatalf("Search: %v", err)
 	}
 
-	if gotPath != "/manga/" {
+	if gotPath != KingOfShojoComicEndpoint {
 		t.Errorf("path = %q, want /manga/", gotPath)
 	}
 
@@ -136,7 +138,7 @@ func TestSearchLastPageHasNextPageFalse(t *testing.T) {
 		t.Fatalf("Search: %v", err)
 	}
 
-	if gotPath != "/manga/" {
+	if gotPath != KingOfShojoComicEndpoint {
 		t.Errorf("path = %q, want /manga/", gotPath)
 	}
 

--- a/api/pkg/sources/kingofshojo/pkg/transport/http/client_test.go
+++ b/api/pkg/sources/kingofshojo/pkg/transport/http/client_test.go
@@ -79,15 +79,17 @@ func TestSearchReturnsItemsAndHasNextPage(t *testing.T) {
 	}
 }
 
-func TestSearchPageTwoHitsMangaPagePath(t *testing.T) {
+func TestSearchPageTwoHitsMangaPageQuery(t *testing.T) {
 	t.Parallel()
 
 	var gotPath string
+	var gotQuery url.Values
 	var n int
 
 	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		n++
 		gotPath = r.URL.Path
+		gotQuery = r.URL.Query()
 		_, _ = w.Write(readFixture(t, "search.html"))
 	})
 
@@ -96,8 +98,12 @@ func TestSearchPageTwoHitsMangaPagePath(t *testing.T) {
 		t.Fatalf("Search: %v", err)
 	}
 
-	if gotPath != "/manga/page/2/" {
-		t.Errorf("path = %q, want /manga/page/2/", gotPath)
+	if gotPath != "/manga/" {
+		t.Errorf("path = %q, want /manga/", gotPath)
+	}
+
+	if gotQuery.Get("page") != "2" {
+		t.Errorf("page = %q, want 2", gotQuery.Get("page"))
 	}
 
 	if n != 1 {
@@ -112,21 +118,30 @@ func TestSearchPageTwoHitsMangaPagePath(t *testing.T) {
 func TestSearchLastPageHasNextPageFalse(t *testing.T) {
 	t.Parallel()
 
+	var gotPath string
+	var gotQuery url.Values
+
 	body := `<!DOCTYPE html><html><body><div class="listupd">` +
 		`<div class="bsx"><a href="/manga/only/"><div class="tt">Only</div><div class="adds">Chapter 1</div></a></div>` +
 		`</div><div class="hpage"></div></body></html>`
 
 	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/manga/page/3/" {
-			t.Errorf("path = %q, want /manga/page/3/", r.URL.Path)
-		}
-
+		gotPath = r.URL.Path
+		gotQuery = r.URL.Query()
 		_, _ = w.Write([]byte(body))
 	})
 
 	res, err := c.Search(context.Background(), domain.SearchCacheOpts{Page: 3})
 	if err != nil {
 		t.Fatalf("Search: %v", err)
+	}
+
+	if gotPath != "/manga/" {
+		t.Errorf("path = %q, want /manga/", gotPath)
+	}
+
+	if gotQuery.Get("page") != "3" {
+		t.Errorf("page = %q, want 3", gotQuery.Get("page"))
 	}
 
 	if len(res.Items) != 1 {

--- a/api/pkg/sources/kingofshojo/pkg/transport/http/client_test.go
+++ b/api/pkg/sources/kingofshojo/pkg/transport/http/client_test.go
@@ -52,7 +52,7 @@ func readFixture(t *testing.T, name string) []byte {
 	return raw
 }
 
-func TestSearchReturnsItemsAndTotal(t *testing.T) {
+func TestSearchReturnsItemsAndHasNextPage(t *testing.T) {
 	t.Parallel()
 
 	body := readFixture(t, "search.html")
@@ -70,31 +70,61 @@ func TestSearchReturnsItemsAndTotal(t *testing.T) {
 		t.Fatalf("Search: %v", err)
 	}
 
-	if res.Meta.Total != 21 {
-		t.Errorf("total = %d, want 21", res.Meta.Total)
+	if !res.Meta.HasNextPage {
+		t.Error("HasNextPage = false, want true")
 	}
 
 	if len(res.Items) != 2 {
 		t.Fatalf("len(items) = %d, want 2", len(res.Items))
 	}
+}
 
-	if res.Items[0].Slug != "tears-on-a-withered-flower" {
-		t.Errorf("item0 slug = %q", res.Items[0].Slug)
+func TestSearchPageTwoHitsMangaPagePath(t *testing.T) {
+	t.Parallel()
+
+	var gotPath string
+	var n int
+
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		n++
+		gotPath = r.URL.Path
+		_, _ = w.Write(readFixture(t, "search.html"))
+	})
+
+	res, err := c.Search(context.Background(), domain.SearchCacheOpts{Page: 2})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
+	if gotPath != "/manga/page/2/" {
+		t.Errorf("path = %q, want /manga/page/2/", gotPath)
+	}
+
+	if n != 1 {
+		t.Errorf("requests = %d, want 1", n)
+	}
+
+	if !res.Meta.HasNextPage {
+		t.Error("HasNextPage = false, want true")
 	}
 }
 
-func TestSearchTotalWithoutNextIsOffsetPlusLen(t *testing.T) {
+func TestSearchLastPageHasNextPageFalse(t *testing.T) {
 	t.Parallel()
 
 	body := `<!DOCTYPE html><html><body><div class="listupd">` +
 		`<div class="bsx"><a href="/manga/only/"><div class="tt">Only</div><div class="adds">Chapter 1</div></a></div>` +
 		`</div><div class="hpage"></div></body></html>`
 
-	c := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/manga/page/3/" {
+			t.Errorf("path = %q, want /manga/page/3/", r.URL.Path)
+		}
+
 		_, _ = w.Write([]byte(body))
 	})
 
-	res, err := c.Search(context.Background(), domain.SearchCacheOpts{Offset: 40, Limit: 20})
+	res, err := c.Search(context.Background(), domain.SearchCacheOpts{Page: 3})
 	if err != nil {
 		t.Fatalf("Search: %v", err)
 	}
@@ -103,8 +133,8 @@ func TestSearchTotalWithoutNextIsOffsetPlusLen(t *testing.T) {
 		t.Fatalf("len(items) = %d, want 1", len(res.Items))
 	}
 
-	if res.Meta.Total != 41 {
-		t.Errorf("total = %d, want 41", res.Meta.Total)
+	if res.Meta.HasNextPage {
+		t.Error("HasNextPage = true, want false")
 	}
 }
 

--- a/api/pkg/sources/kingofshojo/pkg/transport/http/search.go
+++ b/api/pkg/sources/kingofshojo/pkg/transport/http/search.go
@@ -4,7 +4,6 @@ package http
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -14,14 +13,7 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/sources/kingofshojo/pkg/parse"
 )
 
-const (
-	kosPerPage = 40
-	mangaPath  = "/manga/"
-)
-
-func kosPage(offset, _ int) (page int, pageOffset int) {
-	return offset/kosPerPage + 1, offset % kosPerPage
-}
+const mangaPath = "/manga/"
 
 func kosOrder(sort domain.SortType, order domain.SortOrder) string {
 	switch sort {
@@ -45,32 +37,30 @@ func kosOrder(sort domain.SortType, order domain.SortOrder) string {
 func (c *Client) Search(ctx context.Context, opts domain.SearchCacheOpts) (*domain.SearchCacheResult, error) {
 	withDefaults := searchOptsWithDefaults(opts)
 
-	cards, total, err := c.fetchSearchCards(ctx, withDefaults)
+	page, err := c.fetchSearchPage(ctx, withDefaults.Page, withDefaults)
 	if err != nil {
-		return nil, fmt.Errorf("c.fetchSearchCards: %w", err)
+		return nil, fmt.Errorf("c.fetchSearchPage: %w", err)
 	}
 
+	cards := filterSearchCards(page.Items)
 	items := make([]domain.SearchCacheResultItem, len(cards))
 	for i, card := range cards {
 		items[i] = searchCardToItem(card, c.cfg.BaseURL)
 	}
 
-	hasMore := withDefaults.Offset+len(items) < total
-
 	return &domain.SearchCacheResult{
 		Items: items,
 		Meta: domain.SearchResultMeta{
-			Total:   total,
-			PerPage: withDefaults.Limit,
-			HasMore: hasMore,
+			HasNextPage: page.HasNext,
 		},
 	}, nil
 }
 
 func searchOptsWithDefaults(opts domain.SearchCacheOpts) domain.SearchCacheOpts {
 	withDefaults := opts
-	if withDefaults.Limit == 0 {
-		withDefaults.Limit = 20
+
+	if withDefaults.Page < 1 {
+		withDefaults.Page = 1
 	}
 
 	if withDefaults.Sort == "" {
@@ -82,78 +72,6 @@ func searchOptsWithDefaults(opts domain.SearchCacheOpts) domain.SearchCacheOpts 
 	}
 
 	return withDefaults
-}
-
-func searchTotal(offset, limit, nItems int, hasNext bool) int {
-	if hasNext {
-		return offset + limit + 1
-	}
-
-	return offset + nItems
-}
-
-func (c *Client) fetchSearchCards(ctx context.Context, opts domain.SearchCacheOpts) ([]parse.SearchCard, int, error) {
-	pageNum, start := kosPage(opts.Offset, opts.Limit)
-
-	page, err := c.fetchSearchPage(ctx, pageNum, opts)
-	if err != nil {
-		return nil, 0, fmt.Errorf("c.fetchSearchPage: %w", err)
-	}
-
-	result, leftover := appendSearchCards(nil, page.Items, start, opts.Limit)
-	hasNext := leftover || page.HasNext
-	fullPage := len(page.Items) >= kosPerPage
-
-	for len(result) < opts.Limit && fullPage {
-		pageNum++
-
-		nextPage, err := c.fetchSearchPage(ctx, pageNum, opts)
-		if err != nil {
-			if errors.Is(err, domain.ErrNotFound) {
-				hasNext = leftover
-
-				break
-			}
-
-			return nil, 0, fmt.Errorf("c.fetchSearchPage: %w", err)
-		}
-
-		if len(nextPage.Items) == 0 {
-			hasNext = leftover
-
-			break
-		}
-
-		page = nextPage
-		result, leftover = appendSearchCards(result, page.Items, 0, opts.Limit-len(result))
-		hasNext = leftover || page.HasNext
-		fullPage = len(page.Items) >= kosPerPage
-	}
-
-	return result, searchTotal(opts.Offset, opts.Limit, len(result), hasNext), nil
-}
-
-func appendSearchCards(dst, cards []parse.SearchCard, start, remaining int) ([]parse.SearchCard, bool) {
-	filtered := filterSearchCards(cards)
-	if start < 0 {
-		start = 0
-	}
-
-	if start > len(filtered) {
-		start = len(filtered)
-	}
-
-	available := filtered[start:]
-	leftover := remaining < len(available)
-	if remaining > len(available) {
-		remaining = len(available)
-	}
-
-	if remaining <= 0 {
-		return dst, leftover
-	}
-
-	return append(dst, available[:remaining]...), leftover
 }
 
 func filterSearchCards(cards []parse.SearchCard) []parse.SearchCard {

--- a/api/pkg/sources/kingofshojo/pkg/transport/http/search.go
+++ b/api/pkg/sources/kingofshojo/pkg/transport/http/search.go
@@ -37,7 +37,7 @@ func kosOrder(sort domain.SortType, order domain.SortOrder) string {
 func (c *Client) Search(ctx context.Context, opts domain.SearchCacheOpts) (*domain.SearchCacheResult, error) {
 	withDefaults := searchOptsWithDefaults(opts)
 
-	page, err := c.fetchSearchPage(ctx, withDefaults.Page, withDefaults)
+	page, err := c.fetchSearchPage(ctx, withDefaults)
 	if err != nil {
 		return nil, fmt.Errorf("c.fetchSearchPage: %w", err)
 	}
@@ -89,10 +89,9 @@ func filterSearchCards(cards []parse.SearchCard) []parse.SearchCard {
 
 func (c *Client) fetchSearchPage(
 	ctx context.Context,
-	pageNum int,
 	opts domain.SearchCacheOpts,
 ) (parse.SearchPage, error) {
-	targetURL := c.searchPageURL(pageNum, opts)
+	targetURL := c.searchPageURL(opts)
 
 	status, body, err := c.get(ctx, targetURL)
 	if err != nil {
@@ -111,19 +110,12 @@ func (c *Client) fetchSearchPage(
 	return page, nil
 }
 
-func (c *Client) searchPageURL(pageNum int, opts domain.SearchCacheOpts) string {
-	var path string
-	if pageNum <= 1 {
-		path = mangaPath
-	} else {
-		path = mangaPath + "page/" + strconv.Itoa(pageNum) + "/"
-	}
-
+func (c *Client) searchPageURL(opts domain.SearchCacheOpts) string {
 	if q := c.buildSearchQuery(opts); q != "" {
-		return c.mangaURL(path) + "?" + q
+		return c.mangaURL(mangaPath) + "?" + q
 	}
 
-	return c.mangaURL(path)
+	return c.mangaURL(mangaPath)
 }
 
 func (c *Client) buildSearchQuery(opts domain.SearchCacheOpts) string {
@@ -135,6 +127,10 @@ func (c *Client) buildSearchQuery(opts domain.SearchCacheOpts) string {
 
 	if order := kosOrder(opts.Sort, opts.SortOrder); order != "" {
 		q.Set("order", order)
+	}
+
+	if opts.Page > 1 {
+		q.Set("page", strconv.Itoa(opts.Page))
 	}
 
 	return q.Encode()

--- a/web/app/components/Molecule/PaginationFooter.vue
+++ b/web/app/components/Molecule/PaginationFooter.vue
@@ -39,7 +39,7 @@ onBeforeUnmount(() => {
         @click="page--"
       />
       <span v-if="pagesTotal" class="px-1">{{ page }} / {{ pagesTotal }}</span>
-      <span v-else class="px-1">{{ page }}</span>
+      <span v-else class="px-2">{{ page }}</span>
       <VBtn
         style="border-top-left-radius: 0; border-bottom-left-radius: 0;"
         icon="fa6-solid:chevron-right"

--- a/web/app/features/asurascans/components/Comic/Card.vue
+++ b/web/app/features/asurascans/components/Comic/Card.vue
@@ -1,0 +1,25 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+import type { AsuraScansSearchItem } from '../../types'
+import { ASURA_SOURCE_NAME } from '~/constants'
+
+defineProps<{
+  comic: AsuraScansSearchItem
+  loading?: boolean
+}>()
+
+defineEmits<{ toggle: [] }>()
+</script>
+
+<template>
+  <SourcesCardComic
+    :internal-id="comic.internalId"
+    :status="comic.status"
+    :to="`/browse/sources/${ASURA_SOURCE_NAME}/${comic.slug}`"
+    :cover="comic.cover"
+    :title="comic.title"
+    :chapter-count="comic.chapterCount"
+    :loading
+    @toggle="$emit('toggle')"
+  />
+</template>

--- a/web/app/features/asurascans/components/ComicCard.test.ts
+++ b/web/app/features/asurascans/components/ComicCard.test.ts
@@ -7,7 +7,7 @@ import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { describe, expect, it, vi } from 'vitest'
 import { h } from 'vue'
 import { VApp } from 'vuetify/components'
-import ComicCard from './Comic/Card.vue/index.js'
+import ComicCard from './Comic/Card.vue'
 
 function item(internalId?: string): AsuraScansSearchItem {
   return {

--- a/web/app/features/asurascans/components/ComicCard.test.ts
+++ b/web/app/features/asurascans/components/ComicCard.test.ts
@@ -7,7 +7,7 @@ import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { describe, expect, it, vi } from 'vitest'
 import { h } from 'vue'
 import { VApp } from 'vuetify/components'
-import ComicCard from './ComicCard.vue'
+import ComicCard from './Comic/Card.vue/index.js'
 
 function item(internalId?: string): AsuraScansSearchItem {
   return {

--- a/web/app/features/asurascans/composables/asurascans-chapters.composable.test.ts
+++ b/web/app/features/asurascans/composables/asurascans-chapters.composable.test.ts
@@ -7,8 +7,9 @@ import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope } from 'vue'
 import { useToast } from '~/composables/toast.composable'
+import { isChapterDownloadInProgress } from '../../sources/composables/sources.composable'
 import { useAsuraScansChaptersStore } from '../stores/asurascans-chapters.store'
-import { isChapterDownloadInProgress, useAsuraScansChapters } from './asurascans-chapters.composable'
+import { useAsuraScansChapters } from './asurascans-chapters.composable'
 
 const { getSeriesChapters, retryDownloadApi } = vi.hoisted(() => ({
   getSeriesChapters: vi.fn(),

--- a/web/app/features/asurascans/composables/asurascans-chapters.composable.ts
+++ b/web/app/features/asurascans/composables/asurascans-chapters.composable.ts
@@ -14,10 +14,6 @@ export interface AsuraScansChaptersComposable {
   retryDownloadLoading: Ref<boolean>
 }
 
-export function isChapterDownloadInProgress(chapter: AsuraScansComicChapter): boolean {
-  return chapter.download !== undefined && chapter.download >= 0 && chapter.download < 100
-}
-
 export function useAsuraScansChapters(): AsuraScansChaptersComposable {
   const store = useAsuraScansChaptersStore()
   const api = createAsuraScansApi()

--- a/web/app/features/asurascans/composables/asurascans-search.composable.test.ts
+++ b/web/app/features/asurascans/composables/asurascans-search.composable.test.ts
@@ -125,3 +125,26 @@ describe('useAsuraScansSearch library', () => {
     expect(useToast().messages.value).toEqual([{ text: 'error.unknown', color: 'error' }])
   })
 })
+
+describe('useAsuraScansSearch pagination', () => {
+  it('searches with page 1 and stores hasNextPage', async () => {
+    search.mockResolvedValue({ success: true, data: { items: [item('solo')], hasNextPage: true } })
+    const asura = useAsuraScansSearch({ doSearch: true })
+    await vi.waitFor(() => {
+      expect(search).toHaveBeenCalledWith(expect.objectContaining({ page: 1 }))
+    })
+    expect(asura.hasNextPage.value).toBe(true)
+    expect(asura.series.value).toHaveLength(1)
+  })
+
+  it('resets page to 1 when filters change', async () => {
+    search.mockResolvedValue({ success: true, data: { items: [], hasNextPage: false } })
+    const asura = useAsuraScansSearch({ doSearch: true })
+    await vi.waitFor(() => expect(search).toHaveBeenCalled())
+    asura.page.value = 3
+    asura.sort.value = 'latest'
+    await vi.waitFor(() => {
+      expect(asura.page.value).toBe(1)
+    })
+  })
+})

--- a/web/app/features/asurascans/composables/asurascans-search.composable.ts
+++ b/web/app/features/asurascans/composables/asurascans-search.composable.ts
@@ -5,15 +5,13 @@ import type { ComicStatus, ComicType } from '~/features/comics/types'
 import { ASURA_SOURCE_NAME } from '~/constants'
 import { createComicsApi } from '~/features/comics/composables/comics.api'
 
-const PAGE_SIZE = 20
-
 export interface AsuraScansSearchComposable {
   search: Ref<string | undefined>
   sort: Ref<AsuraScansSort>
   status: Ref<ComicStatus | undefined>
   type: Ref<ComicType | undefined>
   page: Ref<number>
-  maxPage: Ref<number>
+  hasNextPage: Ref<boolean>
   series: Ref<AsuraScansSearchItem[]>
   isLoading: Ref<boolean>
   resetFilters: () => void
@@ -51,9 +49,9 @@ export function useAsuraScansSearch(opts: { doSearch: boolean }): AsuraScansSear
     set: (value?: ComicType) => value ? store.setType(value) : store.clearType(),
   })
 
-  const offset = computed({
-    get: () => store.offset,
-    set: (value: number) => store.setOffset(value),
+  const page = computed({
+    get: () => store.page,
+    set: (value: number) => store.setPage(value),
   })
 
   const isLoading = computed({
@@ -75,7 +73,7 @@ export function useAsuraScansSearch(opts: { doSearch: boolean }): AsuraScansSear
     store.invalidate()
   }
 
-  const maxPage = ref(0)
+  const hasNextPage = ref(false)
   const addComicInLibraryLoading = ref<Record<string, boolean>>({})
 
   const debouncedSearchFn = useDebounceFn(async () => {
@@ -86,8 +84,7 @@ export function useAsuraScansSearch(opts: { doSearch: boolean }): AsuraScansSear
       ...(sort.value && { sort: sort.value }),
       ...(status.value && { status: status.value }),
       ...(type.value && { type: type.value }),
-      offset: offset.value,
-      limit: PAGE_SIZE,
+      page: page.value,
     })
 
     isLoading.value = false
@@ -96,7 +93,7 @@ export function useAsuraScansSearch(opts: { doSearch: boolean }): AsuraScansSear
       toast.error(t('sources.asurascans.search.error'))
 
       accumulatedComics.value = []
-      maxPage.value = 0
+      hasNextPage.value = false
       comics.value = []
 
       return
@@ -106,17 +103,17 @@ export function useAsuraScansSearch(opts: { doSearch: boolean }): AsuraScansSear
       accumulatedComics.value = [...accumulatedComics.value, ...res.data.items]
     }
 
-    maxPage.value = Math.ceil(res.data.total / PAGE_SIZE)
+    hasNextPage.value = res.data.hasNextPage
     comics.value = res.data.items
   }, 200)
 
   watch([search, sort, status, type], () => {
-    offset.value = 0
+    page.value = 1
     accumulatedComics.value = []
     comics.value = []
   })
 
-  watch([search, sort, status, type, offset], () => {
+  watch([search, sort, status, type, page], () => {
     if (opts.doSearch) {
       debouncedSearchFn()
     }
@@ -177,8 +174,8 @@ export function useAsuraScansSearch(opts: { doSearch: boolean }): AsuraScansSear
     sort,
     status,
     type,
-    page: offset,
-    maxPage,
+    page,
+    hasNextPage,
     series: computed(() => smAndDown.value ? accumulatedComics.value : comics.value),
     isLoading,
     resetFilters,

--- a/web/app/features/asurascans/composables/asurascans.api.test.ts
+++ b/web/app/features/asurascans/composables/asurascans.api.test.ts
@@ -59,50 +59,60 @@ describe('createAsuraScansApi', () => {
 })
 
 describe('createAsuraScansApi().search', () => {
-  it('requests /search with pagination', async () => {
-    mocks.call.mockResolvedValue({ items: [rawItem], total: 1 })
+  it('requests /search with page', async () => {
+    mocks.call.mockResolvedValue({ items: [rawItem], hasNextPage: true })
 
-    const res = await createAsuraScansApi().search({ offset: 0, limit: 20, sort: 'popular' })
+    const res = await createAsuraScansApi().search({ page: 1, sort: 'popular' })
 
     expect(mocks.call).toHaveBeenCalledWith('/search', {
       method: 'GET',
-      params: { sort: 'popular', offset: 0, limit: 20 },
+      params: { sort: 'popular', page: 1 },
     })
-    expect(res).toEqual({ success: true, data: { items: [item], total: 1 } })
+    expect(res).toEqual({ success: true, data: { items: [item], hasNextPage: true } })
   })
 
   it('omits empty optional filters', async () => {
-    mocks.call.mockResolvedValue({ items: [], total: 0 })
+    mocks.call.mockResolvedValue({ items: [], hasNextPage: false })
 
-    await createAsuraScansApi().search({ offset: 0, limit: 20 })
+    await createAsuraScansApi().search({ page: 1 })
 
     expect(mocks.call).toHaveBeenCalledWith('/search', {
       method: 'GET',
-      params: { offset: 0, limit: 20 },
+      params: { page: 1 },
     })
   })
 
   it('includes status, type and search when set', async () => {
-    mocks.call.mockResolvedValue({ items: [], total: 0 })
+    mocks.call.mockResolvedValue({ items: [], hasNextPage: false })
 
     await createAsuraScansApi().search({
       search: 'solo',
       status: 'ongoing',
       type: 'manhwa',
-      offset: 20,
-      limit: 20,
+      page: 2,
     })
 
     expect(mocks.call).toHaveBeenCalledWith('/search', {
       method: 'GET',
-      params: { search: 'solo', status: 'ongoing', type: 'manhwa', offset: 20, limit: 20 },
+      params: { search: 'solo', status: 'ongoing', type: 'manhwa', page: 2 },
+    })
+  })
+
+  it('includes minChapters when greater than 0', async () => {
+    mocks.call.mockResolvedValue({ items: [], hasNextPage: false })
+
+    await createAsuraScansApi().search({ page: 1, minChapters: 5 })
+
+    expect(mocks.call).toHaveBeenCalledWith('/search', {
+      method: 'GET',
+      params: { page: 1, minChapters: 5 },
     })
   })
 
   it('surfaces a failure with its status', async () => {
     mocks.call.mockRejectedValue({ statusCode: 502, data: {} })
 
-    const res = await createAsuraScansApi().search({ offset: 0, limit: 20 })
+    const res = await createAsuraScansApi().search({ page: 1 })
 
     expect(res.success === false && res.error.status).toBe(502)
   })

--- a/web/app/features/asurascans/composables/asurascans.api.ts
+++ b/web/app/features/asurascans/composables/asurascans.api.ts
@@ -22,15 +22,14 @@ export function createAsuraScansApi(): AsuraScansApi {
         ...(params.status && { status: params.status }),
         ...(params.type && { type: params.type }),
         ...(params.artist && { artist: params.artist }),
-        ...(params.offset >= 0 && { offset: params.offset }),
-        ...(params.limit > 0 && { limit: params.limit }),
+        ...(params.page >= 1 && { page: params.page }),
         ...(params.minChapters && params.minChapters > 0 && { minChapters: params.minChapters }),
       } })
 
       return {
         success: true,
         data: {
-          total: response.total,
+          hasNextPage: response.hasNextPage,
           items: response.items.map(({ lastChapterAt, updatedAt, createdAt, latestChapters, ...rest }) => ({
             ...rest,
             ...(lastChapterAt && { lastChapterAt: new Date(lastChapterAt) }),

--- a/web/app/features/asurascans/stores/asurascans-search.store.test.ts
+++ b/web/app/features/asurascans/stores/asurascans-search.store.test.ts
@@ -35,11 +35,11 @@ describe('useAsuraScansSearchStore', () => {
     setActivePinia(createPinia())
   })
 
-  it('starts with default sort and offset', () => {
+  it('starts with default sort and page', () => {
     const store = useAsuraScansSearchStore()
 
     expect(store.sort).toBe('popular')
-    expect(store.offset).toBe(1)
+    expect(store.page).toBe(1)
     expect(store.comics).toEqual([])
   })
 
@@ -74,13 +74,13 @@ describe('useAsuraScansSearchStore', () => {
     store.setSearch('solo')
     store.setSort('title')
     store.setComics([item('solo-leveling')])
-    store.setOffset(3)
+    store.setPage(3)
 
     store.invalidate()
 
     expect(store.search).toBeUndefined()
     expect(store.sort).toBe('popular')
-    expect(store.offset).toBe(1)
+    expect(store.page).toBe(1)
     expect(store.comics).toEqual([])
   })
 })

--- a/web/app/features/asurascans/stores/asurascans-search.store.ts
+++ b/web/app/features/asurascans/stores/asurascans-search.store.ts
@@ -4,7 +4,7 @@ import type { AsuraScansSearchItem, AsuraScansSort } from '../types'
 import type { ComicStatus, ComicType } from '~/features/comics/types'
 
 const DEFAULT_SORT: AsuraScansSort = 'popular'
-const DEFAULT_OFFSET = 1
+const DEFAULT_PAGE = 1
 
 export interface AsuraScansSearchStore {
   comics: Ref<AsuraScansSearchItem[]>
@@ -37,9 +37,9 @@ export interface AsuraScansSearchStore {
   setType: (value: ComicType) => void
   clearType: () => void
 
-  offset: Ref<number>
-  setOffset: (value: number) => void
-  clearOffset: () => void
+  page: Ref<number>
+  setPage: (value: number) => void
+  clearPage: () => void
 
   invalidate: () => void
 }
@@ -49,7 +49,7 @@ export const useAsuraScansSearchStore = defineStore('asurascans-search', (): Asu
   const sort = ref<AsuraScansSort>(DEFAULT_SORT)
   const status = ref<ComicStatus>()
   const type = ref<ComicType>()
-  const offset = ref<number>(DEFAULT_OFFSET)
+  const page = ref<number>(DEFAULT_PAGE)
   const loading = ref<boolean>(false)
 
   const comics = ref<AsuraScansSearchItem[]>([])
@@ -129,12 +129,12 @@ export const useAsuraScansSearchStore = defineStore('asurascans-search', (): Asu
     type.value = undefined
   }
 
-  function setOffset(value: number): void {
-    offset.value = value
+  function setPage(value: number): void {
+    page.value = value
   }
 
-  function clearOffset(): void {
-    offset.value = DEFAULT_OFFSET
+  function clearPage(): void {
+    page.value = DEFAULT_PAGE
   }
 
   function invalidate(): void {
@@ -142,7 +142,7 @@ export const useAsuraScansSearchStore = defineStore('asurascans-search', (): Asu
     clearSort()
     clearStatus()
     clearType()
-    clearOffset()
+    clearPage()
     clearLoading()
     clearComics()
     clearAccumulatedComics()
@@ -179,9 +179,9 @@ export const useAsuraScansSearchStore = defineStore('asurascans-search', (): Asu
     setType,
     clearType,
 
-    offset,
-    setOffset,
-    clearOffset,
+    page,
+    setPage,
+    clearPage,
 
     invalidate,
   }

--- a/web/app/features/asurascans/types.ts
+++ b/web/app/features/asurascans/types.ts
@@ -10,14 +10,13 @@ export interface AsuraScansSearchParams {
   status?: ComicStatus
   type?: ComicType
   artist?: string
-  offset: number
-  limit: number
+  page: number
   minChapters?: number
 }
 
 export interface AsuraScansSearchResponse {
   items: AsuraScansSearchItem[]
-  total: number
+  hasNextPage: boolean
 }
 
 export interface AsuraScansSearchItem {

--- a/web/app/features/comics/components/Icon/Status.test.ts
+++ b/web/app/features/comics/components/Icon/Status.test.ts
@@ -25,4 +25,14 @@ describe('asuraIconStatus', () => {
     const wrapper = await mount('completed', true)
     expect(wrapper.find('.status-icon-box').exists()).toBe(true)
   })
+
+  it('activates the tooltip from the background box, not the icon', async () => {
+    const wrapper = await mount('completed', true)
+    const tooltip = wrapper.findComponent({ name: 'VTooltip' })
+    const box = wrapper.find('.status-icon-box')
+
+    expect(tooltip.exists()).toBe(true)
+    expect(tooltip.find('.status-icon-box').exists()).toBe(true)
+    expect(box.findComponent({ name: 'VIcon' }).exists()).toBe(true)
+  })
 })

--- a/web/app/features/comics/components/Icon/Status.vue
+++ b/web/app/features/comics/components/Icon/Status.vue
@@ -3,8 +3,9 @@
 import type { ComicStatus } from '~/features/comics/types'
 
 const props = defineProps<{
-  status: ComicStatus
+  status?: ComicStatus
   withBackground?: boolean
+  loading?: boolean
 }>()
 
 const modelValue = computed((): { icon: string, color: string } | undefined => {
@@ -31,14 +32,27 @@ const modelValue = computed((): { icon: string, color: string } | undefined => {
       :color="modelValue.color"
     />
 
-    <div v-else class="d-flex flex-column items-center justify-center rounded-lg border-thin transition-smooth status-icon-box">
-      <VIcon
-        v-tooltip="$t(`sources.asurascans.status.${status}`)"
-        :icon="modelValue.icon"
-        :color="modelValue.color"
-        size="x-small"
-      />
-    </div>
+    <VTooltip v-else :text="$t(`sources.asurascans.status.${status}`)">
+      <template #activator="{ props: tooltipProps }">
+        <div
+          v-bind="tooltipProps"
+          class="d-flex flex-column items-center justify-center rounded-lg border-thin transition-smooth status-icon-box"
+        >
+          <VProgressCircular
+            v-if="loading"
+            indeterminate
+            size="16"
+            width="2"
+            color="primary"
+          />
+          <VIcon
+            :icon="modelValue.icon"
+            :color="modelValue.color"
+            size="x-small"
+          />
+        </div>
+      </template>
+    </VTooltip>
   </template>
 </template>
 

--- a/web/app/features/kingofshojo/components/Btn/Add.test.ts
+++ b/web/app/features/kingofshojo/components/Btn/Add.test.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { VueWrapper } from '@vue/test-utils'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it } from 'vitest'
+import { h } from 'vue'
+import { VApp } from 'vuetify/components'
+import Add from './Add.vue'
+
+async function mount(isLoading = false): Promise<VueWrapper> {
+  return mountSuspended({
+    render: () => h(VApp, () => [h(Add, { loading: isLoading })]),
+  })
+}
+
+describe('asuraScansBtnAdd', () => {
+  it('shows the book icon while idle', async () => {
+    const wrapper = await mount()
+    expect(wrapper.find('.v-icon').exists()).toBe(true)
+  })
+
+  it('shows a spinner while loading', async () => {
+    const wrapper = await mount(true)
+    expect(wrapper.find('.v-progress-circular').isVisible()).toBe(true)
+  })
+})

--- a/web/app/features/kingofshojo/components/Btn/Add.vue
+++ b/web/app/features/kingofshojo/components/Btn/Add.vue
@@ -1,0 +1,39 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+defineProps<{ loading?: boolean }>()
+</script>
+
+<template>
+  <div
+    v-tooltip="$t(`sources.add.title`)"
+    class="d-flex flex-column items-center justify-center rounded-lg transition-smooth add-library-btn border-thin-primary"
+  >
+    <VProgressCircular
+      v-show="loading"
+      indeterminate
+      width="2"
+      size="x-small"
+      color="primary"
+    />
+
+    <VIcon
+      v-show="!loading"
+      icon="fa6-solid:book"
+      size="x-small"
+    />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.add-library-btn {
+  padding: 0.4rem;
+  backdrop-filter: blur(2px);
+  background-color: rgba(var(--v-theme-surface), 0.7);
+  color: rgb(var(--v-theme-primary));
+
+  &:hover {
+    background-color: rgb(var(--v-theme-primary));
+    color: rgb(var(--v-theme-surface));
+  }
+}
+</style>

--- a/web/app/features/kingofshojo/components/Btn/Delete.test.ts
+++ b/web/app/features/kingofshojo/components/Btn/Delete.test.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { VueWrapper } from '@vue/test-utils'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it } from 'vitest'
+import { h } from 'vue'
+import { VApp } from 'vuetify/components'
+import Delete from './Delete.vue'
+
+async function mount(mode: 'btn' | 'label'): Promise<VueWrapper> {
+  return mountSuspended({
+    render: () => h(VApp, () => [h(Delete, { mode })]),
+  })
+}
+
+describe('asuraScansBtnDelete', () => {
+  it('uses the in-library class in label mode', async () => {
+    const wrapper = await mount('label')
+    expect(wrapper.find('.remove-library-btn--label').exists()).toBe(true)
+    expect(wrapper.text()).toContain('In library')
+  })
+
+  it('uses the remove class in btn mode', async () => {
+    const wrapper = await mount('btn')
+    expect(wrapper.find('.remove-library-btn--btn').exists()).toBe(true)
+  })
+})

--- a/web/app/features/kingofshojo/components/Btn/Delete.vue
+++ b/web/app/features/kingofshojo/components/Btn/Delete.vue
@@ -1,0 +1,63 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+const props = defineProps<{
+  mode: 'btn' | 'label'
+}>()
+
+const icon = computed(() => props.mode === 'btn' ? 'fa6-solid:trash' : 'fa6-solid:check')
+const { smAndDown } = useDisplay()
+</script>
+
+<template>
+  <div
+    class="d-flex transition-smooth flex-column items-center justify-center rounded-lg transition-smooth remove-library-btn"
+    :class="{
+      'border-thin': mode === 'label',
+      'border-thin-error': mode === 'btn',
+      'remove-library-btn--btn': mode === 'btn',
+      'remove-library-btn--label': mode === 'label',
+    }"
+  >
+    <div class="d-flex align-center transition-smooth ga-1">
+      <VIcon
+        :icon
+        size="x-small"
+      />
+
+      <VExpandXTransition v-if="!smAndDown">
+        <span
+          v-show="mode === 'label'"
+          class="text-no-wrap text-body-small transition-smooth"
+        >{{ $t('sources.asurascans.label.inLibrary') }}</span>
+      </VExpandXTransition>
+    </div>
+
+    <VTooltip
+      v-if="mode === 'btn'"
+      :text="$t(`comics.remove.title`)"
+      activator="parent"
+    />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.remove-library-btn {
+  padding: 0.4rem;
+  backdrop-filter: blur(2px);
+}
+
+.remove-library-btn--label {
+  background-color: rgba(var(--v-theme-primary), 1);
+  color: rgb(var(--v-theme-surface));
+}
+
+.remove-library-btn--btn {
+  background-color: rgba(var(--v-theme-surface), 0.7);
+  color: rgb(var(--v-theme-error));
+
+  &:hover {
+    background-color: rgb(var(--v-theme-error));
+    color: rgb(var(--v-theme-surface));
+  }
+}
+</style>

--- a/web/app/features/kingofshojo/components/Comic/Card.test.ts
+++ b/web/app/features/kingofshojo/components/Comic/Card.test.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { VueWrapper } from '@vue/test-utils'
+import type { KingOfShojoSearchItem } from '../../types'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { VApp } from 'vuetify/components'
+import Card from './Card.vue'
+
+const mocks = vi.hoisted(() => ({
+  getInfosBySlug: vi.fn(),
+}))
+
+function createKingOfShojoApiMock(): { getInfosBySlug: typeof mocks.getInfosBySlug } {
+  return { getInfosBySlug: mocks.getInfosBySlug }
+}
+
+mockNuxtImport('createKingOfShojoApi', () => createKingOfShojoApiMock)
+
+const SourcesCardStub = defineComponent({
+  name: 'SourcesCardComic',
+  props: {
+    status: { type: String, default: undefined },
+    chapterCount: { type: Number, default: 0 },
+    chapterCountLoading: { type: Boolean, default: false },
+    statusLoading: { type: Boolean, default: false },
+    internalId: { type: String, default: undefined },
+    to: { type: String, required: true },
+    cover: { type: String, required: true },
+    title: { type: String, required: true },
+    loading: { type: Boolean, default: false },
+  },
+  template: '<div data-test="sources-card" />',
+})
+
+function comic(overrides: Partial<KingOfShojoSearchItem> = {}): KingOfShojoSearchItem {
+  return {
+    title: 'Webtoon Character Na Kang Lim',
+    cover: '/cover',
+    publicUrl: '/manga/webtoon-character-na-kang-lim/',
+    sourceUrl: '',
+    status: '' as KingOfShojoSearchItem['status'],
+    type: '' as KingOfShojoSearchItem['type'],
+    author: '',
+    artist: '',
+    description: '',
+    slug: 'webtoon-character-na-kang-lim',
+    altTitles: [],
+    genres: [],
+    chapterCount: 0,
+    rating: 0,
+    updatedAt: new Date('2026-01-01'),
+    createdAt: new Date('2026-01-01'),
+    ...overrides,
+  } as KingOfShojoSearchItem
+}
+
+async function mount(item: KingOfShojoSearchItem = comic()): Promise<VueWrapper> {
+  return mountSuspended(
+    {
+      render: () => h(VApp, () => [h(Card, { comic: item })]),
+    },
+    {
+      global: {
+        stubs: {
+          SourcesCardComic: SourcesCardStub,
+        },
+      },
+    },
+  )
+}
+
+beforeEach(() => {
+  mocks.getInfosBySlug.mockReset()
+  mocks.getInfosBySlug.mockReturnValue(new Promise(() => {}))
+})
+
+describe('kingOfShojoComicCard', () => {
+  it('does not invent an ongoing status before series infos load', async () => {
+    const wrapper = await mount()
+
+    expect(wrapper.findComponent(SourcesCardStub).props('status')).toBeUndefined()
+  })
+
+  it('uses the status returned by getInfosBySlug', async () => {
+    mocks.getInfosBySlug.mockResolvedValue({
+      success: true,
+      data: { status: 'completed', chapterCount: 42 },
+    })
+
+    const wrapper = await mount()
+    await vi.waitFor(() => {
+      expect(wrapper.findComponent(SourcesCardStub).props('status')).toBe('completed')
+    })
+    expect(wrapper.findComponent(SourcesCardStub).props('chapterCount')).toBe(42)
+  })
+})

--- a/web/app/features/kingofshojo/components/Comic/Card.vue
+++ b/web/app/features/kingofshojo/components/Comic/Card.vue
@@ -1,0 +1,54 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+import type { KingOfShojoComicInfos, KingOfShojoSearchItem } from '../../types'
+import type { ComicStatus } from '~/features/comics/types'
+import { KING_OF_SHOJO_SOURCE_NAME } from '~/constants'
+
+const props = defineProps<{
+  comic: KingOfShojoSearchItem | KingOfShojoComicInfos
+  loading?: boolean
+}>()
+
+defineEmits<{ toggle: [] }>()
+
+const COMIC_STATUSES: ComicStatus[] = ['ongoing', 'completed', 'hiatus', 'cancelled']
+
+function isComicStatus(value: string): value is ComicStatus {
+  return COMIC_STATUSES.includes(value as ComicStatus)
+}
+
+const api = createKingOfShojoApi()
+
+const status = ref<ComicStatus | undefined>(isComicStatus(props.comic.status) ? props.comic.status : undefined)
+const chapterCount = ref(props.comic.chapterCount)
+const fetchInfosLoading = ref(false)
+
+onMounted(async () => {
+  fetchInfosLoading.value = true
+  const res = await api.getInfosBySlug(props.comic.slug)
+
+  if (res.success) {
+    status.value = res.data.status
+    chapterCount.value = res.data.chapterCount
+  } else {
+    console.error('api.getInfosBySlug', res.error)
+  }
+
+  fetchInfosLoading.value = false
+})
+</script>
+
+<template>
+  <SourcesCardComic
+    :internal-id="comic.internalId"
+    :status
+    :to="`/browse/sources/${KING_OF_SHOJO_SOURCE_NAME}/${comic.slug}`"
+    :cover="comic.cover"
+    :title="comic.title"
+    :chapter-count
+    :loading
+    :chapter-count-loading="fetchInfosLoading"
+    :status-loading="fetchInfosLoading"
+    @toggle="$emit('toggle')"
+  />
+</template>

--- a/web/app/features/kingofshojo/components/Header.vue
+++ b/web/app/features/kingofshojo/components/Header.vue
@@ -1,0 +1,26 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+const { status, type, sort, search, isLoading } = useKingOfShojoSearch({ doSearch: false })
+
+const { mdAndDown } = useDisplay()
+</script>
+
+<template>
+  <div
+    class="d-flex ga-4"
+    :class="{
+      'flex-column': mdAndDown,
+      'px-4': mdAndDown,
+      'align-center': !mdAndDown,
+      'justify-space-between': !mdAndDown,
+    }"
+  >
+    <AtomInputSearch v-model="search" :style="{ 'max-width': mdAndDown ? '100%' : '25rem' }" />
+
+    <div class="d-flex ga-4" :class="{ 'justify-space-between': mdAndDown }">
+      <KingOfShojoInputSort v-model="sort" :disabled="isLoading" />
+      <ComicsInputStatus v-model="status" :disabled="isLoading" />
+      <ComicsInputType v-model="type" :disabled="isLoading" />
+    </div>
+  </div>
+</template>

--- a/web/app/features/kingofshojo/components/Input/Sort.vue
+++ b/web/app/features/kingofshojo/components/Input/Sort.vue
@@ -1,0 +1,37 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+import type { KingOfShojoSort } from '../../types'
+
+defineProps<{ disabled?: boolean }>()
+const sort = defineModel<KingOfShojoSort>({ required: true })
+const { t } = useI18n()
+
+const items: { value: KingOfShojoSort, title: string }[] = [
+  {
+    value: 'popular',
+    title: t('sources.asurascans.sort.popular'),
+  },
+  {
+    value: 'latest',
+    title: t('sources.asurascans.sort.latest'),
+  },
+  {
+    value: 'title',
+    title: t('sources.asurascans.sort.title'),
+  },
+]
+</script>
+
+<template>
+  <VSelect
+    v-model="sort"
+    density="compact"
+    class="border-thin"
+    style="border-radius: 12px"
+    width="12rem"
+    :disabled
+    hide-details
+    :items="items"
+    :label="$t('sources.asurascans.sort.label')"
+  />
+</template>

--- a/web/app/features/kingofshojo/components/Modal/Delete.test.ts
+++ b/web/app/features/kingofshojo/components/Modal/Delete.test.ts
@@ -13,7 +13,7 @@ const { removeComicFromLibrary } = vi.hoisted(() => ({
   removeComicFromLibrary: vi.fn(),
 }))
 
-vi.mock('~/features/asurascans/composables/asurascans-search.composable', () => ({
+vi.mock('../../composables/kingofshojo-search.composable', () => ({
   useKingOfShojoSearch: () => ({ removeComicFromLibrary }),
 }))
 

--- a/web/app/features/kingofshojo/components/Modal/Delete.test.ts
+++ b/web/app/features/kingofshojo/components/Modal/Delete.test.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { VueWrapper } from '@vue/test-utils'
+import type { KingOfShojoComicInfos, KingOfShojoSearchItem } from '../../types'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, ref } from 'vue'
+import { VApp } from 'vuetify/components'
+import Delete from './Delete.vue'
+
+const { removeComicFromLibrary } = vi.hoisted(() => ({
+  removeComicFromLibrary: vi.fn(),
+}))
+
+vi.mock('~/features/asurascans/composables/asurascans-search.composable', () => ({
+  useKingOfShojoSearch: () => ({ removeComicFromLibrary }),
+}))
+
+const ConfirmationStub = defineComponent({
+  name: 'OrganismModalConfirmation',
+  props: {
+    modelValue: { type: Boolean, default: false },
+    text: { type: String, default: '' },
+    loading: { type: Boolean, default: false },
+  },
+  emits: ['confirm'],
+  template: '<button data-test="confirm" @click="$emit(\'confirm\')" />',
+})
+
+function item(): KingOfShojoSearchItem {
+  return {
+    slug: 'solo-leveling',
+    title: 'Solo Leveling',
+    cover: '/cover',
+    publicUrl: '',
+    sourceUrl: '',
+    status: 'ongoing',
+    type: 'manhwa',
+    author: '',
+    artist: '',
+    description: '',
+    altTitles: [],
+    genres: [],
+    chapterCount: 1,
+    rating: 0,
+    releaseYear: 2020,
+    lastChapterAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    createdAt: new Date('2026-01-01'),
+    internalId: 'c1',
+  }
+}
+
+async function mount(): Promise<{ wrapper: VueWrapper, comic: ReturnType<typeof ref<KingOfShojoSearchItem | undefined>> }> {
+  const show = ref(true)
+  const comic = ref<KingOfShojoSearchItem | undefined>(item())
+
+  const wrapper = await mountSuspended(
+    {
+      render: () => h(VApp, () => [h(Delete, {
+        'modelValue': show.value,
+        'comic': comic.value,
+        'onUpdate:modelValue': (isShown: boolean) => {
+          show.value = isShown
+        },
+        'onUpdate:comic': (value: KingOfShojoSearchItem | KingOfShojoComicInfos | undefined) => {
+          comic.value = value as KingOfShojoSearchItem
+        },
+      })]),
+    },
+    { global: { stubs: { OrganismModalConfirmation: ConfirmationStub } } },
+  )
+
+  return { wrapper, comic }
+}
+
+beforeEach(() => {
+  removeComicFromLibrary.mockReset()
+  removeComicFromLibrary.mockResolvedValue(true)
+})
+
+describe('asuraScansModalDelete', () => {
+  it('names the comic in the confirmation text', async () => {
+    const { wrapper } = await mount()
+    expect(wrapper.findComponent(ConfirmationStub).props('text')).toContain('Solo Leveling')
+  })
+
+  it('removes the comic on confirmation', async () => {
+    const { wrapper } = await mount()
+
+    await wrapper.find('[data-test="confirm"]').trigger('click')
+
+    expect(removeComicFromLibrary).toHaveBeenCalled()
+  })
+})

--- a/web/app/features/kingofshojo/components/Modal/Delete.vue
+++ b/web/app/features/kingofshojo/components/Modal/Delete.vue
@@ -1,0 +1,39 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+import type { KingOfShojoComicInfos, KingOfShojoSearchItem } from '../../types'
+
+const show = defineModel<boolean>({ required: true })
+const comic = defineModel<KingOfShojoSearchItem | KingOfShojoComicInfos | undefined>('comic', { required: true })
+
+const { removeComicFromLibrary } = useKingOfShojoSearch({ doSearch: false })
+
+const loading = ref(false)
+
+watch(show, (value) => {
+  if (!value) {
+    loading.value = false
+    comic.value = undefined
+  }
+})
+
+async function handleDelete(): Promise<void> {
+  if (!comic.value) {
+    return
+  }
+
+  loading.value = true
+
+  await removeComicFromLibrary(comic.value as KingOfShojoSearchItem)
+
+  show.value = false
+}
+</script>
+
+<template>
+  <OrganismModalConfirmation
+    v-model="show"
+    :loading
+    :text="$t('sources.kingofshojo.delete.confirmation', { name: comic?.title ?? '' })"
+    @confirm="handleDelete"
+  />
+</template>

--- a/web/app/features/kingofshojo/composables/kingofshojo-search.composable.test.ts
+++ b/web/app/features/kingofshojo/composables/kingofshojo-search.composable.test.ts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { KingOfShojoSearchItem } from '../types'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useToast } from '~/composables/toast.composable'
+import { useKingOfShojoSearchStore } from '../stores/kingofshojo-search.store'
+import { useKingOfShojoSearch } from './kingofshojo-search.composable'
+
+const { search, create, deleteById, smAndDown } = vi.hoisted(() => ({
+  search: vi.fn(),
+  create: vi.fn(),
+  deleteById: vi.fn(),
+  smAndDown: { value: false },
+}))
+
+vi.mock('./kingofshojo.api', () => ({
+  createKingOfShojoApi: () => ({ search }),
+}))
+
+vi.mock('~/features/comics/composables/comics.api', () => ({
+  createComicsApi: () => ({ create, deleteById }),
+}))
+
+function i18nStub(): { t: (key: string) => string } {
+  return { t: (key: string) => key }
+}
+
+function displayStub(): { smAndDown: { value: boolean } } {
+  return { smAndDown }
+}
+
+mockNuxtImport('useI18n', () => i18nStub)
+mockNuxtImport('useDisplay', () => displayStub)
+
+function item(slug: string, internalId?: string): KingOfShojoSearchItem {
+  return {
+    slug,
+    title: slug,
+    cover: `/cover/${slug}`,
+    publicUrl: '',
+    sourceUrl: '',
+    status: 'ongoing',
+    type: 'manhwa',
+    author: '',
+    artist: '',
+    description: '',
+    altTitles: [],
+    genres: [],
+    chapterCount: 1,
+    rating: 0,
+    releaseYear: 2020,
+    lastChapterAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    createdAt: new Date('2026-01-01'),
+    ...(internalId && { internalId }),
+  }
+}
+
+function apiError(status: number): { success: false, error: { status: number, message: string } } {
+  return { success: false, error: { status, message: 'boom' } }
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  useToast().messages.value.length = 0
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  search.mockReset()
+  create.mockReset()
+  deleteById.mockReset()
+  smAndDown.value = false
+})
+
+describe('useKingOfShojoSearch library', () => {
+  it('adds a comic and stores the returned id', async () => {
+    create.mockResolvedValue({ success: true, data: { id: 'c1', slug: 'solo-leveling', source: 'kingofshojo', status: 'ongoing', chapterCount: 0 } })
+    const kingofshojo = useKingOfShojoSearch({ doSearch: false })
+    useKingOfShojoSearchStore().setComics([item('solo-leveling')])
+
+    await kingofshojo.addComicInLibrary(item('solo-leveling'))
+
+    expect(create).toHaveBeenCalledWith({ source: 'kingofshojo', slug: 'solo-leveling' })
+    expect(useKingOfShojoSearchStore().comics[0]?.internalId).toBe('c1')
+  })
+
+  it('toasts a dedicated message on a 409', async () => {
+    create.mockResolvedValue(apiError(409))
+
+    await useKingOfShojoSearch({ doSearch: false }).addComicInLibrary(item('solo-leveling'))
+
+    expect(useToast().messages.value).toEqual([{ text: 'comics.create.error.alreadyExists', color: 'error' }])
+  })
+
+  it('does not add a comic that already has an internal id', async () => {
+    await useKingOfShojoSearch({ doSearch: false }).addComicInLibrary(item('solo-leveling', 'c1'))
+
+    expect(create).not.toHaveBeenCalled()
+  })
+
+  it('removes a comic and clears its internal id', async () => {
+    deleteById.mockResolvedValue({ success: true, data: undefined })
+    const kingofshojo = useKingOfShojoSearch({ doSearch: false })
+    useKingOfShojoSearchStore().setComics([item('solo-leveling', 'c1')])
+
+    await kingofshojo.removeComicFromLibrary(item('solo-leveling', 'c1'))
+
+    expect(deleteById).toHaveBeenCalledWith('c1')
+    expect(useKingOfShojoSearchStore().comics[0]?.internalId).toBeUndefined()
+  })
+
+  it('does not delete a comic without an internal id', async () => {
+    await useKingOfShojoSearch({ doSearch: false }).removeComicFromLibrary(item('solo-leveling'))
+
+    expect(deleteById).not.toHaveBeenCalled()
+  })
+
+  it('toasts an unknown error when delete fails', async () => {
+    deleteById.mockResolvedValue(apiError(500))
+
+    await useKingOfShojoSearch({ doSearch: false }).removeComicFromLibrary(item('solo-leveling', 'c1'))
+
+    expect(useToast().messages.value).toEqual([{ text: 'error.unknown', color: 'error' }])
+  })
+})

--- a/web/app/features/kingofshojo/composables/kingofshojo-search.composable.test.ts
+++ b/web/app/features/kingofshojo/composables/kingofshojo-search.composable.test.ts
@@ -124,3 +124,26 @@ describe('useKingOfShojoSearch library', () => {
     expect(useToast().messages.value).toEqual([{ text: 'error.unknown', color: 'error' }])
   })
 })
+
+describe('useKingOfShojoSearch pagination', () => {
+  it('searches with page 1 and stores hasNextPage', async () => {
+    search.mockResolvedValue({ success: true, data: { items: [item('solo')], hasNextPage: true } })
+    const kos = useKingOfShojoSearch({ doSearch: true })
+    await vi.waitFor(() => {
+      expect(search).toHaveBeenCalledWith(expect.objectContaining({ page: 1 }))
+    })
+    expect(kos.hasNextPage.value).toBe(true)
+    expect(kos.series.value).toHaveLength(1)
+  })
+
+  it('resets page to 1 when filters change', async () => {
+    search.mockResolvedValue({ success: true, data: { items: [], hasNextPage: false } })
+    const kos = useKingOfShojoSearch({ doSearch: true })
+    await vi.waitFor(() => expect(search).toHaveBeenCalled())
+    kos.page.value = 3
+    kos.sort.value = 'latest'
+    await vi.waitFor(() => {
+      expect(kos.page.value).toBe(1)
+    })
+  })
+})

--- a/web/app/features/kingofshojo/composables/kingofshojo-search.composable.ts
+++ b/web/app/features/kingofshojo/composables/kingofshojo-search.composable.ts
@@ -5,15 +5,13 @@ import type { ComicStatus, ComicType } from '~/features/comics/types'
 import { KING_OF_SHOJO_SOURCE_NAME } from '~/constants'
 import { createComicsApi } from '~/features/comics/composables/comics.api'
 
-const PAGE_SIZE = 20
-
 export interface KingOfShojoSearchComposable {
   search: Ref<string | undefined>
   sort: Ref<KingOfShojoSort>
   status: Ref<ComicStatus | undefined>
   type: Ref<ComicType | undefined>
   page: Ref<number>
-  maxPage: Ref<number>
+  hasNextPage: Ref<boolean>
   series: Ref<KingOfShojoSearchItem[]>
   isLoading: Ref<boolean>
   resetFilters: () => void
@@ -51,9 +49,9 @@ export function useKingOfShojoSearch(opts: { doSearch: boolean }): KingOfShojoSe
     set: (value?: ComicType) => value ? store.setType(value) : store.clearType(),
   })
 
-  const offset = computed({
-    get: () => store.offset,
-    set: (value: number) => store.setOffset(value),
+  const page = computed({
+    get: () => store.page,
+    set: (value: number) => store.setPage(value),
   })
 
   const isLoading = computed({
@@ -75,7 +73,7 @@ export function useKingOfShojoSearch(opts: { doSearch: boolean }): KingOfShojoSe
     store.invalidate()
   }
 
-  const maxPage = ref(0)
+  const hasNextPage = ref(false)
   const addComicInLibraryLoading = ref<Record<string, boolean>>({})
 
   const debouncedSearchFn = useDebounceFn(async () => {
@@ -86,8 +84,7 @@ export function useKingOfShojoSearch(opts: { doSearch: boolean }): KingOfShojoSe
       ...(sort.value && { sort: sort.value }),
       ...(status.value && { status: status.value }),
       ...(type.value && { type: type.value }),
-      offset: offset.value,
-      limit: PAGE_SIZE,
+      page: page.value,
     })
 
     isLoading.value = false
@@ -96,7 +93,7 @@ export function useKingOfShojoSearch(opts: { doSearch: boolean }): KingOfShojoSe
       toast.error(t('sources.kingofshojo.search.error'))
 
       accumulatedComics.value = []
-      maxPage.value = 0
+      hasNextPage.value = false
       comics.value = []
 
       return
@@ -106,17 +103,17 @@ export function useKingOfShojoSearch(opts: { doSearch: boolean }): KingOfShojoSe
       accumulatedComics.value = [...accumulatedComics.value, ...res.data.items]
     }
 
-    maxPage.value = Math.ceil(res.data.total / PAGE_SIZE)
+    hasNextPage.value = res.data.hasNextPage
     comics.value = res.data.items
   }, 200)
 
   watch([search, sort, status, type], () => {
-    offset.value = 0
+    page.value = 1
     accumulatedComics.value = []
     comics.value = []
   })
 
-  watch([search, sort, status, type, offset], () => {
+  watch([search, sort, status, type, page], () => {
     if (opts.doSearch) {
       debouncedSearchFn()
     }
@@ -177,8 +174,8 @@ export function useKingOfShojoSearch(opts: { doSearch: boolean }): KingOfShojoSe
     sort,
     status,
     type,
-    page: offset,
-    maxPage,
+    page,
+    hasNextPage,
     series: computed(() => smAndDown.value ? accumulatedComics.value : comics.value),
     isLoading,
     resetFilters,

--- a/web/app/features/kingofshojo/composables/kingofshojo-search.composable.ts
+++ b/web/app/features/kingofshojo/composables/kingofshojo-search.composable.ts
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { KingOfShojoComicInfos, KingOfShojoSearchItem, KingOfShojoSort } from '../types'
+import type { ComicStatus, ComicType } from '~/features/comics/types'
+import { KING_OF_SHOJO_SOURCE_NAME } from '~/constants'
+import { createComicsApi } from '~/features/comics/composables/comics.api'
+
+const PAGE_SIZE = 20
+
+export interface KingOfShojoSearchComposable {
+  search: Ref<string | undefined>
+  sort: Ref<KingOfShojoSort>
+  status: Ref<ComicStatus | undefined>
+  type: Ref<ComicType | undefined>
+  page: Ref<number>
+  maxPage: Ref<number>
+  series: Ref<KingOfShojoSearchItem[]>
+  isLoading: Ref<boolean>
+  resetFilters: () => void
+
+  removeComicFromLibrary: (comic: KingOfShojoSearchItem) => Promise<boolean>
+  addComicInLibrary: (comic: KingOfShojoSearchItem | KingOfShojoComicInfos) => Promise<string | undefined>
+  addComicInLibraryLoading: Ref<Record<string, boolean>>
+}
+
+export function useKingOfShojoSearch(opts: { doSearch: boolean }): KingOfShojoSearchComposable {
+  const api = createKingOfShojoApi()
+  const store = useKingOfShojoSearchStore()
+  const comicsApi = createComicsApi()
+  const { t } = useI18n()
+  const toast = useToast()
+  const { smAndDown } = useDisplay()
+
+  const search = computed({
+    get: () => store.search,
+    set: (value?: string) => value ? store.setSearch(value) : store.clearSearch(),
+  })
+
+  const sort = computed({
+    get: () => store.sort,
+    set: (value: KingOfShojoSort) => store.setSort(value),
+  })
+
+  const status = computed({
+    get: () => store.status,
+    set: (value?: ComicStatus) => value ? store.setStatus(value) : store.clearStatus(),
+  })
+
+  const type = computed({
+    get: () => store.type,
+    set: (value?: ComicType) => value ? store.setType(value) : store.clearType(),
+  })
+
+  const offset = computed({
+    get: () => store.offset,
+    set: (value: number) => store.setOffset(value),
+  })
+
+  const isLoading = computed({
+    get: () => store.loading,
+    set: (isLoadingValue: boolean) => store.setLoading(isLoadingValue),
+  })
+
+  const comics = computed({
+    get: () => store.comics,
+    set: (value: KingOfShojoSearchItem[]) => store.setComics(value),
+  })
+
+  const accumulatedComics = computed({
+    get: () => store.accumulatedComics,
+    set: (value: KingOfShojoSearchItem[]) => store.setAccumulatedComics(value),
+  })
+
+  function resetFilters(): void {
+    store.invalidate()
+  }
+
+  const maxPage = ref(0)
+  const addComicInLibraryLoading = ref<Record<string, boolean>>({})
+
+  const debouncedSearchFn = useDebounceFn(async () => {
+    isLoading.value = true
+
+    const res = await api.search({
+      ...(search.value && { search: search.value }),
+      ...(sort.value && { sort: sort.value }),
+      ...(status.value && { status: status.value }),
+      ...(type.value && { type: type.value }),
+      offset: offset.value,
+      limit: PAGE_SIZE,
+    })
+
+    isLoading.value = false
+
+    if (!res.success) {
+      toast.error(t('sources.kingofshojo.search.error'))
+
+      accumulatedComics.value = []
+      maxPage.value = 0
+      comics.value = []
+
+      return
+    }
+
+    if (smAndDown.value) {
+      accumulatedComics.value = [...accumulatedComics.value, ...res.data.items]
+    }
+
+    maxPage.value = Math.ceil(res.data.total / PAGE_SIZE)
+    comics.value = res.data.items
+  }, 200)
+
+  watch([search, sort, status, type], () => {
+    offset.value = 0
+    accumulatedComics.value = []
+    comics.value = []
+  })
+
+  watch([search, sort, status, type, offset], () => {
+    if (opts.doSearch) {
+      debouncedSearchFn()
+    }
+  }, { immediate: true })
+
+  async function removeComicFromLibrary(comic: KingOfShojoSearchItem): Promise<boolean> {
+    if (!comic.internalId) {
+      return false
+    }
+
+    const res = await comicsApi.deleteById(comic.internalId)
+    if (!res.success) {
+      console.error('comicsApi.deleteById failed', res.error)
+      toast.error(t('error.unknown'))
+
+      return false
+    }
+
+    store.setComicInternalId(comic.slug, undefined)
+
+    return true
+  }
+
+  async function addComicInLibrary(comic: KingOfShojoSearchItem | KingOfShojoComicInfos): Promise<string | undefined> {
+    if (Object.hasOwn(addComicInLibraryLoading.value, comic.slug) || comic.internalId) {
+      return
+    }
+
+    addComicInLibraryLoading.value[comic.slug] = true
+
+    const res = await comicsApi.create({ source: KING_OF_SHOJO_SOURCE_NAME, slug: comic.slug })
+    if (!res.success) {
+      if (res.error.status === 409) {
+        toast.error(t('comics.create.error.alreadyExists'))
+
+        delete addComicInLibraryLoading.value[comic.slug]
+
+        return
+      }
+
+      console.error('comicsApi.create failed', res.error)
+      toast.error(t('error.unknown'))
+
+      delete addComicInLibraryLoading.value[comic.slug]
+
+      return
+    }
+
+    store.setComicInternalId(comic.slug, res.data.id)
+
+    delete addComicInLibraryLoading.value[comic.slug]
+
+    return res.data.id
+  }
+
+  return {
+    search,
+    sort,
+    status,
+    type,
+    page: offset,
+    maxPage,
+    series: computed(() => smAndDown.value ? accumulatedComics.value : comics.value),
+    isLoading,
+    resetFilters,
+
+    addComicInLibrary,
+    addComicInLibraryLoading,
+    removeComicFromLibrary,
+  }
+}

--- a/web/app/features/kingofshojo/composables/kingofshojo.api.test.ts
+++ b/web/app/features/kingofshojo/composables/kingofshojo.api.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ASURA_SOURCE_NAME } from '~/constants'
+import { KING_OF_SHOJO_SOURCE_NAME } from '~/constants'
 import { createKingOfShojoApi } from './kingofshojo.api'
 
 const mocks = vi.hoisted(() => {
@@ -52,57 +52,56 @@ beforeEach(() => {
 })
 
 describe('createKingOfShojoApi', () => {
-  it('uses ASURA_SOURCE_NAME as the API prefix', () => {
+  it('uses KING_OF_SHOJO_SOURCE_NAME as the API prefix', () => {
     createKingOfShojoApi()
-    expect(mocks.initApi).toHaveBeenCalledWith(`/sources/${ASURA_SOURCE_NAME}`)
+    expect(mocks.initApi).toHaveBeenCalledWith(`/sources/${KING_OF_SHOJO_SOURCE_NAME}`)
   })
 })
 
 describe('createKingOfShojoApi().search', () => {
-  it('requests /search with pagination', async () => {
-    mocks.call.mockResolvedValue({ items: [rawItem], total: 1 })
+  it('requests /search with page', async () => {
+    mocks.call.mockResolvedValue({ items: [rawItem], hasNextPage: true })
 
-    const res = await createKingOfShojoApi().search({ offset: 0, limit: 20, sort: 'popular' })
+    const res = await createKingOfShojoApi().search({ page: 1, sort: 'popular' })
 
     expect(mocks.call).toHaveBeenCalledWith('/search', {
       method: 'GET',
-      params: { sort: 'popular', offset: 0, limit: 20 },
+      params: { sort: 'popular', page: 1 },
     })
-    expect(res).toEqual({ success: true, data: { items: [item], total: 1 } })
+    expect(res).toEqual({ success: true, data: { items: [item], hasNextPage: true } })
   })
 
   it('omits empty optional filters', async () => {
-    mocks.call.mockResolvedValue({ items: [], total: 0 })
+    mocks.call.mockResolvedValue({ items: [], hasNextPage: false })
 
-    await createKingOfShojoApi().search({ offset: 0, limit: 20 })
+    await createKingOfShojoApi().search({ page: 1 })
 
     expect(mocks.call).toHaveBeenCalledWith('/search', {
       method: 'GET',
-      params: { offset: 0, limit: 20 },
+      params: { page: 1 },
     })
   })
 
   it('includes status, type and search when set', async () => {
-    mocks.call.mockResolvedValue({ items: [], total: 0 })
+    mocks.call.mockResolvedValue({ items: [], hasNextPage: false })
 
     await createKingOfShojoApi().search({
       search: 'solo',
       status: 'ongoing',
       type: 'manhwa',
-      offset: 20,
-      limit: 20,
+      page: 2,
     })
 
     expect(mocks.call).toHaveBeenCalledWith('/search', {
       method: 'GET',
-      params: { search: 'solo', status: 'ongoing', type: 'manhwa', offset: 20, limit: 20 },
+      params: { search: 'solo', status: 'ongoing', type: 'manhwa', page: 2 },
     })
   })
 
   it('surfaces a failure with its status', async () => {
     mocks.call.mockRejectedValue({ statusCode: 502, data: {} })
 
-    const res = await createKingOfShojoApi().search({ offset: 0, limit: 20 })
+    const res = await createKingOfShojoApi().search({ page: 1 })
 
     expect(res.success === false && res.error.status).toBe(502)
   })

--- a/web/app/features/kingofshojo/composables/kingofshojo.api.test.ts
+++ b/web/app/features/kingofshojo/composables/kingofshojo.api.test.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ASURA_SOURCE_NAME } from '~/constants'
+import { createKingOfShojoApi } from './kingofshojo.api'
+
+const mocks = vi.hoisted(() => {
+  const call = vi.fn()
+  const initApi = vi.fn(() => call)
+
+  return { call, initApi }
+})
+
+vi.mock('~/utils/api', async importOriginal => ({
+  ...(await importOriginal<typeof import('~/utils/api')>()),
+  initApi: mocks.initApi,
+}))
+
+const rawItem = {
+  slug: 'solo-leveling',
+  title: 'Solo Leveling',
+  cover: '/api/sources/cover/solo-leveling?source=kingofshojo',
+  status: 'ongoing',
+  type: 'manhwa',
+  chapterCount: 12,
+  lastChapterAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  publicUrl: '',
+  sourceUrl: '',
+  author: '',
+  artist: '',
+  description: '',
+  altTitles: [] as string[],
+  genres: [] as string[],
+  latestChapters: [] as [],
+  rating: 0,
+  releaseYear: 2020,
+}
+
+const item = {
+  ...rawItem,
+  lastChapterAt: new Date(rawItem.lastChapterAt),
+  updatedAt: new Date(rawItem.updatedAt),
+  createdAt: new Date(rawItem.createdAt),
+  latestChapters: [],
+}
+
+beforeEach(() => {
+  mocks.call.mockReset()
+  mocks.initApi.mockClear()
+})
+
+describe('createKingOfShojoApi', () => {
+  it('uses ASURA_SOURCE_NAME as the API prefix', () => {
+    createKingOfShojoApi()
+    expect(mocks.initApi).toHaveBeenCalledWith(`/sources/${ASURA_SOURCE_NAME}`)
+  })
+})
+
+describe('createKingOfShojoApi().search', () => {
+  it('requests /search with pagination', async () => {
+    mocks.call.mockResolvedValue({ items: [rawItem], total: 1 })
+
+    const res = await createKingOfShojoApi().search({ offset: 0, limit: 20, sort: 'popular' })
+
+    expect(mocks.call).toHaveBeenCalledWith('/search', {
+      method: 'GET',
+      params: { sort: 'popular', offset: 0, limit: 20 },
+    })
+    expect(res).toEqual({ success: true, data: { items: [item], total: 1 } })
+  })
+
+  it('omits empty optional filters', async () => {
+    mocks.call.mockResolvedValue({ items: [], total: 0 })
+
+    await createKingOfShojoApi().search({ offset: 0, limit: 20 })
+
+    expect(mocks.call).toHaveBeenCalledWith('/search', {
+      method: 'GET',
+      params: { offset: 0, limit: 20 },
+    })
+  })
+
+  it('includes status, type and search when set', async () => {
+    mocks.call.mockResolvedValue({ items: [], total: 0 })
+
+    await createKingOfShojoApi().search({
+      search: 'solo',
+      status: 'ongoing',
+      type: 'manhwa',
+      offset: 20,
+      limit: 20,
+    })
+
+    expect(mocks.call).toHaveBeenCalledWith('/search', {
+      method: 'GET',
+      params: { search: 'solo', status: 'ongoing', type: 'manhwa', offset: 20, limit: 20 },
+    })
+  })
+
+  it('surfaces a failure with its status', async () => {
+    mocks.call.mockRejectedValue({ statusCode: 502, data: {} })
+
+    const res = await createKingOfShojoApi().search({ offset: 0, limit: 20 })
+
+    expect(res.success === false && res.error.status).toBe(502)
+  })
+})

--- a/web/app/features/kingofshojo/composables/kingofshojo.api.ts
+++ b/web/app/features/kingofshojo/composables/kingofshojo.api.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { KingOfShojoComicChapter, KingOfShojoComicInfos, KingOfShojoSearchParams, KingOfShojoSearchResponse } from '../types'
+import type { ApiResponse } from '~/utils/api'
+import { KING_OF_SHOJO_SOURCE_NAME } from '~/constants'
+import { ApiError, initApi } from '~/utils/api'
+
+export interface KingOfShojoApi {
+  search: (params: KingOfShojoSearchParams) => Promise<ApiResponse<KingOfShojoSearchResponse>>
+  getInfosBySlug: (slug: string) => Promise<ApiResponse<KingOfShojoComicInfos>>
+  getSeriesChapters: (slug: string) => Promise<ApiResponse<KingOfShojoComicChapter[]>>
+}
+
+export function createKingOfShojoApi(): KingOfShojoApi {
+  const api = initApi(`/sources/${KING_OF_SHOJO_SOURCE_NAME}`)
+
+  async function search(params: KingOfShojoSearchParams): Promise<ApiResponse<KingOfShojoSearchResponse>> {
+    try {
+      const response = await api<KingOfShojoSearchResponse>('/search', { method: 'GET', params: {
+        ...(params.search && { search: params.search }),
+        ...(params.sort && { sort: params.sort }),
+        ...(params.status && { status: params.status }),
+        ...(params.type && { type: params.type }),
+        ...(params.artist && { artist: params.artist }),
+        ...(params.offset >= 0 && { offset: params.offset }),
+        ...(params.limit > 0 && { limit: params.limit }),
+      } })
+
+      return {
+        success: true,
+        data: {
+          total: response.total,
+          items: response.items.map(({ lastChapterAt, updatedAt, createdAt, ...rest }) => ({
+            ...rest,
+            ...(lastChapterAt && { lastChapterAt: new Date(lastChapterAt) }),
+            updatedAt: new Date(updatedAt),
+            createdAt: new Date(createdAt),
+          })),
+        },
+      }
+    } catch (error) {
+      return { success: false, error: ApiError.fromFetchError(error) }
+    }
+  }
+
+  async function getInfosBySlug(slug: string): Promise<ApiResponse<KingOfShojoComicInfos>> {
+    try {
+      const {
+        lastChapterAt,
+        updatedAt,
+        createdAt,
+        ...rest
+      } = await api<KingOfShojoComicInfos>(`/series/${slug}`, { method: 'GET' })
+
+      return {
+        success: true,
+        data: {
+          ...rest,
+          ...(lastChapterAt && { lastChapterAt: new Date(lastChapterAt) }),
+          updatedAt: new Date(updatedAt),
+          createdAt: new Date(createdAt),
+        },
+      }
+    } catch (error) {
+      return { success: false, error: ApiError.fromFetchError(error) }
+    }
+  }
+
+  async function getSeriesChapters(slug: string): Promise<ApiResponse<KingOfShojoComicChapter[]>> {
+    try {
+      const response = await api<KingOfShojoComicChapter[]>(`/series/${slug}/chapters`, { method: 'GET' })
+
+      return {
+        success: true,
+        data: response.map(({ earlyAccessUntil, publishedAt, ...rest }) => ({
+          ...rest,
+          ...(earlyAccessUntil && { earlyAccessUntil: new Date(earlyAccessUntil) }),
+          publishedAt: new Date(publishedAt),
+        })),
+      }
+    } catch (error) {
+      return { success: false, error: ApiError.fromFetchError(error) }
+    }
+  }
+
+  return {
+    search,
+    getInfosBySlug,
+    getSeriesChapters,
+  }
+}

--- a/web/app/features/kingofshojo/composables/kingofshojo.api.ts
+++ b/web/app/features/kingofshojo/composables/kingofshojo.api.ts
@@ -22,14 +22,13 @@ export function createKingOfShojoApi(): KingOfShojoApi {
         ...(params.status && { status: params.status }),
         ...(params.type && { type: params.type }),
         ...(params.artist && { artist: params.artist }),
-        ...(params.offset >= 0 && { offset: params.offset }),
-        ...(params.limit > 0 && { limit: params.limit }),
+        ...(params.page >= 1 && { page: params.page }),
       } })
 
       return {
         success: true,
         data: {
-          total: response.total,
+          hasNextPage: response.hasNextPage,
           items: response.items.map(({ lastChapterAt, updatedAt, createdAt, ...rest }) => ({
             ...rest,
             ...(lastChapterAt && { lastChapterAt: new Date(lastChapterAt) }),

--- a/web/app/features/kingofshojo/stores/kingofshojo-search.store.test.ts
+++ b/web/app/features/kingofshojo/stores/kingofshojo-search.store.test.ts
@@ -19,7 +19,6 @@ function item(slug: string, internalId?: string): KingOfShojoSearchItem {
     description: '',
     altTitles: [],
     genres: [],
-    latestChapters: [],
     chapterCount: 1,
     rating: 0,
     releaseYear: 2020,

--- a/web/app/features/kingofshojo/stores/kingofshojo-search.store.test.ts
+++ b/web/app/features/kingofshojo/stores/kingofshojo-search.store.test.ts
@@ -34,11 +34,11 @@ describe('useKingOfShojoSearchStore', () => {
     setActivePinia(createPinia())
   })
 
-  it('starts with default sort and offset', () => {
+  it('starts with default sort and page', () => {
     const store = useKingOfShojoSearchStore()
 
     expect(store.sort).toBe('popular')
-    expect(store.offset).toBe(1)
+    expect(store.page).toBe(1)
     expect(store.comics).toEqual([])
   })
 
@@ -73,13 +73,13 @@ describe('useKingOfShojoSearchStore', () => {
     store.setSearch('solo')
     store.setSort('title')
     store.setComics([item('solo-leveling')])
-    store.setOffset(3)
+    store.setPage(3)
 
     store.invalidate()
 
     expect(store.search).toBeUndefined()
     expect(store.sort).toBe('popular')
-    expect(store.offset).toBe(1)
+    expect(store.page).toBe(1)
     expect(store.comics).toEqual([])
   })
 })

--- a/web/app/features/kingofshojo/stores/kingofshojo-search.store.test.ts
+++ b/web/app/features/kingofshojo/stores/kingofshojo-search.store.test.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { KingOfShojoSearchItem } from '../types'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useKingOfShojoSearchStore } from './kingofshojo-search.store'
+
+function item(slug: string, internalId?: string): KingOfShojoSearchItem {
+  return {
+    slug,
+    title: slug,
+    cover: `/cover/${slug}`,
+    publicUrl: '',
+    sourceUrl: '',
+    status: 'ongoing',
+    type: 'manhwa',
+    author: '',
+    artist: '',
+    description: '',
+    altTitles: [],
+    genres: [],
+    latestChapters: [],
+    chapterCount: 1,
+    rating: 0,
+    releaseYear: 2020,
+    lastChapterAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    createdAt: new Date('2026-01-01'),
+    ...(internalId && { internalId }),
+  }
+}
+
+describe('useKingOfShojoSearchStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('starts with default sort and offset', () => {
+    const store = useKingOfShojoSearchStore()
+
+    expect(store.sort).toBe('popular')
+    expect(store.offset).toBe(1)
+    expect(store.comics).toEqual([])
+  })
+
+  it('setComics replaces the current page', () => {
+    const store = useKingOfShojoSearchStore()
+    store.setComics([item('solo-leveling')])
+    expect(store.comics).toHaveLength(1)
+  })
+
+  it('setComicInternalId updates the matching slug', () => {
+    const store = useKingOfShojoSearchStore()
+    store.setComics([item('solo-leveling')])
+    store.setAccumulatedComics([item('solo-leveling')])
+
+    store.setComicInternalId('solo-leveling', 'c1')
+
+    expect(store.comics[0]?.internalId).toBe('c1')
+    expect(store.accumulatedComics[0]?.internalId).toBe('c1')
+  })
+
+  it('setComicInternalId ignores an unknown slug', () => {
+    const store = useKingOfShojoSearchStore()
+    store.setComics([item('solo-leveling')])
+
+    store.setComicInternalId('one-piece', 'c1')
+
+    expect(store.comics[0]?.internalId).toBeUndefined()
+  })
+
+  it('invalidate restores defaults', () => {
+    const store = useKingOfShojoSearchStore()
+    store.setSearch('solo')
+    store.setSort('title')
+    store.setComics([item('solo-leveling')])
+    store.setOffset(3)
+
+    store.invalidate()
+
+    expect(store.search).toBeUndefined()
+    expect(store.sort).toBe('popular')
+    expect(store.offset).toBe(1)
+    expect(store.comics).toEqual([])
+  })
+})

--- a/web/app/features/kingofshojo/stores/kingofshojo-search.store.ts
+++ b/web/app/features/kingofshojo/stores/kingofshojo-search.store.ts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { KingOfShojoSearchItem, KingOfShojoSort } from '../types'
+import type { ComicStatus, ComicType } from '~/features/comics/types'
+
+const DEFAULT_SORT: KingOfShojoSort = 'popular'
+const DEFAULT_OFFSET = 1
+
+export interface KingOfShojoSearchStore {
+  comics: Ref<KingOfShojoSearchItem[]>
+  setComics: (comics: KingOfShojoSearchItem[]) => void
+  clearComics: () => void
+
+  accumulatedComics: Ref<KingOfShojoSearchItem[]>
+  setAccumulatedComics: (comics: KingOfShojoSearchItem[]) => void
+  clearAccumulatedComics: () => void
+
+  setComicInternalId: (slug: string, internalId: string | undefined) => void
+
+  loading: Ref<boolean>
+  setLoading: (isLoading: boolean) => void
+  clearLoading: () => void
+
+  search: Ref<string | undefined>
+  setSearch: (value: string) => void
+  clearSearch: () => void
+
+  sort: Ref<KingOfShojoSort>
+  setSort: (value: KingOfShojoSort) => void
+  clearSort: () => void
+
+  status: Ref<ComicStatus | undefined>
+  setStatus: (value: ComicStatus) => void
+  clearStatus: () => void
+
+  type: Ref<ComicType | undefined>
+  setType: (value: ComicType) => void
+  clearType: () => void
+
+  offset: Ref<number>
+  setOffset: (value: number) => void
+  clearOffset: () => void
+
+  invalidate: () => void
+}
+
+export const useKingOfShojoSearchStore = defineStore('kingofshojo-search', (): KingOfShojoSearchStore => {
+  const search = ref<string>()
+  const sort = ref<KingOfShojoSort>(DEFAULT_SORT)
+  const status = ref<ComicStatus>()
+  const type = ref<ComicType>()
+  const offset = ref<number>(DEFAULT_OFFSET)
+  const loading = ref<boolean>(false)
+
+  const comics = ref<KingOfShojoSearchItem[]>([])
+  const accumulatedComics = ref<KingOfShojoSearchItem[]>([])
+
+  function setComics(value: KingOfShojoSearchItem[]): void {
+    comics.value = [...value]
+  }
+
+  function clearComics(): void {
+    comics.value = []
+  }
+
+  function setAccumulatedComics(value: KingOfShojoSearchItem[]): void {
+    accumulatedComics.value = [...value]
+  }
+
+  function clearAccumulatedComics(): void {
+    accumulatedComics.value = []
+  }
+
+  function setLoading(isLoading: boolean): void {
+    loading.value = isLoading
+  }
+
+  function clearLoading(): void {
+    loading.value = false
+  }
+
+  function setComicInternalId(slug: string, internalId: string | undefined): void {
+    let i = comics.value.findIndex(c => c.slug === slug)
+    if (i === -1) {
+      return
+    }
+
+    const { internalId: _, ...comic } = comics.value[i]!
+
+    comics.value[i] = { ...comic, internalId }
+
+    i = accumulatedComics.value.findIndex(c => c.slug === slug)
+    if (i === -1) {
+      return
+    }
+
+    accumulatedComics.value[i] = { ...comic, internalId }
+  }
+
+  function setSearch(value: string): void {
+    search.value = value
+  }
+
+  function clearSearch(): void {
+    search.value = undefined
+  }
+
+  function setSort(value: KingOfShojoSort): void {
+    sort.value = value
+  }
+
+  function clearSort(): void {
+    sort.value = DEFAULT_SORT
+  }
+
+  function setStatus(value: ComicStatus): void {
+    status.value = value
+  }
+
+  function clearStatus(): void {
+    status.value = undefined
+  }
+
+  function setType(value: ComicType): void {
+    type.value = value
+  }
+
+  function clearType(): void {
+    type.value = undefined
+  }
+
+  function setOffset(value: number): void {
+    offset.value = value
+  }
+
+  function clearOffset(): void {
+    offset.value = DEFAULT_OFFSET
+  }
+
+  function invalidate(): void {
+    clearSearch()
+    clearSort()
+    clearStatus()
+    clearType()
+    clearOffset()
+    clearLoading()
+    clearComics()
+    clearAccumulatedComics()
+  }
+
+  return {
+    comics,
+    setComics,
+    clearComics,
+
+    accumulatedComics,
+    setAccumulatedComics,
+    clearAccumulatedComics,
+
+    setComicInternalId,
+
+    loading,
+    setLoading,
+    clearLoading,
+
+    search,
+    setSearch,
+    clearSearch,
+
+    sort,
+    setSort,
+    clearSort,
+
+    status,
+    setStatus,
+    clearStatus,
+
+    type,
+    setType,
+    clearType,
+
+    offset,
+    setOffset,
+    clearOffset,
+
+    invalidate,
+  }
+})

--- a/web/app/features/kingofshojo/stores/kingofshojo-search.store.ts
+++ b/web/app/features/kingofshojo/stores/kingofshojo-search.store.ts
@@ -4,7 +4,7 @@ import type { KingOfShojoSearchItem, KingOfShojoSort } from '../types'
 import type { ComicStatus, ComicType } from '~/features/comics/types'
 
 const DEFAULT_SORT: KingOfShojoSort = 'popular'
-const DEFAULT_OFFSET = 1
+const DEFAULT_PAGE = 1
 
 export interface KingOfShojoSearchStore {
   comics: Ref<KingOfShojoSearchItem[]>
@@ -37,9 +37,9 @@ export interface KingOfShojoSearchStore {
   setType: (value: ComicType) => void
   clearType: () => void
 
-  offset: Ref<number>
-  setOffset: (value: number) => void
-  clearOffset: () => void
+  page: Ref<number>
+  setPage: (value: number) => void
+  clearPage: () => void
 
   invalidate: () => void
 }
@@ -49,7 +49,7 @@ export const useKingOfShojoSearchStore = defineStore('kingofshojo-search', (): K
   const sort = ref<KingOfShojoSort>(DEFAULT_SORT)
   const status = ref<ComicStatus>()
   const type = ref<ComicType>()
-  const offset = ref<number>(DEFAULT_OFFSET)
+  const page = ref<number>(DEFAULT_PAGE)
   const loading = ref<boolean>(false)
 
   const comics = ref<KingOfShojoSearchItem[]>([])
@@ -129,12 +129,12 @@ export const useKingOfShojoSearchStore = defineStore('kingofshojo-search', (): K
     type.value = undefined
   }
 
-  function setOffset(value: number): void {
-    offset.value = value
+  function setPage(value: number): void {
+    page.value = value
   }
 
-  function clearOffset(): void {
-    offset.value = DEFAULT_OFFSET
+  function clearPage(): void {
+    page.value = DEFAULT_PAGE
   }
 
   function invalidate(): void {
@@ -142,7 +142,7 @@ export const useKingOfShojoSearchStore = defineStore('kingofshojo-search', (): K
     clearSort()
     clearStatus()
     clearType()
-    clearOffset()
+    clearPage()
     clearLoading()
     clearComics()
     clearAccumulatedComics()
@@ -179,9 +179,9 @@ export const useKingOfShojoSearchStore = defineStore('kingofshojo-search', (): K
     setType,
     clearType,
 
-    offset,
-    setOffset,
-    clearOffset,
+    page,
+    setPage,
+    clearPage,
 
     invalidate,
   }

--- a/web/app/features/kingofshojo/types.ts
+++ b/web/app/features/kingofshojo/types.ts
@@ -1,0 +1,70 @@
+import type { ComicStatus, ComicType } from '../comics/types'
+
+export type KingOfShojoSort = 'popular' | 'latest' | 'title' | 'newest'
+export interface KingOfShojoSearchParams {
+  search?: string
+  sort?: KingOfShojoSort
+  status?: ComicStatus
+  type?: ComicType
+  artist?: string
+  offset: number
+  limit: number
+}
+
+export interface KingOfShojoSearchResponse {
+  items: KingOfShojoSearchItem[]
+  total: number
+}
+
+export interface KingOfShojoSearchItem {
+  lastChapterAt?: Date
+  updatedAt: Date
+  createdAt: Date
+  internalId?: string
+  description: string
+  slug: string
+  status: ComicStatus
+  type: ComicType
+  author: string
+  artist: string
+  sourceUrl: string
+  cover: string
+  title: string
+  publicUrl: string
+  genres: string[]
+  altTitles: string[]
+  chapterCount: number
+  rating: number
+  releaseYear: number
+}
+
+export interface KingOfShojoComicInfos {
+  lastChapterAt?: Date
+  updatedAt: Date
+  createdAt: Date
+  internalId?: string
+  author: string
+  publicUrl: string
+  status: ComicStatus
+  type: ComicType
+  title: string
+  artist: string
+  sourceUrl: string
+  cover: string
+  slug: string
+  description: string
+  genres: string[]
+  altTitles: string[]
+  chapterCount: number
+  rating: number
+}
+
+export interface KingOfShojoComicChapter {
+  earlyAccessUntil?: Date
+  publishedAt: Date
+  internalId?: string
+  download?: number
+  id: string
+  title: string
+  number: number
+}

--- a/web/app/features/kingofshojo/types.ts
+++ b/web/app/features/kingofshojo/types.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import type { ComicStatus, ComicType } from '../comics/types'
 
 export type KingOfShojoSort = 'popular' | 'latest' | 'title' | 'newest'
@@ -7,13 +9,12 @@ export interface KingOfShojoSearchParams {
   status?: ComicStatus
   type?: ComicType
   artist?: string
-  offset: number
-  limit: number
+  page: number
 }
 
 export interface KingOfShojoSearchResponse {
   items: KingOfShojoSearchItem[]
-  total: number
+  hasNextPage: boolean
 }
 
 export interface KingOfShojoSearchItem {

--- a/web/app/features/sources/components/Card/Comic.vue
+++ b/web/app/features/sources/components/Card/Comic.vue
@@ -1,17 +1,24 @@
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script setup lang="ts">
-import type { AsuraScansSearchItem } from '../types'
+import type { RouteLocationRaw } from 'vue-router'
+import type { ComicStatus } from '~/features/comics/types'
 import defaultCover from '~/assets/images/default/comic-cover.webp'
-import { ASURA_SOURCE_NAME } from '~/constants'
 
 const props = defineProps<{
-  comic: AsuraScansSearchItem
+  internalId?: string
+  status?: ComicStatus
+  to: RouteLocationRaw
+  cover: string
+  title: string
+  chapterCount: number
+  chapterCountLoading?: boolean
   loading?: boolean
+  statusLoading?: boolean
 }>()
+
 defineEmits<{ toggle: [] }>()
 
-const src = ref<string>(props.comic.cover)
-watch(() => props.comic.cover, (newVal) => {
+const src = ref<string>(props.cover)
+watch(() => props.cover, (newVal) => {
   src.value = newVal
 }, { immediate: true })
 
@@ -21,7 +28,7 @@ const canHover = useMediaQuery('(hover: hover) and (pointer: fine)')
 <template>
   <VHover :disabled="!canHover">
     <template #default="{ isHovering, props: hoverProps }">
-      <AtomLink :to="`/browse/sources/${ASURA_SOURCE_NAME}/${comic.slug}`" v-bind="hoverProps">
+      <AtomLink :to v-bind="hoverProps">
         <div class="d-flex flex-column comic-card w-100 h-100">
           <VImg
             cover
@@ -31,28 +38,37 @@ const canHover = useMediaQuery('(hover: hover) and (pointer: fine)')
             :lazy-src="defaultCover"
             width="100%"
             class="border-thin rounded-lg position-relative"
-            :class="{ 'cover-in-library': comic.internalId }"
+            :class="{ 'cover-in-library': internalId }"
             @error="src = defaultCover"
           >
             <div class="d-flex w-100 justify-space-between position-absolute pa-2 top-0 left-0" style="z-index: 1;">
               <AsuraScansBtnDelete
-                v-if="comic.internalId"
+                v-if="internalId"
                 :mode="isHovering ? 'btn' : 'label'"
                 @click.prevent="$emit('toggle')"
               />
               <AsuraScansBtnAdd
                 v-else
-                :is-in-library="!!comic.internalId"
+                :is-in-library="!!internalId"
                 :loading
                 class="add-library-btn"
                 :class="{ 'add-library-btn-loading': loading }"
                 @click.prevent="$emit('toggle')"
               />
-              <ComicsIconStatus :status="comic.status" with-background />
+              <ComicsIconStatus
+                :status
+                with-background
+                :loading="statusLoading"
+              />
             </div>
           </VImg>
-          <span class="text-body-large font-weight-bold text-truncate mt-2 comic-card-title">{{ comic.title }}</span>
-          <span class="text-body-medium text-medium-emphasis">{{ $t('sources.asurascans.comic.chaptersCount', { count: comic.chapterCount }) }}</span>
+          <span class="text-body-large font-weight-bold text-truncate mt-2 comic-card-title">{{ title }}</span>
+          <VSkeletonLoader
+            v-if="chapterCountLoading"
+            type="text"
+            class="mt-1 w-33"
+          />
+          <span v-else class="text-body-medium text-medium-emphasis">{{ $t('sources.asurascans.comic.chaptersCount', { count: chapterCount }) }}</span>
         </div>
       </AtomLink>
     </template>

--- a/web/app/features/sources/composables/sources.composable.ts
+++ b/web/app/features/sources/composables/sources.composable.ts
@@ -1,0 +1,6 @@
+import type { AsuraScansComicChapter } from '~/features/asurascans/types'
+import type { KingOfShojoComicChapter } from '~/features/kingofshojo/types'
+
+export function isChapterDownloadInProgress(chapter: KingOfShojoComicChapter | AsuraScansComicChapter): boolean {
+  return chapter.download !== undefined && chapter.download >= 0 && chapter.download < 100
+}

--- a/web/app/pages/browse/sources/asurascans/index.test.ts
+++ b/web/app/pages/browse/sources/asurascans/index.test.ts
@@ -9,13 +9,13 @@ import { defineComponent, h } from 'vue'
 import { VApp } from 'vuetify/components'
 import AsuraIndex from './index.vue'
 
-const { series, isLoading, maxPage, smAndDown, page, addComicInLibraryLoading } = await vi.hoisted(async () => {
+const { series, isLoading, hasNextPage, smAndDown, page, addComicInLibraryLoading } = await vi.hoisted(async () => {
   const { ref } = await import('vue')
 
   return {
     series: ref<AsuraScansSearchItem[]>([]),
     isLoading: ref(false),
-    maxPage: ref(1),
+    hasNextPage: ref(false),
     smAndDown: ref(false),
     page: ref(1),
     addComicInLibraryLoading: ref<Record<string, boolean>>({}),
@@ -27,7 +27,7 @@ vi.mock('~/features/asurascans/composables/asurascans-search.composable', () => 
     isLoading,
     series,
     page,
-    maxPage,
+    hasNextPage,
     addComicInLibrary: vi.fn(),
     addComicInLibraryLoading,
   }),
@@ -106,7 +106,7 @@ function item(): AsuraScansSearchItem {
 beforeEach(() => {
   series.value = []
   isLoading.value = false
-  maxPage.value = 1
+  hasNextPage.value = false
   smAndDown.value = false
 })
 

--- a/web/app/pages/browse/sources/asurascans/index.vue
+++ b/web/app/pages/browse/sources/asurascans/index.vue
@@ -33,12 +33,11 @@ const {
   isLoading,
   series,
   page,
-  maxPage,
+  hasNextPage,
   addComicInLibrary,
   addComicInLibraryLoading,
   resetFilters,
 } = useAsuraScansSearch({ doSearch: true })
-const hasNextPage = computed(() => page.value < maxPage.value)
 const loadMoreSentinel = useTemplateRef<HTMLElement>('loadMoreSentinel')
 useIntersectionObserver(loadMoreSentinel, ([entry]) => {
   if (entry?.isIntersecting && smAndDown.value && !isLoading.value && hasNextPage.value) {
@@ -118,7 +117,6 @@ onBeforeRouteLeave((to: RouteLocationNormalized) => {
     <MoleculePaginationFooter
       v-if="!smAndDown"
       v-model="page"
-      :pages-total="maxPage"
       :has-next-page
       fixed
     />

--- a/web/app/pages/browse/sources/kingofshojo/index.vue
+++ b/web/app/pages/browse/sources/kingofshojo/index.vue
@@ -1,0 +1,144 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+import type { RouteLocationNormalized } from 'vue-router'
+import type { PageLayoutBackRoute } from '~/components/Organism/PageLayout.vue'
+import type { KingOfShojoSearchItem } from '~/features/kingofshojo/types'
+import kingOfShojoImg from '~/assets/images/sources/kingofshojo.webp'
+import { AUTHENTICATED_ROUTE_GROUP } from '~/constants/auth'
+
+definePageMeta({
+  layout: 'default',
+  authGroups: [AUTHENTICATED_ROUTE_GROUP],
+})
+
+const { t } = useI18n()
+const { smAndDown } = useDisplay()
+
+const backRoutes = computed((): PageLayoutBackRoute[] => [
+  ...(smAndDown.value
+    ? [
+        {
+          name: t('browse.title'),
+          to: '/browse',
+        },
+      ]
+    : []),
+  {
+    name: t('sources.title'),
+    to: '/browse/sources',
+  },
+])
+
+const {
+  isLoading,
+  series,
+  page,
+  maxPage,
+  addComicInLibrary,
+  addComicInLibraryLoading,
+  resetFilters,
+} = useKingOfShojoSearch({ doSearch: true })
+const hasNextPage = computed(() => page.value < maxPage.value)
+const loadMoreSentinel = useTemplateRef<HTMLElement>('loadMoreSentinel')
+useIntersectionObserver(loadMoreSentinel, ([entry]) => {
+  if (entry?.isIntersecting && smAndDown.value && !isLoading.value && hasNextPage.value) {
+    page.value += 1
+  }
+})
+
+const showDeleteModal = ref(false)
+const comicToDelete = ref<KingOfShojoSearchItem>()
+
+async function doToggleComic(comic: KingOfShojoSearchItem): Promise<void> {
+  if (comic.internalId) {
+    comicToDelete.value = comic
+    showDeleteModal.value = true
+  } else {
+    await addComicInLibrary(comic)
+  }
+}
+
+onBeforeRouteLeave((to: RouteLocationNormalized) => {
+  if (to.name !== 'browse-sources-kingofshojo-slug') {
+    resetFilters()
+  }
+})
+</script>
+
+<template>
+  <OrganismPageLayout
+    :title="$t('sources.kingofshojo.title')"
+    :back-routes
+    :loading="isLoading"
+  >
+    <template #prepend-title>
+      <img
+        aspect-ratio="1"
+        :src="kingOfShojoImg"
+        class="border-thin rounded-lg"
+        style="height: 48px;"
+      >
+    </template>
+
+    <template #sub-header>
+      <KingOfShojoHeader />
+    </template>
+    <KingOfShojoModalDelete v-model="showDeleteModal" v-model:comic="comicToDelete" />
+
+    <div class="pt-6" :class="{ 'px-4': smAndDown }">
+      <div v-if="!isLoading && series.length === 0" class="d-flex justify-center">
+        <span class="text-medium-emphasis text-body-large"> {{ $t('errors.noResults') }} </span>
+      </div>
+
+      <div class="comics-grid">
+        <KingOfShojoComicCard
+          v-for="(comic, i) in series"
+          :key="i"
+          :comic
+          :loading="addComicInLibraryLoading[comic.slug]"
+          @toggle="doToggleComic(comic)"
+        />
+      </div>
+    </div>
+
+    <template v-if="smAndDown" #footer>
+      <div
+        ref="loadMoreSentinel"
+        class="d-flex justify-center py-4"
+      >
+        <VProgressCircular
+          v-if="isLoading && page > 1"
+          color="secondary"
+          indeterminate
+        />
+      </div>
+    </template>
+
+    <MoleculePaginationFooter
+      v-if="!smAndDown"
+      v-model="page"
+      :has-next-page
+      fixed
+    />
+  </OrganismPageLayout>
+</template>
+
+<style lang="scss" scoped>
+.comics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 2rem;
+}
+
+@media screen and (max-width: 768px) {
+  .comics-grid {
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  }
+}
+
+@media screen and (max-width: 400px) {
+  .comics-grid {
+    grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  }
+}
+</style>

--- a/web/app/pages/browse/sources/kingofshojo/index.vue
+++ b/web/app/pages/browse/sources/kingofshojo/index.vue
@@ -59,7 +59,7 @@ async function doToggleComic(comic: KingOfShojoSearchItem): Promise<void> {
 }
 
 onBeforeRouteLeave((to: RouteLocationNormalized) => {
-  if (to.name !== 'browse-sources-kingofshojo-slug') {
+  if ((to.name as string) !== 'browse-sources-kingofshojo-slug') {
     resetFilters()
   }
 })

--- a/web/app/pages/browse/sources/kingofshojo/index.vue
+++ b/web/app/pages/browse/sources/kingofshojo/index.vue
@@ -33,12 +33,11 @@ const {
   isLoading,
   series,
   page,
-  maxPage,
+  hasNextPage,
   addComicInLibrary,
   addComicInLibraryLoading,
   resetFilters,
 } = useKingOfShojoSearch({ doSearch: true })
-const hasNextPage = computed(() => page.value < maxPage.value)
 const loadMoreSentinel = useTemplateRef<HTMLElement>('loadMoreSentinel')
 useIntersectionObserver(loadMoreSentinel, ([entry]) => {
   if (entry?.isIntersecting && smAndDown.value && !isLoading.value && hasNextPage.value) {

--- a/web/i18n/locales/en.json
+++ b/web/i18n/locales/en.json
@@ -289,6 +289,20 @@
     },
     "comic": {
       "viewOnSource": "See on origin website"
+    },
+    "kingofshojo": {
+      "title": "KingOfShojo",
+      "comic": {
+        "notFound": "Comic not found",
+        "chaptersCount": "No chapters | 1 Chapter | {count} Chapters",
+        "chapter": "Chapter {number}",
+        "retryDownloadChapter": {
+          "tooltip": "Click to retry download"
+        }
+      },
+      "delete": {
+        "confirmation": "You are about to remove \"{name}\" from you library"
+      }
     }
   },
   "browse": {

--- a/web/i18n/locales/fr.json
+++ b/web/i18n/locales/fr.json
@@ -264,7 +264,7 @@
       },
       "comic": {
         "notFound": "Serie introuvable",
-        "chaptersCount": "Aucun chapitre | \n1 Chapitre | \n{count} Chapitres",
+        "chaptersCount": "Aucun chapitre | 1 Chapitre | {count} Chapitres",
         "chapter": "Chapitre {number}",
         "chapterUnlocksIn": "Accessible {time}",
         "retryDownloadChapter": {
@@ -290,6 +290,20 @@
     },
     "comic": {
       "viewOnSource": "Voir sur le site d'origine"
+    },
+    "kingofshojo": {
+      "title": "KingOfShojo",
+      "comic": {
+        "notFound": "BD Introuvable",
+        "chaptersCount": "Aucun chapitre | 1 Chapitre | {count} Chapitres",
+        "chapter": "Chapitre {number}",
+        "retryDownloadChapter": {
+          "tooltip": "Cliquez pour réessayer le téléchargement"
+        }
+      },
+      "delete": {
+        "confirmation": "Vous êtes sur le point de supprimer \"{name}\" de votre bibliothèque"
+      }
     }
   },
   "fields": {

--- a/web/nuxt.config.ts
+++ b/web/nuxt.config.ts
@@ -25,6 +25,8 @@ export default defineNuxtConfig({
     { path: '~/features/library/components', prefix: 'Library' },
     { path: '~/features/feed/components', prefix: 'Feed' },
     { path: '~/features/reader/components', prefix: 'Reader' },
+    { path: '~/features/sources/components', prefix: 'Sources' },
+    { path: '~/features/kingofshojo/components', prefix: 'KingOfShojo' },
   ],
 
   imports: {


### PR DESCRIPTION
Closes #66

## Summary

- Add the authenticated KingOfShojo browse page at `/browse/sources/kingofshojo`, mirroring the AsuraScans browse UX (title search, sort controls, results grid, mobile infinite scroll, desktop pagination).
- Introduce the `kingofshojo` Nuxt feature module (API composable, search store/composable, header/sort UI, comic card, add/delete actions) and register it in `nuxt.config.ts`.
- Align search pagination across KingOfShojo and AsuraScans APIs and frontends with `page` + `hasNextPage` instead of offset-based paging; extract a shared `SourcesCardComic` component used by both sources.

## Screenshots
<img width="1584" height="1351" alt="image" src="https://github.com/user-attachments/assets/2082b380-af95-424f-b399-fd09664eada7" />


## Test plan

- [x] Open `/browse/sources/kingofshojo` while authenticated — page loads with default popular desc results
- [x] Search by title and change sort (`popular`, `latest`, `newest`, `title` + asc/desc) — results update accordingly
- [x] Confirm no status/type/genre filter controls are shown
- [x] Desktop: pagination footer navigates between pages (page size 20)
- [x] Mobile: scrolling to the bottom loads the next page (infinite scroll)
- [x] Comic cards link to `/browse/sources/kingofshojo/{slug}` and covers use `/api/sources/cover/{slug}?source=kingofshojo`
- [x] Add/remove from library works from a result row
- [x] Empty, loading, and error states render with i18n strings (`sources.kingofshojo.*`)
- [x] `pnpm test` and `pnpm lint` pass in `web/`
- [x] `go test ./...` passes in `api/` for touched packages
