### PR TITLE
feat(kingofshojo): series detail and chapter list

### DIFF
--- a/web/app/features/kingofshojo/components/Comic/Chapters/Item.test.ts
+++ b/web/app/features/kingofshojo/components/Comic/Chapters/Item.test.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { VueWrapper } from '@vue/test-utils'
+import type { KingOfShojoComicChapter } from '~/features/kingofshojo/types'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { h } from 'vue'
+import { VApp, VProgressCircular } from 'vuetify/components'
+import Item from './Item.vue'
+
+const { retryDownload, retryDownloadLoading } = await vi.hoisted(async () => {
+  const { ref } = await import('vue')
+
+  return {
+    retryDownload: vi.fn(),
+    retryDownloadLoading: ref(false),
+  }
+})
+
+vi.mock('~/features/kingofshojo/composables/kingofshojo-chapters.composable', () => ({
+  useKingOfShojoChapters: () => ({
+    retryDownload,
+    retryDownloadLoading,
+  }),
+}))
+
+function chapter(overrides: Partial<KingOfShojoComicChapter> = {}): KingOfShojoComicChapter {
+  return {
+    id: 'ch-1',
+    title: 'The beginning',
+    number: 12,
+    publishedAt: new Date('2026-08-18T12:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+async function mount(value: KingOfShojoComicChapter = chapter()): Promise<VueWrapper> {
+  return mountSuspended({
+    render: () => h(VApp, () => [h(Item, {
+      chapter: value,
+      comicOriginUrl: 'https://kingofshojo.com/solo-leveling',
+    })]),
+  })
+}
+
+beforeEach(() => {
+  retryDownload.mockReset()
+  retryDownloadLoading.value = false
+})
+
+describe('asuraScansComicChaptersItem', () => {
+  it('links a readable chapter to the source chapter page', async () => {
+    const wrapper = await mount()
+    expect(wrapper.find('a').attributes('href')).toBe('https://kingofshojo.com/solo-leveling-chapter-12')
+    expect(wrapper.text()).toContain('Chapter 12')
+    expect(wrapper.text()).toContain('The beginning')
+  })
+
+  it('builds the chapter path from site origin, comic slug and number', async () => {
+    const wrapper = await mount(chapter({ number: 111.5 }))
+    expect(wrapper.find('a').attributes('href')).toBe('https://kingofshojo.com/solo-leveling-chapter-111-5')
+  })
+
+  it('shows a check when the chapter is downloaded', async () => {
+    const wrapper = await mount(chapter({
+      internalId: 'internal-1',
+      download: 100,
+    }))
+
+    expect(wrapper.find('.v-icon').exists()).toBe(true)
+  })
+
+  it('shows progress while a past early-access chapter is downloading', async () => {
+    const wrapper = await mount(chapter({
+      internalId: 'internal-1',
+      download: 40,
+      earlyAccessUntil: new Date('2020-01-01'),
+    }))
+
+    expect(wrapper.findComponent(VProgressCircular).props('modelValue')).toBe(40)
+  })
+
+  it('retries a failed download from the error icon', async () => {
+    const wrapper = await mount(chapter({
+      internalId: 'internal-1',
+      download: -1,
+    }))
+
+    await wrapper.find('.v-icon').trigger('click')
+
+    expect(retryDownload).toHaveBeenCalledWith('internal-1')
+  })
+})

--- a/web/app/features/kingofshojo/components/Comic/Chapters/Item.vue
+++ b/web/app/features/kingofshojo/components/Comic/Chapters/Item.vue
@@ -1,0 +1,96 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+import type { KingOfShojoComicChapter } from '~/features/kingofshojo/types'
+import { formatRelativeTime } from '~/utils/date.utils'
+
+const props = defineProps<{
+  chapter: KingOfShojoComicChapter
+  comicOriginUrl: string
+}>()
+
+const { retryDownload, retryDownloadLoading } = useKingOfShojoChapters()
+
+const { locale } = useI18n()
+
+const date = computed(() => {
+  const aMonthAgo = new Date()
+  aMonthAgo.setMonth(aMonthAgo.getMonth() - 1)
+
+  if (props.chapter.publishedAt < aMonthAgo) {
+    return props.chapter.publishedAt.toLocaleDateString(locale.value, { dateStyle: 'medium' })
+  }
+
+  return formatRelativeTime(props.chapter.publishedAt, { locale: locale.value })
+})
+
+const isChapterDownloading = computed(() => props.chapter.internalId
+  && props.chapter.download !== undefined
+  && props.chapter.download >= 0
+  && props.chapter.download < 100
+  && (!props.chapter.earlyAccessUntil || props.chapter.earlyAccessUntil < new Date()))
+const isChapterDownloaded = computed(() => props.chapter.internalId && props.chapter.download === 100)
+const isChapterDownloadingError = computed(() => props.chapter.internalId && props.chapter.download === -1 && !retryDownloadLoading.value)
+
+const to = computed(() => `${props.comicOriginUrl}-chapter-${String(props.chapter.number).replaceAll('.', '-')}`)
+</script>
+
+<template>
+  <AtomLink
+    :to
+    external
+    new-tab
+    no-external-icon
+  >
+    <div class="d-flex justify-space-between ga-6 pa-4 border-b-thin bg-surface align-center text-truncate transition-smooth readable-chapter">
+      <div class="d-flex align-center ga-4">
+        <div class="d-flex flex-wrap text-truncate align-center ga-4">
+          <span class="text-body-large font-weight-bold">{{ $t('sources.kingofshojo.comic.chapter', { number: chapter.number }) }}</span>
+          <span v-if="chapter.title" class="text-body-medium text-medium-emphasis text-truncate">{{ chapter.title }}</span>
+        </div>
+      </div>
+
+      <div class="d-flex align-center ga-3">
+        <VProgressCircular
+          v-if="isChapterDownloading"
+          :model-value="chapter.download"
+          size="18"
+          :indeterminate="chapter.download === 0"
+          width="2"
+          color="primary"
+        />
+        <VIcon
+          v-if="isChapterDownloaded"
+          icon="fa6-solid:check"
+          size="x-small"
+          color="success"
+        />
+        <VIcon
+          v-if="isChapterDownloadingError && !retryDownloadLoading"
+          v-tooltip:bottom="$t('sources.kingofshojo.comic.retryDownloadChapter.tooltip')"
+          icon="fa6-solid:exclamation"
+          classs="cursor-pointer"
+          size="x-small"
+          color="error"
+          @click.prevent="retryDownload(chapter.internalId as string)"
+        />
+        <VProgressCircular
+          v-if="isChapterDownloadingError && retryDownloadLoading"
+          indeterminate
+          size="18"
+          width="2"
+          color="error"
+        />
+        <span class="text-body-medium text-medium-emphasis">{{ date }}</span>
+      </div>
+    </div>
+  </AtomLink>
+</template>
+
+<style lang="scss">
+.readable-chapter {
+  &:hover {
+    color: rgb(var(--v-theme-primary));
+    background-color: rgba(var(--v-theme-surface-variant));
+  }
+}
+</style>

--- a/web/app/features/kingofshojo/components/Comic/Chapters/index.test.ts
+++ b/web/app/features/kingofshojo/components/Comic/Chapters/index.test.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { VueWrapper } from '@vue/test-utils'
+import type { KingOfShojoComicChapter } from '../../../types'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { VApp } from 'vuetify/components'
+import Chapters from './index.vue'
+
+const { sort, chapters, loading, fetchChapters } = await vi.hoisted(async () => {
+  const { ref: vueRef } = await import('vue')
+
+  return {
+    sort: vueRef<'asc' | 'desc'>('desc'),
+    chapters: vueRef<KingOfShojoComicChapter[]>([]),
+    loading: vueRef(false),
+    fetchChapters: vi.fn(),
+  }
+})
+
+vi.mock('~/features/kingofshojo/composables/kingofshojo-chapters.composable', () => ({
+  useKingOfShojoChapters: () => ({
+    sort,
+    chapters,
+    loading,
+    fetchChapters,
+  }),
+}))
+
+const ItemStub = defineComponent({
+  name: 'KingOfShojoComicChaptersItem',
+  props: {
+    chapter: { type: Object, required: true },
+    comicOriginUrl: { type: String, required: true },
+  },
+  template: '<div data-test="chapter">{{ chapter.number }}</div>',
+})
+
+function chapter(number: number): KingOfShojoComicChapter {
+  return {
+    id: `ch-${number}`,
+    title: `Chapter ${number}`,
+    number,
+    publishedAt: new Date('2026-01-01'),
+  }
+}
+
+async function mount(slug = 'solo-leveling'): Promise<VueWrapper> {
+  return mountSuspended(
+    {
+      render: () => h(VApp, () => [h(Chapters, {
+        slug,
+      })]),
+    },
+    {
+      global: {
+        stubs: {
+          KingOfShojoComicChaptersItem: ItemStub,
+          VVirtualScroll: false,
+        },
+      },
+    },
+  )
+}
+
+beforeEach(() => {
+  sort.value = 'desc'
+  chapters.value = []
+  loading.value = false
+  fetchChapters.mockReset()
+})
+
+describe('asuraScansComicChapters', () => {
+  it('fetches chapters on mount', async () => {
+    await mount()
+    expect(fetchChapters).toHaveBeenCalled()
+  })
+
+  it('shows an empty state when there are no chapters', async () => {
+    const wrapper = await mount()
+    expect(wrapper.text()).toContain('No chapters')
+  })
+
+  it('shows a spinner while loading', async () => {
+    loading.value = true
+    const wrapper = await mount()
+    expect(wrapper.find('.v-progress-circular').exists()).toBe(true)
+  })
+
+  it('toggles sort between latest and oldest', async () => {
+    chapters.value = [chapter(2), chapter(1)]
+    const wrapper = await mount()
+
+    expect(wrapper.text()).toContain('Latest')
+
+    const buttons = wrapper.findAll('button')
+    await buttons[0]!.trigger('click')
+
+    expect(sort.value).toBe('asc')
+    expect(wrapper.text()).toContain('Oldest')
+  })
+})

--- a/web/app/features/kingofshojo/components/Comic/Chapters/index.vue
+++ b/web/app/features/kingofshojo/components/Comic/Chapters/index.vue
@@ -1,0 +1,48 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+import { KING_OF_SHOJO_URL } from '~/constants'
+
+const props = defineProps<{ slug: string }>()
+
+const { sort, chapters, loading, fetchChapters } = useKingOfShojoChapters()
+
+watch(() => props.slug, () => {
+  fetchChapters()
+}, { immediate: true })
+
+const comicOriginUrl = computed(() => `${KING_OF_SHOJO_URL}/${props.slug}`)
+</script>
+
+<template>
+  <div class="d-flex flex-column w-100 position-relative bg-surface" style="border-radius: 12px; max-height: 40rem;">
+    <div class="d-flex justify-space-between ga-6 pa-4 border-b-thin bg-surface align-center" style="z-index: 1; border-top-left-radius: 12px; border-top-right-radius: 12px;">
+      <span class="text-title-large font-weight-bold">{{ $t('sources.kingofshojo.comic.chaptersCount', { count: chapters.length }) }}</span>
+      <VBtn
+        variant="tonal"
+        class="text-body-medium"
+        color="surfaceVariant"
+        :text="sort === 'asc' ? $t('common.sort.oldest') : $t('common.sort.latest')"
+        :prepend-icon="sort === 'desc' ? 'fa6-solid:arrow-down-short-wide' : 'fa6-solid:arrow-up-short-wide'"
+        @click="sort = sort === 'asc' ? 'desc' : 'asc'"
+      />
+    </div>
+
+    <div v-if="loading || chapters.length === 0" class="d-flex justify-center align-center w-100 pa-4">
+      <VProgressCircular
+        v-if="loading"
+        class="m-auto"
+        indeterminate
+        color="primary"
+      />
+      <span v-else class="text-medium-emphasis">{{ $t('sources.kingofshojo.comic.chaptersCount', { count: 0 }) }}</span>
+    </div>
+    <VVirtualScroll :items="chapters" style="border-bottom-left-radius: 12px; border-bottom-right-radius: 12px;">
+      <template #default="{ item }">
+        <KingOfShojoComicChaptersItem
+          :chapter="item"
+          :comic-origin-url="comicOriginUrl"
+        />
+      </template>
+    </VVirtualScroll>
+  </div>
+</template>

--- a/web/app/features/kingofshojo/components/Comic/GeneralInfos.test.ts
+++ b/web/app/features/kingofshojo/components/Comic/GeneralInfos.test.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { VueWrapper } from '@vue/test-utils'
+import type { KingOfShojoComicInfos } from '../../types'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { h } from 'vue'
+import { VApp } from 'vuetify/components'
+import GeneralInfos from './GeneralInfos.vue'
+
+const { smAndDown } = await vi.hoisted(async () => {
+  const { ref } = await import('vue')
+
+  return { smAndDown: ref(true) }
+})
+
+function displayStub(): { smAndDown: typeof smAndDown } {
+  return { smAndDown }
+}
+
+mockNuxtImport('useDisplay', () => displayStub)
+
+function comic(overrides: Partial<KingOfShojoComicInfos> = {}): KingOfShojoComicInfos {
+  return {
+    title: 'Solo Leveling',
+    cover: '/cover',
+    publicUrl: '',
+    sourceUrl: '',
+    status: 'ongoing',
+    type: 'manhwa',
+    author: 'Chugong',
+    artist: 'Jang',
+    description: '<p>A hunter.</p>\nSecond line',
+    slug: 'solo-leveling',
+    altTitles: ['나 혼자만 레벨업', 'Only I Level Up'],
+    genres: ['action'],
+    chapterCount: 1,
+    rating: 9,
+    updatedAt: new Date('2026-01-01'),
+    createdAt: new Date('2026-01-01'),
+    ...overrides,
+  }
+}
+
+async function mount(value: KingOfShojoComicInfos = comic()): Promise<VueWrapper> {
+  return mountSuspended({
+    render: () => h(VApp, () => [h(GeneralInfos, { comic: value })]),
+  })
+}
+
+beforeEach(() => {
+  smAndDown.value = true
+})
+
+describe('asuraScansComicGeneralInfos', () => {
+  it('strips HTML and newlines from the description', async () => {
+    const wrapper = await mount()
+    expect(wrapper.text()).toContain('A hunter. Second line')
+    expect(wrapper.text()).not.toContain('<p>')
+  })
+
+  it('joins alternate titles', async () => {
+    const wrapper = await mount()
+    expect(wrapper.text()).toContain('나 혼자만 레벨업, Only I Level Up')
+  })
+
+  it('renders genres', async () => {
+    const wrapper = await mount()
+    expect(wrapper.text()).toContain('action')
+  })
+
+  it('starts expanded on desktop', async () => {
+    smAndDown.value = false
+    const wrapper = await mount()
+    expect(wrapper.text()).toContain('Show less')
+    expect(wrapper.find('.text-truncate').exists()).toBe(false)
+  })
+
+  it('expands truncated text when show more is clicked', async () => {
+    const wrapper = await mount()
+    expect(wrapper.text()).toContain('Show more')
+    expect(wrapper.find('.text-truncate').exists()).toBe(true)
+
+    await wrapper.findAll('button').at(-1)!.trigger('click')
+
+    expect(wrapper.text()).toContain('Show less')
+    expect(wrapper.find('.text-truncate').exists()).toBe(false)
+  })
+})

--- a/web/app/features/kingofshojo/components/Comic/GeneralInfos.vue
+++ b/web/app/features/kingofshojo/components/Comic/GeneralInfos.vue
@@ -1,0 +1,47 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+import type { KingOfShojoComicInfos } from '../../types'
+
+const props = defineProps<{
+  comic: KingOfShojoComicInfos
+}>()
+
+const { smAndDown } = useDisplay()
+const showMore = ref(!smAndDown.value)
+
+const sanitzedDescription = computed(() => props.comic.description.replace(/<[^>]*>?/g, '').replaceAll('\n', ' '))
+</script>
+
+<template>
+  <div class="d-flex flex-column ga-4 transition-smooth pa-4 bg-surface w-100" style="border-radius: 12px;">
+    <span
+      v-if="sanitzedDescription"
+      class="text-body-large transition-smooth"
+      :class="{ 'text-truncate': !showMore }"
+    >{{ sanitzedDescription }}</span>
+
+    <span
+      v-if="comic.altTitles"
+      class="transition-smooth text-medium-emphasis text-body-small"
+      :class="{ 'text-truncate': !showMore }"
+    >{{ comic.altTitles.join(', ') }}</span>
+
+    <div v-if="comic.genres.length" class="d-flex flex-wrap ga-3">
+      <span
+        v-for="(genre, i) in comic.genres"
+        :key="i"
+        class="text-capitalize px-2 py-1 bg-background border-thin text-body-medium rounded-lg"
+      >{{ genre }}</span>
+    </div>
+
+    <div class="d-flex justify-end">
+      <VBtn
+        variant="text"
+        color="primary"
+        :text="showMore ? $t('common.showLess') : $t('common.showMore')"
+        :append-icon="showMore ? 'fa6-solid:angle-up' : 'fa6-solid:angle-down'"
+        @click="showMore = !showMore"
+      />
+    </div>
+  </div>
+</template>

--- a/web/app/features/kingofshojo/components/Comic/Link/OriginalSite.test.ts
+++ b/web/app/features/kingofshojo/components/Comic/Link/OriginalSite.test.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it } from 'vitest'
+import { h } from 'vue'
+import OriginalSite from './OriginalSite.vue'
+
+describe('asuraScansComicLinkOriginalSite', () => {
+  it('opens the source URL in a new tab', async () => {
+    const wrapper = await mountSuspended({
+      render: () => h(OriginalSite, { to: 'https://kingofshojo.com/series/solo-leveling' }),
+    })
+    const anchor = wrapper.find('a')
+
+    expect(anchor.attributes('href')).toBe('https://kingofshojo.com/series/solo-leveling')
+    expect(anchor.attributes('target')).toBe('_blank')
+  })
+})

--- a/web/app/features/kingofshojo/components/Comic/Link/OriginalSite.vue
+++ b/web/app/features/kingofshojo/components/Comic/Link/OriginalSite.vue
@@ -1,0 +1,28 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+defineProps<{ to: string }>()
+</script>
+
+<template>
+  <AtomLink
+    :to
+    new-tab
+    external
+    class="original-site-link-icon"
+    no-prefetch
+  >
+    <VIcon
+      v-tooltip="$t('sources.comic.viewOnSource')"
+      icon="fa6-solid:arrow-up-right-from-square"
+      class="original-site-link-icon transition-smooth"
+    />
+  </AtomLink>
+</template>
+
+<style lang="scss" scoped>
+.original-site-link-icon {
+  &:hover {
+    color: rgb(var(--v-theme-primary));
+  }
+}
+</style>

--- a/web/app/features/kingofshojo/components/Comic/StatusInfos.test.ts
+++ b/web/app/features/kingofshojo/components/Comic/StatusInfos.test.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { VueWrapper } from '@vue/test-utils'
+import type { KingOfShojoComicInfos } from '../../types'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { VApp, VBtn } from 'vuetify/components'
+import StatusInfos from './StatusInfos.vue'
+
+function asuraSearchStub(): { addComicInLibrary: () => Promise<undefined> } {
+  return { addComicInLibrary: vi.fn() }
+}
+
+function asuraChaptersStub(): { fetchChapters: () => Promise<void> } {
+  return { fetchChapters: vi.fn() }
+}
+
+mockNuxtImport('useKingOfShojoSearch', () => asuraSearchStub)
+mockNuxtImport('useKingOfShojoChapters', () => asuraChaptersStub)
+
+const DeleteStub = defineComponent({
+  name: 'KingOfShojoModalDelete',
+  props: {
+    modelValue: { type: Boolean, default: false },
+    comic: { type: Object, required: true },
+  },
+  template: '<div data-test="delete-modal" />',
+})
+
+const LinkStub = defineComponent({
+  name: 'KingOfShojoComicLinkOriginalSite',
+  props: { to: { type: String, required: true } },
+  template: '<a data-test="origin" :href="to" />',
+})
+
+function infos(overrides: Partial<KingOfShojoComicInfos> = {}): KingOfShojoComicInfos {
+  return {
+    title: 'Solo Leveling',
+    cover: '/cover',
+    publicUrl: '',
+    sourceUrl: '',
+    status: 'ongoing',
+    type: 'manhwa',
+    author: 'Chugong',
+    artist: 'Jang',
+    description: 'A hunter',
+    slug: 'solo-leveling',
+    altTitles: [],
+    genres: ['action', 'fantasy'],
+    chapterCount: 1,
+    rating: 9,
+    updatedAt: new Date('2026-01-01'),
+    createdAt: new Date('2026-01-01'),
+    ...overrides,
+  }
+}
+
+async function mount(comic: KingOfShojoComicInfos): Promise<{ wrapper: VueWrapper, comic: KingOfShojoComicInfos }> {
+  const wrapper = await mountSuspended(
+    {
+      render: () => h(VApp, () => [h(StatusInfos, {
+        comicOriginUrl: 'https://kingofshojo.com/series/solo-leveling',
+        modelValue: comic,
+      })]),
+    },
+    {
+      global: {
+        stubs: {
+          KingOfShojoModalDelete: DeleteStub,
+          KingOfShojoComicLinkOriginalSite: LinkStub,
+        },
+      },
+    },
+  )
+
+  return { wrapper, comic }
+}
+
+describe('asuraScansComicStatusInfos', () => {
+  it('renders status, type, author and artist', async () => {
+    const { wrapper } = await mount(infos())
+
+    expect(wrapper.text()).toContain('Ongoing')
+    expect(wrapper.text()).toContain('Manhwa')
+    expect(wrapper.text()).toContain('Chugong')
+    expect(wrapper.text()).toContain('Jang')
+    expect(wrapper.text()).not.toContain('action')
+    expect(wrapper.find('[data-test="origin"]').attributes('href')).toBe('https://kingofshojo.com/series/solo-leveling')
+  })
+
+  it('shows the add-to-library action when the comic is not in the library', async () => {
+    const { wrapper } = await mount(infos())
+
+    expect(wrapper.text()).toContain('Add to library')
+    expect(wrapper.findComponent(VBtn).props('color')).toBe('primary')
+  })
+
+  it('shows the remove action when the comic is already in the library', async () => {
+    const { wrapper } = await mount(infos({ internalId: 'c1' }))
+
+    expect(wrapper.text()).toContain('Remove from library')
+    expect(wrapper.find('[data-test="delete-modal"]').exists()).toBe(true)
+  })
+})

--- a/web/app/features/kingofshojo/components/Comic/StatusInfos.vue
+++ b/web/app/features/kingofshojo/components/Comic/StatusInfos.vue
@@ -1,0 +1,91 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+import type { KingOfShojoComicInfos } from '../../types'
+
+const props = defineProps<{ comicOriginUrl: string }>()
+
+const comic = defineModel<KingOfShojoComicInfos>({ required: true })
+
+const { addComicInLibrary } = useKingOfShojoSearch({ doSearch: false })
+const { fetchChapters } = useKingOfShojoChapters()
+
+const showDeleteModal = ref(false)
+const addToLibraryLoading = ref(false)
+
+function toggleLibraryAction(): void {
+  if (!comic.value) {
+    return
+  }
+
+  if (comic.value.internalId) {
+    showDeleteModal.value = true
+  } else {
+    addComicToLibrary()
+  }
+}
+
+async function addComicToLibrary(): Promise<void> {
+  if (!comic.value) {
+    return
+  }
+
+  addToLibraryLoading.value = true
+
+  const internalId = await addComicInLibrary(comic.value)
+  if (internalId) {
+    comic.value.internalId = internalId
+  }
+
+  addToLibraryLoading.value = false
+}
+
+watch(() => comic.value.internalId, () => {
+  fetchChapters()
+})
+</script>
+
+<template>
+  <KingOfShojoModalDelete
+    v-if="comic"
+    v-model="showDeleteModal"
+    :comic
+    @update:comic="comic = { ...comic, internalId: $event?.internalId }"
+  />
+
+  <div
+    class="d-flex flex-column ga-4 pa-4 bg-surface"
+    style="border-radius: 12px"
+  >
+    <div class="d-flex flex-wrap align-center justify-space-between ga-4">
+      <div class="d-flex flex-wrap ga-4">
+        <ComicsChipStatus :status="comic.status" />
+        <ComicsChipType :type="comic.type" />
+      </div>
+
+      <KingOfShojoComicLinkOriginalSite :to="`${props.comicOriginUrl}`" />
+    </div>
+
+    <VBtn
+      variant="tonal"
+      class="w-100"
+      :color="comic.internalId ? 'error' : 'primary'"
+      :class="{
+        'border-thin-error': comic.internalId,
+        'border-thin-primary': !comic.internalId,
+      }"
+      :prepend-icon="comic.internalId ? 'fa6-solid:trash' : 'fa6-solid:book'"
+      size="large"
+      :text="comic.internalId ? $t('comics.remove.title') : $t('sources.add.title')"
+      :loading="addToLibraryLoading"
+      @click="toggleLibraryAction"
+    />
+    <div v-if="comic.author" class="d-flex ga-2 justify-space-between">
+      <span class="text-body-large text-medium-emphasis text-uppercase text-truncate">{{ $t('comic.fields.author') }}</span>
+      <span class="text-body-large font-weight-bold text-truncate">{{ comic.author }}</span>
+    </div>
+    <div v-if="comic.artist" class="d-flex ga-2 justify-space-between">
+      <span class="text-body-large text-medium-emphasis text-uppercase text-truncate">{{ $t('comic.fields.artist') }}</span>
+      <span class="text-body-large font-weight-bold text-truncate">{{ comic.artist }}</span>
+    </div>
+  </div>
+</template>

