### PR TITLE
fix(sources): enrich KingOfShojo catalogue cards via getInfosBySlug

### DIFF
--- a/web/app/features/sources/composables/sources-search.composable.test.ts
+++ b/web/app/features/sources/composables/sources-search.composable.test.ts
@@ -160,10 +160,6 @@ describe('useSourceSearch pagination', () => {
 })
 
 describe('useSourceSearch series infos enrichment', () => {
-  function kosItem(slug: string): SourceSearchItem {
-    return item(slug)
-  }
-
   it('does not call getInfosBySlug for asurascans search', async () => {
     search.mockResolvedValue({ success: true, data: { items: [item('solo')], hasNextPage: false } })
     useSourceSearch('asurascans', { doSearch: true })
@@ -178,7 +174,7 @@ describe('useSourceSearch series infos enrichment', () => {
   })
 
   it('patches status type and chapterCount from getInfosBySlug', async () => {
-    search.mockResolvedValue({ success: true, data: { items: [kosItem('solo')], hasNextPage: false } })
+    search.mockResolvedValue({ success: true, data: { items: [item('solo')], hasNextPage: false } })
     getInfosBySlug.mockResolvedValue({
       success: true,
       data: { slug: 'solo', status: 'completed', type: 'manhwa', chapterCount: 120 },
@@ -212,12 +208,13 @@ describe('useSourceSearch series infos enrichment', () => {
   it('leaves a failed slug unchanged, logs, and does not toast', async () => {
     search.mockResolvedValue({
       success: true,
-      data: { items: [kosItem('ok'), kosItem('missing')], hasNextPage: false },
+      data: { items: [item('ok'), item('missing')], hasNextPage: false },
     })
     getInfosBySlug.mockImplementation(async (slug: string) => {
       if (slug === 'missing') {
         return { success: false, error: { status: 404, message: 'missing' } }
       }
+
       return { success: true, data: { slug, status: 'completed', type: 'manhwa', chapterCount: 10 } }
     })
 
@@ -235,20 +232,19 @@ describe('useSourceSearch series infos enrichment', () => {
   })
 
   it('ignores stale enrichment after a new search', async () => {
-    let resolveFirst: (value: unknown) => void = () => {}
-    const firstInfos = new Promise((resolve) => {
-      resolveFirst = resolve
-    })
+    const { promise: firstInfos, resolve: resolveFirst } = Promise.withResolvers<unknown>()
 
     search
-      .mockResolvedValueOnce({ success: true, data: { items: [kosItem('old')], hasNextPage: false } })
-      .mockResolvedValueOnce({ success: true, data: { items: [kosItem('new')], hasNextPage: false } })
+      .mockResolvedValueOnce({ success: true, data: { items: [item('old')], hasNextPage: false } })
+      .mockResolvedValueOnce({ success: true, data: { items: [item('new')], hasNextPage: false } })
 
     getInfosBySlug.mockImplementation(async (slug: string) => {
       if (slug === 'old') {
         await firstInfos
+
         return { success: true, data: { slug: 'old', status: 'completed', type: 'manga', chapterCount: 99 } }
       }
+
       return { success: true, data: { slug: 'new', status: 'ongoing', type: 'manhwa', chapterCount: 2 } }
     })
 
@@ -268,16 +264,15 @@ describe('useSourceSearch series infos enrichment', () => {
   })
 
   it('exposes infosLoading while enrichment is in flight', async () => {
-    let resolveInfos: (value: unknown) => void = () => {}
-    getInfosBySlug.mockImplementation(() => new Promise((resolve) => {
-      resolveInfos = resolve
-    }))
-    search.mockResolvedValue({ success: true, data: { items: [kosItem('solo')], hasNextPage: false } })
+    const { promise: infosPromise, resolve: resolveInfos } = Promise.withResolvers<unknown>()
+
+    getInfosBySlug.mockImplementation(() => infosPromise)
+    search.mockResolvedValue({ success: true, data: { items: [item('solo')], hasNextPage: false } })
 
     const sourceSearch = useSourceSearch('kingofshojo', { doSearch: true })
-    await vi.waitFor(() => expect(sourceSearch.infosLoading.value['solo']).toBe(true))
+    await vi.waitFor(() => expect(sourceSearch.infosLoading.value.solo).toBe(true))
 
     resolveInfos({ success: true, data: { slug: 'solo', status: 'ongoing', type: 'manga', chapterCount: 4 } })
-    await vi.waitFor(() => expect(sourceSearch.infosLoading.value['solo']).toBeUndefined())
+    await vi.waitFor(() => expect(sourceSearch.infosLoading.value.solo).toBeUndefined())
   })
 })

--- a/web/app/features/sources/composables/sources-search.composable.test.ts
+++ b/web/app/features/sources/composables/sources-search.composable.test.ts
@@ -9,15 +9,16 @@ import { useToast } from '~/composables/toast.composable'
 import { useSourceSearchStore } from '../stores/sources-search.store'
 import { useSourceSearch } from './sources-search.composable'
 
-const { search, create, deleteById, smAndDown } = vi.hoisted(() => ({
+const { search, getInfosBySlug, create, deleteById, smAndDown } = vi.hoisted(() => ({
   search: vi.fn(),
+  getInfosBySlug: vi.fn(),
   create: vi.fn(),
   deleteById: vi.fn(),
   smAndDown: { value: false },
 }))
 
 vi.mock('./sources.api', () => ({
-  createSourceApi: () => ({ search }),
+  createSourceApi: () => ({ search, getInfosBySlug }),
 }))
 
 vi.mock('~/features/comics/composables/comics.api', () => ({
@@ -68,6 +69,7 @@ beforeEach(() => {
   useToast().messages.value.length = 0
   vi.spyOn(console, 'error').mockImplementation(() => {})
   search.mockReset()
+  getInfosBySlug.mockReset()
   create.mockReset()
   deleteById.mockReset()
   smAndDown.value = false
@@ -154,5 +156,128 @@ describe('useSourceSearch pagination', () => {
     await vi.waitFor(() => {
       expect(sourceSearch.page.value).toBe(1)
     })
+  })
+})
+
+describe('useSourceSearch series infos enrichment', () => {
+  function kosItem(slug: string): SourceSearchItem {
+    return item(slug)
+  }
+
+  it('does not call getInfosBySlug for asurascans search', async () => {
+    search.mockResolvedValue({ success: true, data: { items: [item('solo')], hasNextPage: false } })
+    useSourceSearch('asurascans', { doSearch: true })
+    await vi.waitFor(() => expect(search).toHaveBeenCalled())
+    expect(getInfosBySlug).not.toHaveBeenCalled()
+  })
+
+  it('does not enrich when doSearch is false', async () => {
+    useSourceSearch('kingofshojo', { doSearch: false })
+    expect(search).not.toHaveBeenCalled()
+    expect(getInfosBySlug).not.toHaveBeenCalled()
+  })
+
+  it('patches status type and chapterCount from getInfosBySlug', async () => {
+    search.mockResolvedValue({ success: true, data: { items: [kosItem('solo')], hasNextPage: false } })
+    getInfosBySlug.mockResolvedValue({
+      success: true,
+      data: { slug: 'solo', status: 'completed', type: 'manhwa', chapterCount: 120 },
+    })
+
+    useSourceSearch('kingofshojo', { doSearch: true })
+    await vi.waitFor(() => expect(getInfosBySlug).toHaveBeenCalledWith('solo'))
+    await vi.waitFor(() => {
+      expect(useSourceSearchStore('kingofshojo').comics[0]).toMatchObject({
+        status: 'completed',
+        type: 'manhwa',
+        chapterCount: 120,
+      })
+    })
+  })
+
+  it('does not overwrite internalId when patching infos', async () => {
+    search.mockResolvedValue({ success: true, data: { items: [{ ...item('solo'), internalId: 'lib-1' }], hasNextPage: false } })
+    getInfosBySlug.mockResolvedValue({
+      success: true,
+      data: { slug: 'solo', status: 'hiatus', type: 'manga', chapterCount: 3, internalId: 'from-series' },
+    })
+
+    useSourceSearch('kingofshojo', { doSearch: true })
+    await vi.waitFor(() => {
+      expect(useSourceSearchStore('kingofshojo').comics[0]?.internalId).toBe('lib-1')
+      expect(useSourceSearchStore('kingofshojo').comics[0]?.status).toBe('hiatus')
+    })
+  })
+
+  it('leaves a failed slug unchanged, logs, and does not toast', async () => {
+    search.mockResolvedValue({
+      success: true,
+      data: { items: [kosItem('ok'), kosItem('missing')], hasNextPage: false },
+    })
+    getInfosBySlug.mockImplementation(async (slug: string) => {
+      if (slug === 'missing') {
+        return { success: false, error: { status: 404, message: 'missing' } }
+      }
+      return { success: true, data: { slug, status: 'completed', type: 'manhwa', chapterCount: 10 } }
+    })
+
+    useSourceSearch('kingofshojo', { doSearch: true })
+    await vi.waitFor(() => expect(getInfosBySlug).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => {
+      expect(useSourceSearchStore('kingofshojo').comics.find(c => c.slug === 'ok')).toMatchObject({
+        status: 'completed',
+        chapterCount: 10,
+      })
+    })
+    expect(useSourceSearchStore('kingofshojo').comics.find(c => c.slug === 'missing')?.chapterCount).toBe(1)
+    expect(console.error).toHaveBeenCalled()
+    expect(useToast().messages.value).toEqual([])
+  })
+
+  it('ignores stale enrichment after a new search', async () => {
+    let resolveFirst: (value: unknown) => void = () => {}
+    const firstInfos = new Promise((resolve) => {
+      resolveFirst = resolve
+    })
+
+    search
+      .mockResolvedValueOnce({ success: true, data: { items: [kosItem('old')], hasNextPage: false } })
+      .mockResolvedValueOnce({ success: true, data: { items: [kosItem('new')], hasNextPage: false } })
+
+    getInfosBySlug.mockImplementation(async (slug: string) => {
+      if (slug === 'old') {
+        await firstInfos
+        return { success: true, data: { slug: 'old', status: 'completed', type: 'manga', chapterCount: 99 } }
+      }
+      return { success: true, data: { slug: 'new', status: 'ongoing', type: 'manhwa', chapterCount: 2 } }
+    })
+
+    const sourceSearch = useSourceSearch('kingofshojo', { doSearch: true })
+    await vi.waitFor(() => expect(getInfosBySlug).toHaveBeenCalledWith('old'))
+
+    sourceSearch.sort.value = 'latest'
+    await vi.waitFor(() => expect(getInfosBySlug).toHaveBeenCalledWith('new'))
+    await vi.waitFor(() => {
+      expect(useSourceSearchStore('kingofshojo').comics.map(c => c.slug)).toEqual(['new'])
+    })
+
+    resolveFirst(undefined)
+    await Promise.resolve()
+    expect(useSourceSearchStore('kingofshojo').comics[0]?.slug).toBe('new')
+    expect(useSourceSearchStore('kingofshojo').comics[0]?.chapterCount).not.toBe(99)
+  })
+
+  it('exposes infosLoading while enrichment is in flight', async () => {
+    let resolveInfos: (value: unknown) => void = () => {}
+    getInfosBySlug.mockImplementation(() => new Promise((resolve) => {
+      resolveInfos = resolve
+    }))
+    search.mockResolvedValue({ success: true, data: { items: [kosItem('solo')], hasNextPage: false } })
+
+    const sourceSearch = useSourceSearch('kingofshojo', { doSearch: true })
+    await vi.waitFor(() => expect(sourceSearch.infosLoading.value['solo']).toBe(true))
+
+    resolveInfos({ success: true, data: { slug: 'solo', status: 'ongoing', type: 'manga', chapterCount: 4 } })
+    await vi.waitFor(() => expect(sourceSearch.infosLoading.value['solo']).toBeUndefined())
   })
 })

--- a/web/app/features/sources/composables/sources-search.composable.ts
+++ b/web/app/features/sources/composables/sources-search.composable.ts
@@ -3,6 +3,7 @@
 import type { SourceComicInfos, SourceSearchItem, SourceSort } from '../types'
 import type { ComicSource, ComicStatus, ComicType } from '~/features/comics/types'
 import { createComicsApi } from '~/features/comics/composables/comics.api'
+import { getSourceConfig } from '../config/sources.config'
 import { useSourceSearchStore } from '../stores/sources-search.store'
 import { createSourceApi } from './sources.api'
 
@@ -20,6 +21,7 @@ export interface SourceSearchComposable {
   removeComicFromLibrary: (comic: SourceSearchItem) => Promise<boolean>
   addComicInLibrary: (comic: SourceSearchItem | SourceComicInfos) => Promise<string | undefined>
   addComicInLibraryLoading: Ref<Record<string, boolean>>
+  infosLoading: ComputedRef<Record<string, boolean>>
 }
 
 export function useSourceSearch(sourceId: ComicSource, opts: { doSearch: boolean }): SourceSearchComposable {
@@ -76,6 +78,31 @@ export function useSourceSearch(sourceId: ComicSource, opts: { doSearch: boolean
 
   const hasNextPage = ref(false)
   const addComicInLibraryLoading = ref<Record<string, boolean>>({})
+  let enrichGeneration = 0
+
+  const infosLoading = computed(() => store.infosLoading)
+
+  async function enrichSearchItems(items: SourceSearchItem[], generation: number): Promise<void> {
+    await Promise.all(items.map(async (item) => {
+      store.setInfosLoading(item.slug, true)
+      const infos = await api.getInfosBySlug(item.slug)
+      if (generation !== enrichGeneration) {
+        return
+      }
+
+      store.setInfosLoading(item.slug, false)
+      if (!infos.success) {
+        console.error('api.getInfosBySlug', infos.error)
+        return
+      }
+
+      store.patchComic(item.slug, {
+        status: infos.data.status,
+        type: infos.data.type,
+        chapterCount: infos.data.chapterCount,
+      })
+    }))
+  }
 
   const debouncedSearchFn = useDebounceFn(async () => {
     isLoading.value = true
@@ -106,6 +133,16 @@ export function useSourceSearch(sourceId: ComicSource, opts: { doSearch: boolean
 
     hasNextPage.value = res.data.hasNextPage
     comics.value = res.data.items
+
+    const isNewResultSet = page.value === 1 || !smAndDown.value
+    if (isNewResultSet) {
+      enrichGeneration += 1
+      store.clearInfosLoading()
+    }
+
+    if (getSourceConfig(sourceId)?.enrichSearchFromSeries) {
+      void enrichSearchItems(res.data.items, enrichGeneration)
+    }
   }, 200)
 
   watch([search, sort, status, type], () => {
@@ -184,5 +221,6 @@ export function useSourceSearch(sourceId: ComicSource, opts: { doSearch: boolean
     addComicInLibrary,
     addComicInLibraryLoading,
     removeComicFromLibrary,
+    infosLoading,
   }
 }

--- a/web/app/features/sources/composables/sources-search.composable.ts
+++ b/web/app/features/sources/composables/sources-search.composable.ts
@@ -93,6 +93,7 @@ export function useSourceSearch(sourceId: ComicSource, opts: { doSearch: boolean
       store.setInfosLoading(item.slug, false)
       if (!infos.success) {
         console.error('api.getInfosBySlug', infos.error)
+
         return
       }
 

--- a/web/app/features/sources/config/sources.config.test.ts
+++ b/web/app/features/sources/config/sources.config.test.ts
@@ -37,4 +37,12 @@ describe('sources.config', () => {
     const config = getSourceConfig('kingofshojo')!
     expect(getComicOriginUrl(config, 'https://kingofshojo.com/manga/solo-leveling')).toBe('https://kingofshojo.com/manga/solo-leveling')
   })
+
+  it('does not enrich asurascans search from series infos', () => {
+    expect(getSourceConfig('asurascans')?.enrichSearchFromSeries).toBeFalsy()
+  })
+
+  it('enriches kingofshojo search from series infos', () => {
+    expect(getSourceConfig('kingofshojo')?.enrichSearchFromSeries).toBe(true)
+  })
 })

--- a/web/app/features/sources/config/sources.config.ts
+++ b/web/app/features/sources/config/sources.config.ts
@@ -22,6 +22,7 @@ export const SOURCES_CONFIG: Record<ComicSource, SourceConfig> = {
     image: kingOfShojoImg,
     color: '#2503e5',
     allowedSorts: ['popular', 'latest', 'title', 'newest'],
+    enrichSearchFromSeries: true,
   },
 }
 

--- a/web/app/features/sources/stores/sources-search.store.test.ts
+++ b/web/app/features/sources/stores/sources-search.store.test.ts
@@ -38,4 +38,48 @@ describe('useSourceSearchStore', () => {
     expect(store.search).toBeUndefined()
     expect(store.page).toBe(1)
   })
+
+  it('patches status type and chapterCount on both comic lists', () => {
+    const store = useSourceSearchStore('kingofshojo')
+    const comic = { slug: 'manga-1', title: 'Manga 1', status: 'ongoing', type: 'manga', chapterCount: 0, internalId: 'keep-me' } as any
+    store.setComics([comic])
+    store.setAccumulatedComics([comic])
+
+    store.patchComic('manga-1', { status: 'completed', type: 'manhwa', chapterCount: 42 })
+
+    expect(store.comics[0]).toMatchObject({
+      slug: 'manga-1',
+      status: 'completed',
+      type: 'manhwa',
+      chapterCount: 42,
+      internalId: 'keep-me',
+    })
+    expect(store.accumulatedComics[0]).toMatchObject({
+      slug: 'manga-1',
+      status: 'completed',
+      type: 'manhwa',
+      chapterCount: 42,
+      internalId: 'keep-me',
+    })
+  })
+
+  it('does not add a comic when patching an unknown slug', () => {
+    const store = useSourceSearchStore('kingofshojo')
+    store.setComics([])
+    store.patchComic('missing', { chapterCount: 9 })
+    expect(store.comics).toEqual([])
+  })
+
+  it('tracks infos loading per slug and clears it on invalidate', () => {
+    const store = useSourceSearchStore('kingofshojo')
+    store.setInfosLoading('manga-1', true)
+    expect(store.infosLoading['manga-1']).toBe(true)
+
+    store.setInfosLoading('manga-1', false)
+    expect(store.infosLoading['manga-1']).toBeUndefined()
+
+    store.setInfosLoading('manga-1', true)
+    store.invalidate()
+    expect(store.infosLoading).toEqual({})
+  })
 })

--- a/web/app/features/sources/stores/sources-search.store.ts
+++ b/web/app/features/sources/stores/sources-search.store.ts
@@ -112,6 +112,7 @@ function createSearchStoreDefinition(sourceId: ComicSource): SearchStoreDefiniti
 
       const next = [...list]
       next[i] = { ...next[i]!, ...patch }
+
       return next
     }
 
@@ -123,6 +124,7 @@ function createSearchStoreDefinition(sourceId: ComicSource): SearchStoreDefiniti
     function setInfosLoading(slug: string, isLoading: boolean): void {
       if (isLoading) {
         infosLoading.value = { ...infosLoading.value, [slug]: true }
+
         return
       }
 

--- a/web/app/features/sources/stores/sources-search.store.ts
+++ b/web/app/features/sources/stores/sources-search.store.ts
@@ -16,6 +16,11 @@ export interface SourceSearchStore {
   clearAccumulatedComics: () => void
 
   setComicInternalId: (slug: string, internalId: string | undefined) => void
+  patchComic: (slug: string, patch: Partial<SourceSearchItem>) => void
+
+  infosLoading: Ref<Record<string, boolean>>
+  setInfosLoading: (slug: string, isLoading: boolean) => void
+  clearInfosLoading: () => void
 
   loading: Ref<boolean>
   setLoading: (isLoading: boolean) => void
@@ -59,6 +64,7 @@ function createSearchStoreDefinition(sourceId: ComicSource): SearchStoreDefiniti
 
     const comics = ref<SourceSearchItem[]>([])
     const accumulatedComics = ref<SourceSearchItem[]>([])
+    const infosLoading = ref<Record<string, boolean>>({})
 
     function setComics(value: SourceSearchItem[]): void {
       comics.value = [...value]
@@ -96,6 +102,36 @@ function createSearchStoreDefinition(sourceId: ComicSource): SearchStoreDefiniti
         const { internalId: _, ...comic } = accumulatedComics.value[i]!
         accumulatedComics.value[i] = { ...comic, internalId }
       }
+    }
+
+    function patchList(list: SourceSearchItem[], slug: string, patch: Partial<SourceSearchItem>): SourceSearchItem[] {
+      const i = list.findIndex(c => c.slug === slug)
+      if (i === -1) {
+        return list
+      }
+
+      const next = [...list]
+      next[i] = { ...next[i]!, ...patch }
+      return next
+    }
+
+    function patchComic(slug: string, patch: Partial<SourceSearchItem>): void {
+      comics.value = patchList(comics.value, slug, patch)
+      accumulatedComics.value = patchList(accumulatedComics.value, slug, patch)
+    }
+
+    function setInfosLoading(slug: string, isLoading: boolean): void {
+      if (isLoading) {
+        infosLoading.value = { ...infosLoading.value, [slug]: true }
+        return
+      }
+
+      const { [slug]: _, ...rest } = infosLoading.value
+      infosLoading.value = rest
+    }
+
+    function clearInfosLoading(): void {
+      infosLoading.value = {}
     }
 
     function setSearch(value: string): void {
@@ -147,6 +183,7 @@ function createSearchStoreDefinition(sourceId: ComicSource): SearchStoreDefiniti
       clearLoading()
       clearComics()
       clearAccumulatedComics()
+      clearInfosLoading()
     }
 
     return {
@@ -157,6 +194,10 @@ function createSearchStoreDefinition(sourceId: ComicSource): SearchStoreDefiniti
       setAccumulatedComics,
       clearAccumulatedComics,
       setComicInternalId,
+      patchComic,
+      infosLoading,
+      setInfosLoading,
+      clearInfosLoading,
       loading,
       setLoading,
       clearLoading,

--- a/web/app/features/sources/types.ts
+++ b/web/app/features/sources/types.ts
@@ -81,4 +81,5 @@ export interface SourceConfig {
   image: string
   color: string
   allowedSorts: SourceSort[]
+  enrichSearchFromSeries?: boolean
 }

--- a/web/app/pages/browse/sources/[source]/index.test.ts
+++ b/web/app/pages/browse/sources/[source]/index.test.ts
@@ -10,7 +10,7 @@ import { VApp } from 'vuetify/components'
 import { ASURA_SOURCE_NAME } from '~/constants'
 import SourceBrowsePage from './index.vue'
 
-const { series, isLoading, hasNextPage, smAndDown, page, addComicInLibrary, addComicInLibraryLoading, resetFilters, params, navigateTo } = await vi.hoisted(async () => {
+const { series, isLoading, hasNextPage, smAndDown, page, addComicInLibrary, addComicInLibraryLoading, infosLoading, resetFilters, params, navigateTo } = await vi.hoisted(async () => {
   const { ref } = await import('vue')
 
   return {
@@ -21,6 +21,7 @@ const { series, isLoading, hasNextPage, smAndDown, page, addComicInLibrary, addC
     page: ref(1),
     addComicInLibrary: vi.fn(),
     addComicInLibraryLoading: ref<Record<string, boolean>>({}),
+    infosLoading: ref<Record<string, boolean>>({}),
     resetFilters: vi.fn(),
     params: { source: 'asurascans' },
     navigateTo: vi.fn(),
@@ -35,6 +36,7 @@ vi.mock('~/features/sources/composables/sources-search.composable', () => ({
     hasNextPage,
     addComicInLibrary,
     addComicInLibraryLoading,
+    infosLoading,
     resetFilters,
   }),
 }))
@@ -72,9 +74,14 @@ const HeaderStub = defineComponent({
 
 const CardStub = defineComponent({
   name: 'SourcesComicCard',
-  props: { comic: { type: Object, required: true }, sourceId: { type: String, required: true } },
+  props: {
+    comic: { type: Object, required: true },
+    sourceId: { type: String, required: true },
+    statusLoading: { type: Boolean, default: false },
+    chapterCountLoading: { type: Boolean, default: false },
+  },
   emits: ['toggle'],
-  template: '<button data-test="comic-card" @click="$emit(\'toggle\')">{{ comic.title }}</button>',
+  template: '<button data-test="comic-card" :data-status-loading="statusLoading" :data-chapter-count-loading="chapterCountLoading" @click="$emit(\'toggle\')">{{ comic.title }}</button>',
 })
 
 const DeleteStub = defineComponent({
@@ -127,6 +134,7 @@ beforeEach(() => {
   hasNextPage.value = false
   smAndDown.value = false
   page.value = 1
+  infosLoading.value = {}
   params.source = ASURA_SOURCE_NAME
   addComicInLibrary.mockReset()
   resetFilters.mockReset()
@@ -143,6 +151,15 @@ describe('browse Source Page', () => {
     series.value = [item()]
     const wrapper = await mount()
     expect(wrapper.findAll('[data-test="comic-card"]').map(n => n.text())).toEqual(['Solo Leveling'])
+  })
+
+  it('forwards infos loading onto each card', async () => {
+    series.value = [item()]
+    infosLoading.value = { 'solo-leveling': true }
+    const wrapper = await mount()
+    const card = wrapper.find('[data-test="comic-card"]')
+    expect(card.attributes('data-status-loading')).toBe('true')
+    expect(card.attributes('data-chapter-count-loading')).toBe('true')
   })
 
   it('adds a comic that is not in the library', async () => {

--- a/web/app/pages/browse/sources/[source]/index.vue
+++ b/web/app/pages/browse/sources/[source]/index.vue
@@ -47,6 +47,7 @@ const {
   hasNextPage,
   addComicInLibrary,
   addComicInLibraryLoading,
+  infosLoading,
   resetFilters,
 } = useSourceSearch(sourceId, { doSearch: true })
 const loadMoreSentinel = useTemplateRef<HTMLElement>('loadMoreSentinel')
@@ -112,6 +113,8 @@ onBeforeRouteLeave((to: RouteLocationNormalized) => {
           :source-id="sourceId"
           :comic
           :loading="addComicInLibraryLoading[comic.slug]"
+          :status-loading="infosLoading[comic.slug]"
+          :chapter-count-loading="infosLoading[comic.slug]"
           @toggle="doToggleComic(comic)"
         />
       </div>


### PR DESCRIPTION
## Summary

- Add `enrichSearchFromSeries` source config flag (enabled for KingOfShojo only) so sparse search results are enriched client-side via `getInfosBySlug`.
- Extend the search store and composable with `patchComic`, per-slug `infosLoading` tracking, and stale-generation guards when filters or pages change.
- Wire catalogue card loaders on the browse page so status and chapter count show spinners while series infos load.

Closes #134

## Test plan

- [x] On `/browse/sources/kingofshojo`, cards eventually show status and real chapter count after enrichment
- [x] Loaders appear on status/chapter count while `getInfosBySlug` is in flight
- [x] On `/browse/sources/asurascans`, no extra `getInfosBySlug` calls from search
- [x] Changing page or filters does not apply stale enrichment to the new result set
- [x] A failed slug (404) does not block other cards and does not toast
- [x] `pnpm test` — store, composable, config, and browse page coverage
- [x] `pnpm lint`, `pnpm typecheck`, and `pnpm knip` pass in CI