### PR TITLE
fix: restore library access for non-admin users

### DIFF
--- a/api/cmd/uchiyomiserver/setup.go
+++ b/api/cmd/uchiyomiserver/setup.go
@@ -921,7 +921,7 @@ type ctrlsDeps struct {
 	Registry               *health.Registry
 	AuthService            *auth.Service
 	OIDCProvidersService   *oidcproviders.Service
-	ComicsService          *comics.Service
+	ComicsService          comics.ComicsService
 	ChaptersService        *chapters.Service
 }
 
@@ -1061,7 +1061,7 @@ func setupCtrls(deps ctrlsDeps) (*ctrls, error) {
 	comicsCtrl, err := httpcomics.New(
 		httpcomics.Config{
 			Endpoint:    "/comics",
-			Middlewares: chi.Middlewares{authenticator.Middleware, authenticator.RequireAdmin},
+			Middlewares: chi.Middlewares{authenticator.Middleware},
 		},
 		httpcomics.Deps{
 			Logger:        deps.Logger,

--- a/api/cmd/uchiyomiserver/setup_internal_test.go
+++ b/api/cmd/uchiyomiserver/setup_internal_test.go
@@ -25,6 +25,44 @@ import (
 	"github.com/kharente-deuh/uchiyomi-server/pkg/utils/health"
 )
 
+type stubComicsService struct{}
+
+func (stubComicsService) Create(context.Context, comics.CreateOpts) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (stubComicsService) GetByID(context.Context, comics.GetByIDOpts) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (stubComicsService) GetMany(context.Context, comics.GetManyOpts) (comics.Page, error) {
+	return comics.Page{}, nil
+}
+
+func (stubComicsService) Delete(context.Context, comics.DeleteOpts) error {
+	return nil
+}
+
+func (stubComicsService) RefreshChapterLists(context.Context) error {
+	return nil
+}
+
+func (stubComicsService) RefreshComic(context.Context, comics.RefreshComicOpts) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
+func (stubComicsService) RetryChapters(context.Context, comics.RetryChaptersOpts) error {
+	return nil
+}
+
+func (stubComicsService) ServeCover(context.Context, comics.GetByIDOpts) (string, string, error) {
+	return "", "", coredomain.ErrNotFound
+}
+
+func (stubComicsService) UpdateType(context.Context, comics.UpdateTypeOpts) (*comics.Comic, error) {
+	return nil, coredomain.ErrNotFound
+}
+
 type stubComicsRepository struct{}
 
 func (stubComicsRepository) GetByID(context.Context, comics.GetByIDOpts) (*comics.Comic, error) {
@@ -301,6 +339,7 @@ func newTestCtrlsForUser(t *testing.T, user *users.User) *ctrls {
 		AsuraScansApp:          asuraScansApp,
 		KingOfShojoApp:         kingOfShojoApp,
 		CoversService:          coversBundle.Service,
+		ComicsService:          stubComicsService{},
 		SessionsService:        newTestSessionsService(t, user),
 		Logger:                 logger,
 		Registry:               health.NewRegistry(),
@@ -357,6 +396,45 @@ func TestSetupCoversServeUnknownSource(t *testing.T) {
 	_, _, err = bundle.Service.Serve(context.Background(), "unknown", "solo-leveling")
 	if !errors.Is(err, covers.ErrUnknownSource) {
 		t.Errorf("Serve = %v, want ErrUnknownSource", err)
+	}
+}
+
+func TestComicsController(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		user       *users.User
+		wantStatus int
+	}{
+		"non-admin is let through": {
+			user:       &users.User{ID: uuid.New(), Name: "alice", IsAdmin: false},
+			wantStatus: http.StatusOK,
+		},
+		"admin is let through": {
+			user:       &users.User{ID: uuid.New(), Name: "root", IsAdmin: true},
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c := newTestCtrlsForUser(t, tc.user)
+
+			r := chi.NewRouter()
+			c.Comics.InitRouter(r)
+
+			req := httptest.NewRequest(http.MethodGet, "/comics", nil)
+			req.AddCookie(&http.Cookie{Name: "uchiyomi_session", Value: "any-token"})
+
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Errorf("GET /comics = %d, want %d (body: %s)", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+		})
 	}
 }
 

--- a/api/cmd/uchiyomiserver/setup_internal_test.go
+++ b/api/cmd/uchiyomiserver/setup_internal_test.go
@@ -399,57 +399,65 @@ func TestSetupCoversServeUnknownSource(t *testing.T) {
 	}
 }
 
-func TestComicsController(t *testing.T) {
+const (
+	testSessionCookie = "uchiyomi_session"
+	comicsPath        = "/comics"
+	oidcProvidersPath = "/oidc/providers"
+)
+
+func serveAuthedGET(
+	t *testing.T,
+	user *users.User,
+	path string,
+	mount func(*ctrls, chi.Router),
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	c := newTestCtrlsForUser(t, user)
+	r := chi.NewRouter()
+	mount(c, r)
+
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.AddCookie(&http.Cookie{Name: testSessionCookie, Value: "any-token"})
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	return rec
+}
+
+type adminGateCase struct {
+	mount      func(*ctrls, chi.Router)
+	user       *users.User
+	path       string
+	wantStatus int
+}
+
+func TestControllerAdminGates(t *testing.T) {
 	t.Parallel()
 
-	tests := map[string]struct {
-		user       *users.User
-		wantStatus int
-	}{
-		"non-admin is let through": {
+	tests := map[string]adminGateCase{
+		"comics: non-admin is let through": {
+			path:       comicsPath,
+			mount:      func(c *ctrls, r chi.Router) { c.Comics.InitRouter(r) },
 			user:       &users.User{ID: uuid.New(), Name: "alice", IsAdmin: false},
 			wantStatus: http.StatusOK,
 		},
-		"admin is let through": {
+		"comics: admin is let through": {
+			path:       comicsPath,
+			mount:      func(c *ctrls, r chi.Router) { c.Comics.InitRouter(r) },
 			user:       &users.User{ID: uuid.New(), Name: "root", IsAdmin: true},
 			wantStatus: http.StatusOK,
 		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			c := newTestCtrlsForUser(t, tc.user)
-
-			r := chi.NewRouter()
-			c.Comics.InitRouter(r)
-
-			req := httptest.NewRequest(http.MethodGet, "/comics", nil)
-			req.AddCookie(&http.Cookie{Name: "uchiyomi_session", Value: "any-token"})
-
-			rec := httptest.NewRecorder()
-			r.ServeHTTP(rec, req)
-
-			if rec.Code != tc.wantStatus {
-				t.Errorf("GET /comics = %d, want %d (body: %s)", rec.Code, tc.wantStatus, rec.Body.String())
-			}
-		})
-	}
-}
-
-func TestOIDCProvidersController(t *testing.T) {
-	t.Parallel()
-
-	tests := map[string]struct {
-		user       *users.User
-		wantStatus int
-	}{
-		"non-admin is rejected": {
+		"oidc: non-admin is rejected": {
+			path:       oidcProvidersPath,
+			mount:      func(c *ctrls, r chi.Router) { c.OIDCProviders.InitRouter(r) },
 			user:       &users.User{ID: uuid.New(), Name: "alice", IsAdmin: false},
 			wantStatus: http.StatusForbidden,
 		},
-		"admin is let through": {
+		"oidc: admin is let through": {
+			path:       oidcProvidersPath,
+			mount:      func(c *ctrls, r chi.Router) { c.OIDCProviders.InitRouter(r) },
 			user:       &users.User{ID: uuid.New(), Name: "root", IsAdmin: true},
 			wantStatus: http.StatusOK,
 		},
@@ -459,19 +467,9 @@ func TestOIDCProvidersController(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			c := newTestCtrlsForUser(t, tc.user)
-
-			r := chi.NewRouter()
-			c.OIDCProviders.InitRouter(r)
-
-			req := httptest.NewRequest(http.MethodGet, "/oidc/providers", nil)
-			req.AddCookie(&http.Cookie{Name: "uchiyomi_session", Value: "any-token"})
-
-			rec := httptest.NewRecorder()
-			r.ServeHTTP(rec, req)
-
+			rec := serveAuthedGET(t, tc.user, tc.path, tc.mount)
 			if rec.Code != tc.wantStatus {
-				t.Errorf("GET /oidc/providers = %d, want %d (body: %s)", rec.Code, tc.wantStatus, rec.Body.String())
+				t.Errorf("GET %s = %d, want %d (body: %s)", tc.path, rec.Code, tc.wantStatus, rec.Body.String())
 			}
 		})
 	}

--- a/web/app/pages/settings/index.vue
+++ b/web/app/pages/settings/index.vue
@@ -1,11 +1,11 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script setup lang="ts">
 import type { RouteLocationRaw } from 'vue-router'
-import { ADMIN_ROUTE_GROUP, AUTHENTICATED_ROUTE_GROUP } from '~/constants/auth'
+import { AUTHENTICATED_ROUTE_GROUP } from '~/constants/auth'
 
 definePageMeta({
   layout: 'default',
-  authGroups: [AUTHENTICATED_ROUTE_GROUP, ADMIN_ROUTE_GROUP],
+  authGroups: [AUTHENTICATED_ROUTE_GROUP],
 })
 
 const { isAdmin } = useAuth()

--- a/web/app/utils/guards/auth-guard.test.ts
+++ b/web/app/utils/guards/auth-guard.test.ts
@@ -51,17 +51,37 @@ describe('resolveAuthGuard', () => {
 })
 
 describe('resolveAuthGuard, admin group', () => {
-  const admin = routeStub({ name: 'settings', fullPath: '/settings', meta: { authGroups: [ADMIN_ROUTE_GROUP] } })
+  const oidc = routeStub({
+    name: 'settings-oidc',
+    fullPath: '/settings/oidc',
+    meta: { authGroups: [ADMIN_ROUTE_GROUP] },
+  })
 
   it('sends anonymous user to /login rather than bouncing through home', () => {
-    expect(resolveAuthGuard({ to: admin, ...ANONYMOUS })).toBe('/login?redirect=%2Fsettings')
+    expect(resolveAuthGuard({ to: oidc, ...ANONYMOUS })).toBe('/login?redirect=%2Fsettings%2Foidc')
   })
 
   it('redirects authenticated user without rights to home', () => {
-    expect(resolveAuthGuard({ to: admin, ...USER })).toBe(DEFAULT_PAGE)
+    expect(resolveAuthGuard({ to: oidc, ...USER })).toBe(DEFAULT_PAGE)
   })
 
   it('allows an admin through', () => {
-    expect(resolveAuthGuard({ to: admin, ...ADMIN })).toBeUndefined()
+    expect(resolveAuthGuard({ to: oidc, ...ADMIN })).toBeUndefined()
+  })
+})
+
+describe('resolveAuthGuard, settings hub', () => {
+  const settings = routeStub({
+    name: 'settings',
+    fullPath: '/settings',
+    meta: { authGroups: [AUTHENTICATED_ROUTE_GROUP] },
+  })
+
+  it('allows an authenticated non-admin through', () => {
+    expect(resolveAuthGuard({ to: settings, ...USER })).toBeUndefined()
+  })
+
+  it('sends anonymous user to /login', () => {
+    expect(resolveAuthGuard({ to: settings, ...ANONYMOUS })).toBe('/login?redirect=%2Fsettings')
   })
 })


### PR DESCRIPTION
Closes #133

## Summary

- Drop `RequireAdmin` on `/api/comics` so a signed-in user can list, add, open, type-update, and bulk-retry comics in their own library. Membership in that library remains the service-level 403 gate.
- Open `/settings` to every authenticated user so they can reach reader settings. OIDC provider pages and `/api/oidc/providers` stay admin-only.

## Test plan

- [ ] As a non-admin, add a comic from browse, see it on `/library`, open `/comic/:id`, change its type, retry one chapter and several chapters.
- [ ] Open `/settings` as a non-admin and save reader settings.
- [ ] Confirm 403 when the comic is not in that user's library.
- [ ] Confirm anonymous requests still get 401 (or the SPA login redirect).
- [x] Confirm a non-admin cannot open `/settings/oidc` or call `/api/oidc/providers`; an admin still can.
- [x] `go test ./cmd/uchiyomiserver/` and `pnpm vitest run app/utils/guards/auth-guard.test.ts`
- [x] Pre-push: API lint/test/build and web knip/lint/typecheck/test (803 tests)