--- a/web/app/features/kingofshojo/composables/kingofshojo-chapters.composable.test.ts
+++ b/web/app/features/kingofshojo/composables/kingofshojo-chapters.composable.test.ts
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// @vitest-environment nuxt
+
+import type { KingOfShojoComicChapter } from '../types'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope } from 'vue'
+import { useToast } from '~/composables/toast.composable'
+import { isChapterDownloadInProgress } from '../../sources/composables/sources.composable'
+import { useKingOfShojoChaptersStore } from '../stores/kingofshojo-chapters.store'
+import { useKingOfShojoChapters } from './kingofshojo-chapters.composable'
+
+const { getSeriesChapters, retryDownloadApi } = vi.hoisted(() => ({
+  getSeriesChapters: vi.fn(),
+  retryDownloadApi: vi.fn(),
+}))
+
+vi.mock('./kingofshojo.api', () => ({
+  createKingOfShojoApi: () => ({ getSeriesChapters }),
+}))
+
+function i18nStub(): { t: (key: string) => string } {
+  return { t: (key: string) => key }
+}
+
+function routeStub(): { params: { slug: string } } {
+  return { params: { slug: 'solo-leveling' } }
+}
+
+function createChaptersApiStub(): ChaptersApi {
+  return {
+    retryDownload: retryDownloadApi,
+    getByIds: vi.fn(),
+    getByComicId: vi.fn(),
+    getById: vi.fn(),
+    saveProgress: vi.fn(),
+    deleteProgress: vi.fn(),
+  }
+}
+
+mockNuxtImport('useI18n', () => i18nStub)
+mockNuxtImport('useRoute', () => routeStub)
+mockNuxtImport('createChaptersApi', () => createChaptersApiStub)
+
+function chapter(overrides: Partial<KingOfShojoComicChapter> = {}): KingOfShojoComicChapter {
+  return {
+    id: 'ch-1',
+    title: 'One',
+    number: 1,
+    publishedAt: new Date('2026-01-01'),
+    earlyAccessUntil: new Date(0),
+    ...overrides,
+  }
+}
+
+function apiError(status: number): { success: false, error: { status: number, message: string } } {
+  return { success: false, error: { status, message: 'boom' } }
+}
+
+const scopes: ReturnType<typeof effectScope>[] = []
+
+function setup(): ReturnType<typeof useKingOfShojoChapters> {
+  const scope = effectScope()
+  scopes.push(scope)
+  const composable = scope.run(() => useKingOfShojoChapters())
+  if (!composable) {
+    throw new Error('useKingOfShojoChapters returned undefined')
+  }
+
+  return composable
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  useToast().messages.value.length = 0
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  getSeriesChapters.mockReset()
+  retryDownloadApi.mockReset()
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  while (scopes.length > 0) {
+    scopes.pop()?.stop()
+  }
+
+  vi.useRealTimers()
+})
+
+describe('isChapterDownloadInProgress', () => {
+  it('is true only for a defined progress between 0 and 99', () => {
+    expect(isChapterDownloadInProgress(chapter())).toBe(false)
+    expect(isChapterDownloadInProgress(chapter({ download: -1 }))).toBe(false)
+    expect(isChapterDownloadInProgress(chapter({ download: 0 }))).toBe(true)
+    expect(isChapterDownloadInProgress(chapter({ download: 42 }))).toBe(true)
+    expect(isChapterDownloadInProgress(chapter({ download: 99 }))).toBe(true)
+    expect(isChapterDownloadInProgress(chapter({ download: 100 }))).toBe(false)
+  })
+})
+
+describe('useKingOfShojoChapters polling', () => {
+  it('toasts on the initial fetch and does not poll', async () => {
+    getSeriesChapters.mockResolvedValue(apiError(500))
+
+    await setup().fetchChapters()
+    await vi.advanceTimersByTimeAsync(4000)
+
+    expect(getSeriesChapters).toHaveBeenCalledTimes(1)
+    expect(useToast().messages.value).toEqual([{ text: 'error.unknown', color: 'error' }])
+  })
+
+  it('does not poll when no chapter is in progress', async () => {
+    getSeriesChapters.mockResolvedValue({
+      success: true,
+      data: [
+        chapter({ download: 100 }),
+        chapter({ id: 'ch-2', number: 2, download: -1 }),
+        chapter({ id: 'ch-3', number: 3 }),
+      ],
+    })
+
+    await setup().fetchChapters()
+    await vi.advanceTimersByTimeAsync(4000)
+
+    expect(getSeriesChapters).toHaveBeenCalledTimes(1)
+  })
+
+  it('polls every 2s without loading or toasts while a download is in progress', async () => {
+    getSeriesChapters
+      .mockResolvedValueOnce({ success: true, data: [chapter({ download: 10 })] })
+      .mockResolvedValueOnce({ success: true, data: [chapter({ download: 40 })] })
+
+    const kingofshojo = setup()
+    await kingofshojo.fetchChapters()
+    expect(kingofshojo.loading.value).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(2000)
+
+    expect(getSeriesChapters).toHaveBeenCalledTimes(2)
+    expect(kingofshojo.loading.value).toBe(false)
+    expect(useKingOfShojoChaptersStore().chapters[0]?.download).toBe(40)
+    expect(useToast().messages.value).toEqual([])
+  })
+
+  it('keeps the last list and does not toast when a poll fails', async () => {
+    getSeriesChapters
+      .mockResolvedValueOnce({ success: true, data: [chapter({ download: 10 })] })
+      .mockResolvedValueOnce(apiError(500))
+
+    await setup().fetchChapters()
+    useToast().messages.value.length = 0
+
+    await vi.advanceTimersByTimeAsync(2000)
+
+    expect(useKingOfShojoChaptersStore().chapters[0]?.download).toBe(10)
+    expect(useToast().messages.value).toEqual([])
+  })
+
+  it('stops polling once no chapter is in progress', async () => {
+    getSeriesChapters
+      .mockResolvedValueOnce({ success: true, data: [chapter({ download: 90 })] })
+      .mockResolvedValueOnce({ success: true, data: [chapter({ download: 100 })] })
+
+    await setup().fetchChapters()
+    await vi.advanceTimersByTimeAsync(2000)
+    await vi.advanceTimersByTimeAsync(4000)
+
+    expect(getSeriesChapters).toHaveBeenCalledTimes(2)
+  })
+
+  it('skips a tick while a fetch is already in flight', async () => {
+    getSeriesChapters.mockResolvedValueOnce({ success: true, data: [chapter({ download: 10 })] })
+
+    const poll = Promise.withResolvers<{ success: true, data: KingOfShojoComicChapter[] }>()
+    getSeriesChapters.mockImplementationOnce(() => poll.promise)
+
+    await setup().fetchChapters()
+    await vi.advanceTimersByTimeAsync(2000)
+    await vi.advanceTimersByTimeAsync(2000)
+
+    expect(getSeriesChapters).toHaveBeenCalledTimes(2)
+
+    poll.resolve({ success: true, data: [chapter({ download: 20 })] })
+    await Promise.resolve()
+  })
+})
+
+describe('useKingOfShojoChapters retryDownload', () => {
+  it('refetches chapters without loading and starts polling after success', async () => {
+    retryDownloadApi.mockResolvedValue({ success: true, data: undefined })
+    getSeriesChapters
+      .mockResolvedValueOnce({ success: true, data: [chapter({ internalId: 'ch-1', download: -1 })] })
+      .mockResolvedValueOnce({ success: true, data: [chapter({ internalId: 'ch-1', download: 0 })] })
+      .mockResolvedValueOnce({ success: true, data: [chapter({ internalId: 'ch-1', download: 20 })] })
+
+    const kingofshojo = setup()
+    await kingofshojo.fetchChapters()
+    await kingofshojo.retryDownload('ch-1')
+
+    expect(retryDownloadApi).toHaveBeenCalledWith('ch-1')
+    expect(getSeriesChapters).toHaveBeenCalledTimes(2)
+    expect(useKingOfShojoChaptersStore().chapters[0]?.download).toBe(0)
+    expect(kingofshojo.loading.value).toBe(false)
+    expect(useToast().messages.value).toEqual([])
+
+    await vi.advanceTimersByTimeAsync(2000)
+
+    expect(getSeriesChapters).toHaveBeenCalledTimes(3)
+    expect(useKingOfShojoChaptersStore().chapters[0]?.download).toBe(20)
+  })
+
+  it('toasts notFound on 404 and does not refetch', async () => {
+    retryDownloadApi.mockResolvedValue(apiError(404))
+    getSeriesChapters.mockResolvedValue({ success: true, data: [chapter({ download: -1 })] })
+
+    const kingofshojo = setup()
+    await kingofshojo.fetchChapters()
+    await kingofshojo.retryDownload('ch-1')
+
+    expect(getSeriesChapters).toHaveBeenCalledTimes(1)
+    expect(useToast().messages.value).toEqual([{
+      text: 'sources.kingofshojo.comic.chapters.error.retry.notFound',
+      color: 'error',
+    }])
+  })
+
+  it('toasts forbidden on 403', async () => {
+    retryDownloadApi.mockResolvedValue(apiError(403))
+    getSeriesChapters.mockResolvedValue({ success: true, data: [chapter({ download: -1 })] })
+
+    await setup().retryDownload('ch-1')
+
+    expect(useToast().messages.value).toEqual([{
+      text: 'sources.kingofshojo.comic.chapters.error.retry.forbidden',
+      color: 'error',
+    }])
+  })
+
+  it('toasts conflict on 409', async () => {
+    retryDownloadApi.mockResolvedValue(apiError(409))
+    getSeriesChapters.mockResolvedValue({ success: true, data: [chapter({ download: 100 })] })
+
+    await setup().retryDownload('ch-1')
+
+    expect(useToast().messages.value).toEqual([{
+      text: 'sources.kingofshojo.comic.chapters.error.retry.conflict',
+      color: 'error',
+    }])
+  })
+
+  it('toasts unknown on other errors', async () => {
+    retryDownloadApi.mockResolvedValue(apiError(500))
+    getSeriesChapters.mockResolvedValue({ success: true, data: [chapter({ download: -1 })] })
+
+    await setup().retryDownload('ch-1')
+
+    expect(useToast().messages.value).toEqual([{ text: 'error.unknown', color: 'error' }])
+  })
+})

