### PR TITLE
feat(comics): update comic type on library comics

### DIFF
--- a/api/cmd/uchiyomiserver/setup_internal_test.go
+++ b/api/cmd/uchiyomiserver/setup_internal_test.go
@@ -73,6 +73,10 @@ func (stubComicsRepository) UpdateStatusAndChapterCount(context.Context, comics.
 	return nil
 }
 
+func (stubComicsRepository) UpdateType(context.Context, comics.UpdateTypeOpts) error {
+	return nil
+}
+
 type stubFeedService struct{}
 
 func (stubFeedService) Get(context.Context, feed.GetOpts) (feed.Page, error) {

--- a/api/pkg/core/chapters/download/worker_test.go
+++ b/api/pkg/core/chapters/download/worker_test.go
@@ -145,6 +145,10 @@ func (f *fakeComicsRepository) UpdateStatusAndChapterCount(context.Context, comi
 	panic("not implemented")
 }
 
+func (f *fakeComicsRepository) UpdateType(context.Context, comics.UpdateTypeOpts) error {
+	panic("not implemented")
+}
+
 type fakeSource struct {
 	pageURLs []string
 }

--- a/api/pkg/core/comics/domain.go
+++ b/api/pkg/core/comics/domain.go
@@ -57,6 +57,7 @@ type ComicsRepository interface {
 	GetMany(context.Context, GetManyOpts) (Page, error)
 	ListByStatuses(context.Context, ListByStatusesOpts) ([]Comic, error)
 	UpdateStatusAndChapterCount(context.Context, UpdateStatusAndChapterCountOpts) error
+	UpdateType(context.Context, UpdateTypeOpts) error
 }
 
 type CreateComicOpts struct {
@@ -102,6 +103,7 @@ type ComicsService interface {
 	RefreshComic(context.Context, RefreshComicOpts) (*Comic, error)
 	RetryChapters(context.Context, RetryChaptersOpts) error
 	ServeCover(ctx context.Context, opts GetByIDOpts) (diskPath, contentType string, err error)
+	UpdateType(context.Context, UpdateTypeOpts) (*Comic, error)
 }
 
 type CreateOpts struct {
@@ -182,4 +184,10 @@ type UpdateStatusAndChapterCountOpts struct {
 	Status       sources.SeriesStatus
 	ID           uuid.UUID
 	ChapterCount int
+}
+
+type UpdateTypeOpts struct {
+	UserID uuid.UUID
+	ID     uuid.UUID
+	Type   sources.SeriesType
 }

--- a/api/pkg/core/comics/domain.go
+++ b/api/pkg/core/comics/domain.go
@@ -187,7 +187,7 @@ type UpdateStatusAndChapterCountOpts struct {
 }
 
 type UpdateTypeOpts struct {
+	Type   sources.SeriesType
 	UserID uuid.UUID
 	ID     uuid.UUID
-	Type   sources.SeriesType
 }

--- a/api/pkg/core/comics/gateway/http/controller.go
+++ b/api/pkg/core/comics/gateway/http/controller.go
@@ -94,6 +94,7 @@ func (c *Controller) InitRouter(r chi.Router) {
 		r.Post("/{id}/retry", c.retryChapters)
 		r.Get("/{id}/cover", c.serveCover)
 		r.Get("/{id}", c.getByID)
+		r.Patch("/{id}", c.updateType)
 		r.Delete("/{id}", c.deleteByID)
 	})
 }
@@ -162,6 +163,64 @@ func (c *Controller) getByID(w http.ResponseWriter, r *http.Request) {
 		}
 
 		c.deps.Logger.Error("failed to get comic by id", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	httputils.WriteJSON(w, c.deps.Logger, http.StatusOK, comicResponseFromDomain(comic))
+}
+
+func (c *Controller) updateType(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user, ok := httpsession.UserFrom(ctx)
+	if !ok {
+		c.deps.Logger.Error("user not found in context")
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+
+		return
+	}
+
+	id, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "id must be a valid UUID")
+
+		return
+	}
+
+	req, err := httputils.DecodeJSON[updateComicRequest](r)
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "invalid request body")
+
+		return
+	}
+
+	seriesType, err := sources.ParseSeriesType(string(req.Type))
+	if err != nil {
+		httputils.WriteError(w, c.deps.Logger, http.StatusBadRequest, "invalid comic type")
+
+		return
+	}
+
+	comic, err := c.deps.ComicsService.UpdateType(ctx, comics.UpdateTypeOpts{
+		UserID: user.ID,
+		ID:     id,
+		Type:   seriesType,
+	})
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusNotFound, "comic not found")
+
+			return
+		}
+
+		if errors.Is(err, domain.ErrForbidden) {
+			httputils.WriteError(w, c.deps.Logger, http.StatusForbidden, "comic not in library")
+
+			return
+		}
+
+		c.deps.Logger.Error("failed to update comic type", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 
 		return

--- a/api/pkg/core/comics/gateway/http/controller_test.go
+++ b/api/pkg/core/comics/gateway/http/controller_test.go
@@ -37,6 +37,7 @@ const (
 	testComicSlug  = "solo-leveling"
 )
 
+//nolint:govet // fieldalignment on a test fake is not worth the unreadable field order
 type stubComicsService struct {
 	createErr          error
 	getByIDErr         error
@@ -45,16 +46,20 @@ type stubComicsService struct {
 	serveCoverErr      error
 	refreshComicErr    error
 	retryChaptersErr   error
+	updateTypeErr      error
 	createResult       *comics.Comic
 	getByIDResult      *comics.Comic
 	refreshComicResult *comics.Comic
-	serveCoverPath     string
-	serveCoverType     string
+	updateTypeResult   *comics.Comic
 	getManyResult      comics.Page
 	lastGetMany        comics.GetManyOpts
 	lastRetryChapters  comics.RetryChaptersOpts
-	serveCoverCalls    int
+	serveCoverPath     string
+	serveCoverType     string
+	lastUpdateType     comics.UpdateTypeOpts
 	lastServeCoverID   uuid.UUID
+	serveCoverCalls    int
+	updateTypeCalls    int
 }
 
 func (s *stubComicsService) Create(_ context.Context, _ comics.CreateOpts) (*comics.Comic, error) {
@@ -94,6 +99,13 @@ func (s *stubComicsService) ServeCover(_ context.Context, opts comics.GetByIDOpt
 	s.lastServeCoverID = opts.ID
 
 	return s.serveCoverPath, s.serveCoverType, s.serveCoverErr
+}
+
+func (s *stubComicsService) UpdateType(_ context.Context, opts comics.UpdateTypeOpts) (*comics.Comic, error) {
+	s.updateTypeCalls++
+	s.lastUpdateType = opts
+
+	return s.updateTypeResult, s.updateTypeErr
 }
 
 type stubSessionService struct {
@@ -284,10 +296,11 @@ type comicshttpPage struct {
 }
 
 type comicshttpDetail struct {
-	Cover        string    `json:"cover"`
-	AltTitles    []string  `json:"altTitles"`
-	ChapterCount int       `json:"chapterCount"`
-	ID           uuid.UUID `json:"id"`
+	Type         sources.SeriesType `json:"type"`
+	Cover        string             `json:"cover"`
+	AltTitles    []string           `json:"altTitles"`
+	ChapterCount int                `json:"chapterCount"`
+	ID           uuid.UUID          `json:"id"`
 }
 
 func TestGetByIDNotFound(t *testing.T) {
@@ -849,5 +862,137 @@ func TestRetryChaptersAccepted(t *testing.T) {
 	last := svc.lastRetryChapters
 	if last.ComicID != comicID || last.UserID != user.ID || len(last.ChapterIDs) != 1 || last.ChapterIDs[0] != chapterID {
 		t.Errorf("unexpected lastRetryChapters: %+v", last)
+	}
+}
+
+func TestUpdateTypeSuccess(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.New()
+	userID := uuid.New()
+	user := &users.User{ID: userID, Name: testUsername}
+	stub := &stubComicsService{
+		updateTypeResult: &comics.Comic{
+			ID:           id,
+			Title:        testComicTitle,
+			Slug:         testComicSlug,
+			Source:       sources.SourceKingOfShojo,
+			Status:       sources.SeriesStatusOngoing,
+			Type:         sources.SeriesTypeManga,
+			ChapterCount: 10,
+		},
+	}
+	r := newTestRouter(t, stub, authenticatorFor(t, user))
+
+	body := []byte(`{"type":"manga"}`)
+	req := httptest.NewRequest(http.MethodPatch, comicsEndpoint+"/"+id.String(), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var res comicshttpDetail
+	if err := json.NewDecoder(rec.Body).Decode(&res); err != nil {
+		t.Fatalf("json decode: %v", err)
+	}
+
+	if res.Type != sources.SeriesTypeManga {
+		t.Errorf("res.Type = %q, want %q", res.Type, sources.SeriesTypeManga)
+	}
+	if stub.lastUpdateType.ID != id {
+		t.Errorf("stub.lastUpdateType.ID = %v, want %v", stub.lastUpdateType.ID, id)
+	}
+	if stub.lastUpdateType.UserID != userID {
+		t.Errorf("stub.lastUpdateType.UserID = %v, want %v", stub.lastUpdateType.UserID, userID)
+	}
+}
+
+func TestUpdateTypeInvalidUUID(t *testing.T) {
+	t.Parallel()
+
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	r := newTestRouter(t, &stubComicsService{}, authenticatorFor(t, user))
+
+	body := []byte(`{"type":"manga"}`)
+	req := httptest.NewRequest(http.MethodPatch, comicsEndpoint+"/invalid-uuid", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestUpdateTypeInvalidType(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.New()
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	r := newTestRouter(t, &stubComicsService{}, authenticatorFor(t, user))
+
+	body := []byte(`{"type":"invalid_type"}`)
+	req := httptest.NewRequest(http.MethodPatch, comicsEndpoint+"/"+id.String(), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestUpdateTypeNotFound(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.New()
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	stub := &stubComicsService{
+		updateTypeErr: domain.ErrNotFound,
+	}
+	r := newTestRouter(t, stub, authenticatorFor(t, user))
+
+	body := []byte(`{"type":"manga"}`)
+	req := httptest.NewRequest(http.MethodPatch, comicsEndpoint+"/"+id.String(), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestUpdateTypeForbidden(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.New()
+	user := &users.User{ID: uuid.New(), Name: testUsername}
+	stub := &stubComicsService{
+		updateTypeErr: domain.ErrForbidden,
+	}
+	r := newTestRouter(t, stub, authenticatorFor(t, user))
+
+	body := []byte(`{"type":"manga"}`)
+	req := httptest.NewRequest(http.MethodPatch, comicsEndpoint+"/"+id.String(), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	rec := httptest.NewRecorder()
+
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusForbidden)
 	}
 }

--- a/api/pkg/core/comics/gateway/http/dto.go
+++ b/api/pkg/core/comics/gateway/http/dto.go
@@ -56,6 +56,10 @@ type createRequest struct {
 	Slug   string             `json:"slug" validate:"required"`
 }
 
+type updateComicRequest struct {
+	Type sources.SeriesType `json:"type"`
+}
+
 type comicResponse struct {
 	Artist       string               `json:"artist"`
 	Type         sources.SeriesType   `json:"type"`

--- a/api/pkg/core/comics/refresh/app_test.go
+++ b/api/pkg/core/comics/refresh/app_test.go
@@ -76,6 +76,10 @@ func (f *fakeComicsService) ServeCover(context.Context, comics.GetByIDOpts) (str
 	panic("ServeCover must not be called")
 }
 
+func (f *fakeComicsService) UpdateType(context.Context, comics.UpdateTypeOpts) (*comics.Comic, error) {
+	panic("UpdateType must not be called")
+}
+
 func TestNewRejectsShortInterval(t *testing.T) {
 	t.Parallel()
 

--- a/api/pkg/core/comics/repository/pg/repository.go
+++ b/api/pkg/core/comics/repository/pg/repository.go
@@ -292,6 +292,27 @@ func (r *PGComicsRepository) UpdateStatusAndChapterCount(
 	return nil
 }
 
+func (r *PGComicsRepository) UpdateType(
+	ctx context.Context,
+	opts comics.UpdateTypeOpts,
+) error {
+	values := map[string]any{
+		"comic_type": pgmodels.ComicTypeFromDomain(opts.Type),
+		"updated_at": time.Now(),
+	}
+
+	rows, err := r.db(ctx).Where("id = ?", opts.ID).Set(clause.Assignments(values)).Update(ctx)
+	if err != nil {
+		return fmt.Errorf("r.db(ctx).Update: %w", err)
+	}
+
+	if rows == 0 {
+		return domain.ErrNotFound
+	}
+
+	return nil
+}
+
 // nolint:lll
 func (r *PGComicsRepository) GetBySlugsAndSource(ctx context.Context, opts comics.GetBySlugsAndSource) ([]comics.Comic, error) {
 	if len(opts.Slugs) == 0 {

--- a/api/pkg/core/comics/repository/pg/repository_test.go
+++ b/api/pkg/core/comics/repository/pg/repository_test.go
@@ -596,6 +596,56 @@ func TestUpdateStatusAndChapterCountNotFound(t *testing.T) {
 	}
 }
 
+func TestUpdateType(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newComicsRepo(t)
+	id := uuid.New()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "comics" SET "comic_type"=\$1,"updated_at"=\$2 WHERE id = \$3`).
+		WithArgs(string(sources.SeriesTypeManga), sqlmock.AnyArg(), id).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	err := r.UpdateType(context.Background(), comics.UpdateTypeOpts{
+		ID:   id,
+		Type: sources.SeriesTypeManga,
+	})
+	if err != nil {
+		t.Fatalf("UpdateType: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestUpdateTypeNotFound(t *testing.T) {
+	t.Parallel()
+
+	r, mock := newComicsRepo(t)
+	id := uuid.New()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "comics" SET "comic_type"=\$1,"updated_at"=\$2 WHERE id = \$3`).
+		WithArgs(string(sources.SeriesTypeManga), sqlmock.AnyArg(), id).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	err := r.UpdateType(context.Background(), comics.UpdateTypeOpts{
+		ID:   id,
+		Type: sources.SeriesTypeManga,
+	})
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("UpdateType = %v, want ErrNotFound", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
 func TestGetBySlugsAndSource(t *testing.T) {
 	t.Parallel()
 

--- a/api/pkg/core/comics/service.go
+++ b/api/pkg/core/comics/service.go
@@ -353,3 +353,39 @@ func (s *Service) RetryChapters(ctx context.Context, opts RetryChaptersOpts) err
 
 	return nil
 }
+
+func (s *Service) UpdateType(ctx context.Context, opts UpdateTypeOpts) (*Comic, error) {
+	if _, err := sources.ParseSeriesType(string(opts.Type)); err != nil {
+		return nil, fmt.Errorf("sources.ParseSeriesType: %w", err)
+	}
+
+	comic, err := s.deps.ComicsRepository.FindByID(ctx, opts.ID)
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.ComicsRepository.FindByID: %w", err)
+	}
+
+	if comic == nil {
+		return nil, domain.ErrNotFound
+	}
+
+	inLibrary, err := s.deps.LibraryRepository.ExistsByUserAndComic(ctx, opts.UserID, opts.ID)
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.LibraryRepository.ExistsByUserAndComic: %w", err)
+	}
+
+	if !inLibrary {
+		return nil, domain.ErrForbidden
+	}
+
+	err = s.deps.ComicsRepository.UpdateType(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.ComicsRepository.UpdateType: %w", err)
+	}
+
+	updated, err := s.deps.ComicsRepository.FindByID(ctx, opts.ID)
+	if err != nil {
+		return nil, fmt.Errorf("s.deps.ComicsRepository.FindByID: %w", err)
+	}
+
+	return updated, nil
+}

--- a/api/pkg/core/comics/service_test.go
+++ b/api/pkg/core/comics/service_test.go
@@ -89,6 +89,7 @@ type fakeComicsRepository struct {
 	getManyErr             error
 	listByStatusesErr      error
 	updateStatusErr        error
+	updateTypeErr          error
 	getByIDResult          *comics.Comic
 	findByIDResult         *comics.Comic
 	findBySourceSlugResult *comics.Comic
@@ -98,6 +99,7 @@ type fakeComicsRepository struct {
 	listByStatusesResult   []comics.Comic
 	getManyResult          comics.Page
 	lastUpdateStatus       comics.UpdateStatusAndChapterCountOpts
+	lastUpdateType         comics.UpdateTypeOpts
 	lastCreateOpts         comics.CreateComicOpts
 	findBySourceSlugCalls  int
 	createCalls            int
@@ -107,6 +109,7 @@ type fakeComicsRepository struct {
 	deleteCalls            int
 	listByStatusesCalls    int
 	updateStatusCalls      int
+	updateTypeCalls        int
 	lastDeleteID           uuid.UUID
 }
 
@@ -212,6 +215,17 @@ func (f *fakeComicsRepository) UpdateStatusAndChapterCount(
 	}
 
 	return f.updateStatusErr
+}
+
+func (f *fakeComicsRepository) UpdateType(_ context.Context, opts comics.UpdateTypeOpts) error {
+	f.updateTypeCalls++
+	f.lastUpdateType = opts
+
+	if f.findByIDResult != nil && f.findByIDResult.ID == opts.ID {
+		f.findByIDResult.Type = opts.Type
+	}
+
+	return f.updateTypeErr
 }
 
 type fakeLibraryRepository struct {
@@ -430,6 +444,31 @@ func (f *fakeSource) GetChaptersBySlug(
 
 func (f *fakeSource) GetPageURLsByChapter(context.Context, sources.GetPageURLsByChapterOpts) ([]string, error) {
 	return nil, nil
+}
+
+type serviceDepsOverrides struct {
+	comicsRepo  *fakeComicsRepository
+	libraryRepo *fakeLibraryRepository
+}
+
+func newServiceWithDeps(t *testing.T, overrides serviceDepsOverrides) *comics.Service {
+	t.Helper()
+
+	deps := validServiceDeps()
+	if overrides.comicsRepo != nil {
+		deps.ComicsRepository = overrides.comicsRepo
+	}
+
+	if overrides.libraryRepo != nil {
+		deps.LibraryRepository = overrides.libraryRepo
+	}
+
+	svc, err := comics.NewService(deps)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	return svc
 }
 
 func validServiceDeps() comics.Deps {
@@ -1293,5 +1332,113 @@ func TestServiceRetryChaptersSuccess(t *testing.T) {
 
 	if len(fakeChapters.retryDownloadCalls) != 2 {
 		t.Fatalf("expected 2 retry calls (excluding 100%%), got %d", len(fakeChapters.retryDownloadCalls))
+	}
+}
+
+func TestUpdateTypeSuccess(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	userID := uuid.New()
+	existingComic := &comics.Comic{
+		ID:   comicID,
+		Type: sources.SeriesTypeMangatoon,
+	}
+
+	repo := &fakeComicsRepository{
+		findByIDResult: existingComic,
+	}
+	libRepo := &fakeLibraryRepository{
+		inLibrary: true,
+	}
+
+	svc := newServiceWithDeps(t, serviceDepsOverrides{
+		comicsRepo:  repo,
+		libraryRepo: libRepo,
+	})
+
+	res, err := svc.UpdateType(context.Background(), comics.UpdateTypeOpts{
+		UserID: userID,
+		ID:     comicID,
+		Type:   sources.SeriesTypeManga,
+	})
+	if err != nil {
+		t.Fatalf("UpdateType: %v", err)
+	}
+
+	if res == nil {
+		t.Fatal("expected non-nil comic response")
+	}
+
+	if res.Type != sources.SeriesTypeManga {
+		t.Errorf("res.Type = %v, want manga", res.Type)
+	}
+
+	if repo.updateTypeCalls != 1 {
+		t.Errorf("repo.updateTypeCalls = %d, want 1", repo.updateTypeCalls)
+	}
+
+	if repo.lastUpdateType.Type != sources.SeriesTypeManga {
+		t.Errorf("repo.lastUpdateType.Type = %v, want manga", repo.lastUpdateType.Type)
+	}
+}
+
+func TestUpdateTypeInvalidSeriesType(t *testing.T) {
+	t.Parallel()
+
+	svc := newServiceWithDeps(t, serviceDepsOverrides{})
+
+	_, err := svc.UpdateType(context.Background(), comics.UpdateTypeOpts{
+		UserID: uuid.New(),
+		ID:     uuid.New(),
+		Type:   sources.SeriesType("invalid"),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid series type, got nil")
+	}
+}
+
+func TestUpdateTypeComicNotFound(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeComicsRepository{
+		findByIDErr: domain.ErrNotFound,
+	}
+	svc := newServiceWithDeps(t, serviceDepsOverrides{
+		comicsRepo: repo,
+	})
+
+	_, err := svc.UpdateType(context.Background(), comics.UpdateTypeOpts{
+		UserID: uuid.New(),
+		ID:     uuid.New(),
+		Type:   sources.SeriesTypeManga,
+	})
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("UpdateType = %v, want ErrNotFound", err)
+	}
+}
+
+func TestUpdateTypeNotInLibrary(t *testing.T) {
+	t.Parallel()
+
+	comicID := uuid.New()
+	repo := &fakeComicsRepository{
+		findByIDResult: &comics.Comic{ID: comicID},
+	}
+	libRepo := &fakeLibraryRepository{
+		inLibrary: false,
+	}
+	svc := newServiceWithDeps(t, serviceDepsOverrides{
+		comicsRepo:  repo,
+		libraryRepo: libRepo,
+	})
+
+	_, err := svc.UpdateType(context.Background(), comics.UpdateTypeOpts{
+		UserID: uuid.New(),
+		ID:     comicID,
+		Type:   sources.SeriesTypeManga,
+	})
+	if !errors.Is(err, domain.ErrForbidden) {
+		t.Fatalf("UpdateType = %v, want ErrForbidden", err)
 	}
 }

--- a/api/pkg/core/fixture_internal_test.go
+++ b/api/pkg/core/fixture_internal_test.go
@@ -356,6 +356,10 @@ func (stubComicsRepository) UpdateStatusAndChapterCount(context.Context, comics.
 	return nil
 }
 
+func (stubComicsRepository) UpdateType(context.Context, comics.UpdateTypeOpts) error {
+	return nil
+}
+
 type fakeComicsService struct{}
 
 func (fakeComicsService) Create(context.Context, comics.CreateOpts) (*comics.Comic, error) {
@@ -388,6 +392,10 @@ func (fakeComicsService) RetryChapters(context.Context, comics.RetryChaptersOpts
 
 func (fakeComicsService) ServeCover(context.Context, comics.GetByIDOpts) (string, string, error) {
 	return "", "", errors.New(notImplemented)
+}
+
+func (fakeComicsService) UpdateType(context.Context, comics.UpdateTypeOpts) (*comics.Comic, error) {
+	return nil, errors.New(notImplemented)
 }
 
 type fakeChaptersService struct{}

--- a/api/pkg/sources/asurascans/pkg/core/app_test.go
+++ b/api/pkg/sources/asurascans/pkg/core/app_test.go
@@ -69,6 +69,10 @@ func (stubComicsRepository) UpdateStatusAndChapterCount(context.Context, comics.
 	return nil
 }
 
+func (stubComicsRepository) UpdateType(context.Context, comics.UpdateTypeOpts) error {
+	return nil
+}
+
 type libraryComicsRepository struct {
 	err    error
 	comics []comics.Comic
@@ -117,6 +121,10 @@ func (r libraryComicsRepository) ListByStatuses(context.Context, comics.ListBySt
 }
 
 func (r libraryComicsRepository) UpdateStatusAndChapterCount(context.Context, comics.UpdateStatusAndChapterCountOpts) error {
+	return nil
+}
+
+func (r libraryComicsRepository) UpdateType(context.Context, comics.UpdateTypeOpts) error {
 	return nil
 }
 
@@ -172,6 +180,10 @@ func (r inLibraryComicsRepository) ListByStatuses(context.Context, comics.ListBy
 }
 
 func (r inLibraryComicsRepository) UpdateStatusAndChapterCount(context.Context, comics.UpdateStatusAndChapterCountOpts) error {
+	return nil
+}
+
+func (r inLibraryComicsRepository) UpdateType(context.Context, comics.UpdateTypeOpts) error {
 	return nil
 }
 

--- a/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
+++ b/api/pkg/sources/asurascans/pkg/gateway/http/controller_test.go
@@ -79,6 +79,10 @@ func (stubComicsRepository) UpdateStatusAndChapterCount(context.Context, comics.
 	return nil
 }
 
+func (stubComicsRepository) UpdateType(context.Context, comics.UpdateTypeOpts) error {
+	return nil
+}
+
 type inLibraryComicsRepository struct {
 	comic *comics.Comic
 }
@@ -126,6 +130,10 @@ func (r inLibraryComicsRepository) ListByStatuses(context.Context, comics.ListBy
 }
 
 func (r inLibraryComicsRepository) UpdateStatusAndChapterCount(context.Context, comics.UpdateStatusAndChapterCountOpts) error {
+	return nil
+}
+
+func (r inLibraryComicsRepository) UpdateType(context.Context, comics.UpdateTypeOpts) error {
 	return nil
 }
 

--- a/api/pkg/sources/kingofshojo/pkg/core/app_test.go
+++ b/api/pkg/sources/kingofshojo/pkg/core/app_test.go
@@ -70,6 +70,10 @@ func (stubComicsRepository) UpdateStatusAndChapterCount(context.Context, comics.
 	return nil
 }
 
+func (stubComicsRepository) UpdateType(context.Context, comics.UpdateTypeOpts) error {
+	return nil
+}
+
 type libraryComicsRepository struct {
 	err    error
 	comics []comics.Comic
@@ -118,6 +122,10 @@ func (r libraryComicsRepository) ListByStatuses(context.Context, comics.ListBySt
 }
 
 func (r libraryComicsRepository) UpdateStatusAndChapterCount(context.Context, comics.UpdateStatusAndChapterCountOpts) error {
+	return nil
+}
+
+func (r libraryComicsRepository) UpdateType(context.Context, comics.UpdateTypeOpts) error {
 	return nil
 }
 
@@ -173,6 +181,10 @@ func (r inLibraryComicsRepository) ListByStatuses(context.Context, comics.ListBy
 }
 
 func (r inLibraryComicsRepository) UpdateStatusAndChapterCount(context.Context, comics.UpdateStatusAndChapterCountOpts) error {
+	return nil
+}
+
+func (r inLibraryComicsRepository) UpdateType(context.Context, comics.UpdateTypeOpts) error {
 	return nil
 }
 

--- a/api/pkg/sources/kingofshojo/pkg/gateway/http/controller_test.go
+++ b/api/pkg/sources/kingofshojo/pkg/gateway/http/controller_test.go
@@ -86,6 +86,10 @@ func (stubComicsRepository) UpdateStatusAndChapterCount(context.Context, comics.
 	return nil
 }
 
+func (stubComicsRepository) UpdateType(context.Context, comics.UpdateTypeOpts) error {
+	return nil
+}
+
 func coverURLBuilder(source, slug string) string {
 	return "/api/sources/cover/" + slug + "?source=" + source
 }

--- a/web/app/features/comics/components/Chip/Type.vue
+++ b/web/app/features/comics/components/Chip/Type.vue
@@ -2,21 +2,100 @@
 <script setup lang="ts">
 import type { ComicType } from '../../types'
 
-withDefaults(defineProps<{
+const props = withDefaults(defineProps<{
   type: ComicType
+  updatable?: boolean
   size?: 'default' | 'small'
 }>(), { size: 'default' })
+
+const emit = defineEmits<{ 'update:type': [ComicType] }>()
+
+const { t } = useI18n()
+
+const menuItems: { label: string, value: ComicType }[] = [
+  {
+    label: t('comics.type.manga'),
+    value: 'manga',
+  },
+  {
+    label: t('comics.type.manhua'),
+    value: 'manhua',
+  },
+  {
+    label: t('comics.type.manhwa'),
+    value: 'manhwa',
+  },
+  {
+    label: t('comics.type.mangatoon'),
+    value: 'mangatoon',
+  },
+]
+
+const showMenu = ref(false)
+
+function toggleItem(item: ComicType): void {
+  if (item !== props.type) {
+    emit('update:type', item)
+  }
+
+  showMenu.value = false
+}
 </script>
 
 <template>
   <span
-    class="ga-3 w-fit h-fit px-2 py-1 border-thin text-truncate text-uppercase bg-background"
+    class="ga-3 w-fit h-fit px-2 py-1 border-thin text-truncate text-uppercase bg-background d-flex ga-1 align-center"
     :class="{
       'text-body-large': size === 'default',
       'text-body-medium': size === 'small',
+      'cursor-pointer': updatable,
     }"
     :style="{ borderRadius: '12px' }"
   >
-    <span class="">{{ $t(`sources.asurascans.type.${type}`) }}</span>
+    <span>{{ $t(`comics.type.${type}`) }}</span>
+    <template v-if="updatable">
+      <VIcon
+        icon="fa6-solid:pencil"
+        class="text-label-small"
+        size="x-small"
+      />
+      <VMenu
+        v-model="showMenu"
+        activator="parent"
+        location="bottom center"
+        offset="8"
+      >
+        <div
+          class="d-flex flex-column bg-surface border-thin transition-smooth pa-2"
+          style="border-radius: 12px;"
+        >
+          <div
+            v-for="item in menuItems"
+            :key="item.value"
+            class="px-2 py-1 type-chip-item"
+            :class="{ 'type-chip-item-active': type === item.value }"
+            @click="toggleItem(item.value)"
+          >
+            <span class="transition-smooth">{{ $t(`comics.type.${item.value}`) }}</span>
+          </div>
+        </div>
+      </VMenu>
+    </template>
   </span>
 </template>
+
+<style scoped lang="scss">
+.type-chip-item {
+  cursor: pointer;
+  border-radius: 8px;
+
+  &:hover {
+    color: rgb(var(--v-theme-primary));
+  }
+}
+
+.type-chip-item-active {
+  background-color: rgba(var(--v-theme-primary), 0.1);
+  color: rgb(var(--v-theme-primary));
+}
+</style>

--- a/web/app/features/comics/components/StatusInfos.vue
+++ b/web/app/features/comics/components/StatusInfos.vue
@@ -1,8 +1,10 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script setup lang="ts">
-import type { Comic } from '../types'
+import type { Comic, ComicType } from '../types'
 
 defineProps<{ comic: Comic }>()
+
+defineEmits<{ 'update:type': [ComicType] }>()
 </script>
 
 <template>
@@ -12,7 +14,11 @@ defineProps<{ comic: Comic }>()
   >
     <div class="d-flex flex-wrap ga-4">
       <ComicsChipStatus :status="comic.status" />
-      <ComicsChipType :type="comic.type" />
+      <ComicsChipType
+        :type="comic.type"
+        updatable
+        @update:type="$emit('update:type', $event)"
+      />
       <ComicsChipSource :source="comic.source" />
     </div>
 

--- a/web/app/features/comics/composables/comics.api.ts
+++ b/web/app/features/comics/composables/comics.api.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import type { Comic, ComicProgress, LightComic, SearchComicParams, SearchComicResponse, SetChaptersProgressParams } from '../types'
+import type { Comic, ComicProgress, ComicType, LightComic, SearchComicParams, SearchComicResponse, SetChaptersProgressParams } from '../types'
 import type { ApiResponse } from '~/utils/api'
 import { ApiError, initApi } from '~/utils/api'
 
@@ -13,6 +13,7 @@ export interface ComicsApi {
   getProgress: (id: string) => Promise<ApiResponse<ComicProgress>>
   setChaptersProgress: (params: SetChaptersProgressParams) => Promise<ApiResponse<void>>
   retryChaptersDownload: (comicId: string, chapterIds: string[]) => Promise<ApiResponse<void>>
+  updateType: (id: string, type: ComicType) => Promise<ApiResponse<void>>
 }
 
 export interface CreateComicParams {
@@ -119,6 +120,16 @@ export function createComicsApi(): ComicsApi {
     }
   }
 
+  async function updateType(id: string, type: ComicType): Promise<ApiResponse<void>> {
+    try {
+      await api<void>(`/${id}`, { method: 'PATCH', body: { type } })
+
+      return { success: true, data: undefined }
+    } catch (error) {
+      return { success: false, error: ApiError.fromFetchError(error) }
+    }
+  }
+
   return {
     create,
     deleteById,
@@ -128,5 +139,6 @@ export function createComicsApi(): ComicsApi {
     getProgress,
     setChaptersProgress,
     retryChaptersDownload,
+    updateType,
   }
 }

--- a/web/app/pages/comic/[id]/index.vue
+++ b/web/app/pages/comic/[id]/index.vue
@@ -110,6 +110,20 @@ async function refreshComic(): Promise<void> {
 }
 
 const showDeleteModal = ref(false)
+
+watch(() => comic.value?.type, async (newType, oldType) => {
+  if (!comic.value) {
+    return
+  }
+
+  if (!!newType && !!oldType && newType !== oldType) {
+    const response = await api.updateType(comic.value.id, newType)
+    if (!response.success) {
+      console.error('api.updateType', response.error)
+      comic.value.type = oldType
+    }
+  }
+})
 </script>
 
 <template>
@@ -165,6 +179,7 @@ const showDeleteModal = ref(false)
         <ComicsStatusInfos
           v-if="!smAndDown"
           :comic
+          @update:type="comic.type = $event"
         />
       </div>
 
@@ -194,7 +209,12 @@ const showDeleteModal = ref(false)
             <template v-if="smAndDown">
               <div class="d-flex flex-wrap ga-3 align-center my-1">
                 <ComicsIconStatus :status="comic.status" with-background />
-                <ComicsChipType :type="comic.type" size="small" />
+                <ComicsChipType
+                  :type="comic.type"
+                  size="small"
+                  updatable
+                  @update:type="comic.type = $event"
+                />
                 <ComicsChipSource
                   :source="comic.source"
                   size="small"

--- a/web/i18n/locales/en.json
+++ b/web/i18n/locales/en.json
@@ -360,6 +360,12 @@
     },
     "refresh": {
       "title": "Refresh"
+    },
+    "type": {
+      "manga": "Manga",
+      "manhua": "Manhua",
+      "manhwa": "Manhwa",
+      "mangatoon": "Mangatoon"
     }
   },
   "comic": {

--- a/web/i18n/locales/fr.json
+++ b/web/i18n/locales/fr.json
@@ -359,6 +359,12 @@
     },
     "refresh": {
       "title": "Rafraîchir"
+    },
+    "type": {
+      "manga": "Manga",
+      "manhua": "Manhua",
+      "manhwa": "Manhwa",
+      "mangatoon": "Mangatoon"
     }
   },
   "library": {


### PR DESCRIPTION
Closes #123

## Summary

- Add `UpdateType` support across backend domain, repository, service, and HTTP layers to allow updating a comic's type (`manga`, `manhwa`, `manhua`, `mangatoon`).
- Expose `PATCH /api/comics/{id}` endpoint with `{ "type": "manga" | "manhwa" | "manhua" | "mangatoon" }` payload and proper validation/error handling.
- Extend frontend `ComicsStatusInfos` and `ComicsChipType` to allow interactive type selection via a menu on the comic detail page for library comics.
- Add i18n keys for comic type options, tooltips, and update feedback in English and French.

## Screenshots

<img width="429" height="287" alt="image" src="https://github.com/user-attachments/assets/def8427b-45aa-4faa-83b9-1a9339feac9c" />


## Test plan

- [x] Backend tests: `go test ./...` in `api/` (all tests pass, including service, repository, and controller test suites).
- [x] Backend lint: `golangci-lint run ./...` in `api/`.
- [x] Frontend tests: `pnpm test` in `web/` (all 129 test files, 801 tests pass).
- [x] Frontend typecheck, lint & knip: `pnpm typecheck`, `pnpm lint`, and `pnpm knip` pass in `web/`.
- [x] Change comic type from comic detail page and verify the badge and state update immediately.