--- a/web/app/features/kingofshojo/composables/kingofshojo-chapters.composable.ts
+++ b/web/app/features/kingofshojo/composables/kingofshojo-chapters.composable.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { KingOfShojoComicChapter } from '../types'
+import { useKingOfShojoChaptersStore } from '../stores/kingofshojo-chapters.store'
+
+const POLL_INTERVAL_MS = 2000
+
+export interface KingOfShojoChaptersComposable {
+  sort: Ref<'asc' | 'desc'>
+  chapters: Ref<KingOfShojoComicChapter[]>
+  loading: Ref<boolean>
+  fetchChapters: () => Promise<void>
+  retryDownload: (chapterId: string) => Promise<void>
+  retryDownloadLoading: Ref<boolean>
+}
+
+export function useKingOfShojoChapters(): KingOfShojoChaptersComposable {
+  const store = useKingOfShojoChaptersStore()
+  const api = createKingOfShojoApi()
+  const chaptersApi = createChaptersApi()
+  const toast = useToast()
+  const { t } = useI18n()
+  const route = useRoute('browse-sources-kingofshojo-slug')
+
+  const sort = ref<'asc' | 'desc'>('desc')
+  const chapters = computed(() => store.chapters.toSorted((a, b) => {
+    if (sort.value === 'asc') {
+      return a.number - b.number
+    }
+
+    return b.number - a.number
+  }))
+
+  const loading = ref(false)
+  let isInFlight = false
+
+  async function loadChapters(shouldNotify: boolean): Promise<void> {
+    const res = await api.getSeriesChapters(route.params.slug)
+
+    if (res.success) {
+      store.setChapters(res.data)
+
+      return
+    }
+
+    console.error('api.getSeriesChapters', res.error)
+
+    if (!shouldNotify) {
+      return
+    }
+
+    if (res.error.status === 404) {
+      toast.error(t('sources.kingofshojo.comic.chapters.error.fetch'))
+    } else {
+      toast.error(t('error.unknown'))
+    }
+  }
+
+  const retryDownloadLoading = ref(false)
+  async function retryDownload(chapterId: string): Promise<void> {
+    if (!chapterId) {
+      return
+    }
+
+    retryDownloadLoading.value = true
+
+    const res = await chaptersApi.retryDownload(chapterId)
+    if (res.success) {
+      await loadChapters(false)
+      syncPolling()
+
+      retryDownloadLoading.value = false
+
+      return
+    }
+
+    console.error('chaptersApi.retryDownload', res.error)
+
+    switch (res.error.status) {
+      case 404:
+        toast.error(t('sources.kingofshojo.comic.chapters.error.retry.notFound'))
+        break
+      case 403:
+        toast.error(t('sources.kingofshojo.comic.chapters.error.retry.forbidden'))
+        break
+      case 409:
+        toast.error(t('sources.kingofshojo.comic.chapters.error.retry.conflict'))
+        break
+      default:
+        toast.error(t('error.unknown'))
+        break
+    }
+
+    retryDownloadLoading.value = false
+  }
+
+  async function pollChapters(): Promise<void> {
+    if (isInFlight || loading.value) {
+      return
+    }
+
+    isInFlight = true
+    await loadChapters(false)
+    isInFlight = false
+    syncPolling()
+  }
+
+  const { pause, resume } = useIntervalFn(() => {
+    void pollChapters()
+  }, POLL_INTERVAL_MS, { immediate: false })
+
+  function syncPolling(): void {
+    if (store.chapters.some(chapter => isChapterDownloadInProgress(chapter))) {
+      resume()
+    } else {
+      pause()
+    }
+  }
+
+  async function fetchChapters(): Promise<void> {
+    loading.value = true
+    await loadChapters(true)
+    loading.value = false
+    syncPolling()
+  }
+
+  onBeforeRouteLeave(() => {
+    pause()
+    store.invalidate()
+  })
+
+  return {
+    sort,
+    chapters,
+    loading,
+    fetchChapters,
+    retryDownload,
+    retryDownloadLoading,
+  }
+}

--- a/web/app/features/kingofshojo/stores/kingofshojo-chapters.store.test.ts
+++ b/web/app/features/kingofshojo/stores/kingofshojo-chapters.store.test.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { KingOfShojoComicChapter } from '../types'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useKingOfShojoChaptersStore } from './kingofshojo-chapters.store'
+
+function chapter(overrides: Partial<KingOfShojoComicChapter> = {}): KingOfShojoComicChapter {
+  return {
+    id: 'ch-1',
+    title: 'One',
+    number: 1,
+    publishedAt: new Date('2026-01-01'),
+    ...overrides,
+  }
+}
+
+describe('useKingOfShojoChaptersStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('starts empty', () => {
+    expect(useKingOfShojoChaptersStore().chapters).toEqual([])
+  })
+
+  it('setChapters replaces the list', () => {
+    const store = useKingOfShojoChaptersStore()
+    store.setChapters([chapter(), chapter({ id: 'ch-2', number: 2 })])
+
+    expect(store.chapters.map(c => c.id)).toEqual(['ch-1', 'ch-2'])
+  })
+
+  it('invalidate clears the list', () => {
+    const store = useKingOfShojoChaptersStore()
+    store.setChapters([chapter()])
+
+    store.invalidate()
+
+    expect(store.chapters).toEqual([])
+  })
+})

--- a/web/app/features/kingofshojo/stores/kingofshojo-chapters.store.ts
+++ b/web/app/features/kingofshojo/stores/kingofshojo-chapters.store.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { KingOfShojoComicChapter } from '../types'
+
+export interface KingOfShojoChaptersStore {
+  chapters: KingOfShojoComicChapter[]
+  setChapters: (value: KingOfShojoComicChapter[]) => void
+  invalidate: () => void
+}
+
+export const useKingOfShojoChaptersStore = defineStore('kingofshojo-chapters', () => {
+  const chapters = ref<KingOfShojoComicChapter[]>([])
+
+  function setChapters(value: KingOfShojoComicChapter[]): void {
+    chapters.value = value
+  }
+
+  function invalidate(): void {
+    chapters.value = []
+  }
+
+  return {
+    chapters,
+
+    setChapters,
+    invalidate,
+  }
+})

--- a/web/app/pages/browse/sources/kingofshojo/[slug].vue
+++ b/web/app/pages/browse/sources/kingofshojo/[slug].vue
@@ -1,0 +1,120 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script setup lang="ts">
+import type KingOfShojoComicChapters from '~/features/kingofshojo/components/Comic/Chapters/index.vue'
+import type { KingOfShojoComicInfos } from '~/features/kingofshojo/types'
+import defaultCover from '~/assets/images/default/comic-cover.webp'
+import asuraImg from '~/assets/images/sources/kingofshojo.webp'
+import { KING_OF_SHOJO_SOURCE_NAME } from '~/constants'
+import { AUTHENTICATED_ROUTE_GROUP } from '~/constants/auth'
+
+definePageMeta({
+  layout: 'default',
+  authGroups: [AUTHENTICATED_ROUTE_GROUP],
+})
+
+const route = useRoute('browse-sources-kingofshojo-slug')
+const toast = useToast()
+const { t } = useI18n()
+const { smAndDown } = useDisplay()
+const api = createKingOfShojoApi()
+
+const fetchInfosLoading = ref(false)
+const infos = ref<KingOfShojoComicInfos>()
+
+const coverSrc = ref<string>()
+
+onMounted(() => {
+  fetchInfos()
+})
+
+async function fetchInfos(): Promise<void> {
+  fetchInfosLoading.value = true
+
+  const res = await api.getInfosBySlug(route.params.slug as string)
+
+  if (res.success) {
+    infos.value = res.data
+    coverSrc.value = res.data.cover
+  } else {
+    console.error('api.getInfosBySlug', res.error)
+    toast.error(res.error.status === 404
+      ? t('sources.kingofshojo.comic.notFound')
+      : t('error.unknown'))
+
+    await navigateTo(`/browse/sources/${KING_OF_SHOJO_SOURCE_NAME}`)
+  }
+
+  fetchInfosLoading.value = false
+}
+</script>
+
+<template>
+  <OrganismPageLayout
+    :title="infos?.title ?? ''"
+    :loading="fetchInfosLoading"
+    :global-loader="fetchInfosLoading"
+    sticky-header
+    :back-routes="[{
+      to: `/browse/sources/${KING_OF_SHOJO_SOURCE_NAME}`,
+      name: $t('sources.kingofshojo.title'),
+      image: asuraImg }]"
+  >
+    <div
+      v-if="infos"
+      :class="smAndDown ? 'd-flex flex-column ga-8 px-6' : 'comic-infos-grid'"
+    >
+      <div v-if="!smAndDown" class="d-flex flex-column ga-6">
+        <VImg
+          v-if="coverSrc"
+          :src="coverSrc"
+          rounded="lg"
+          :aspect-ratio="2 / 3"
+          cover
+          :lazy-src="defaultCover"
+          class="border-thin rounded-lg flex-grow-0"
+          @error="coverSrc = defaultCover"
+        />
+
+        <KingOfShojoComicStatusInfos
+          v-if="!smAndDown"
+          v-model="infos"
+          :comic-origin-url="infos?.publicUrl ?? ''"
+        />
+      </div>
+
+      <div class="d-flex flex-column ga-6 w-100">
+        <div class="d-flex ga-4 align-center">
+          <VImg
+            v-if="coverSrc && smAndDown"
+            :src="coverSrc"
+            rounded="lg"
+            :aspect-ratio="2 / 3"
+            cover
+            :width="120"
+            :lazy-src="defaultCover"
+            class="border-thin rounded-lg flex-0-0"
+            @error="coverSrc = defaultCover"
+          />
+
+          <span class="font-title font-weight-bold" :class="{ 'text-display-medium': !smAndDown, 'text-title-large': smAndDown }">{{ infos.title }}</span>
+        </div>
+        <KingOfShojoComicStatusInfos
+          v-if="smAndDown"
+          v-model="infos"
+          :comic-origin-url="infos?.publicUrl ?? ''"
+        />
+        <KingOfShojoComicGeneralInfos :comic="infos" />
+        <KingOfShojoComicChapters :slug="route.params.slug" />
+      </div>
+    </div>
+  </OrganismPageLayout>
+</template>
+
+<style scoped lang="scss">
+.comic-infos-grid {
+  display: grid;
+  align-items: start;
+  gap: 3rem;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
+}
+</style>

--- a/web/app/pages/browse/sources/kingofshojo/index.vue
+++ b/web/app/pages/browse/sources/kingofshojo/index.vue
@@ -58,7 +58,7 @@ async function doToggleComic(comic: KingOfShojoSearchItem): Promise<void> {
 }
 
 onBeforeRouteLeave((to: RouteLocationNormalized) => {
-  if ((to.name as string) !== 'browse-sources-kingofshojo-slug') {
+  if (to.name !== 'browse-sources-kingofshojo-slug') {
     resetFilters()
   }
 })


### PR DESCRIPTION
Closes #67

## Summary

- Add authenticated KingOfShojo series detail page at `/browse/sources/kingofshojo/{slug}` with metadata (title, cover, description, author/artist, status, type, genres) and link to the original site.
- Library actions mirror Asura: add via existing comics API, remove with confirm modal; chapters refresh when the comic enters/leaves the library.
- Full chapter list with client-side asc/desc sort, download progress polling (~2s), retry on failure, and early-access row treatment when applicable.
- 404 on unknown slug shows a toast and redirects back to the KingOfShojo browse page.

## Screenshots
<img width="1583" height="1349" alt="image" src="https://github.com/user-attachments/assets/b2ef58e1-715d-4c31-9b18-f80c56a83784" />

## Test plan

- [x] Open `/browse/sources/kingofshojo/{slug}` for a known series — metadata, cover, and original-site link render correctly.
- [x] Add a series to the library, then remove it via the confirm modal.
- [x] Chapter list loads fully, toggles between latest/oldest, and shows download progress for library comics.
- [x] Retry a failed chapter download and verify 404/403/409 toasts.
- [x] Visit an unknown slug — toast + redirect to browse.
- [x] `pnpm vitest run app/features/kingofshojo/components/Comic app/features/kingofshojo/composables/kingofshojo-chapters.composable.test.ts app/features/kingofshojo/stores/kingofshojo-chapters.store.test.ts`
